### PR TITLE
Add forgot username feature and password reset tests

### DIFF
--- a/pkg/httpserver/password_reset_test.go
+++ b/pkg/httpserver/password_reset_test.go
@@ -1,0 +1,76 @@
+package httpserver
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestGenerateResetToken(t *testing.T) {
+	rawToken1, hash1, err := generateResetToken()
+	if err != nil {
+		t.Fatalf("generateResetToken failed: %v", err)
+	}
+
+	// Token should be non-empty
+	if rawToken1 == "" {
+		t.Error("rawToken should not be empty")
+	}
+	if hash1 == "" {
+		t.Error("hash should not be empty")
+	}
+
+	// Token should be base64 URL encoded (44 chars for 32 bytes)
+	if len(rawToken1) != 44 {
+		t.Errorf("expected rawToken length 44 (base64 of 32 bytes), got %d", len(rawToken1))
+	}
+
+	// Token should be valid base64 URL encoding
+	decoded, err := base64.URLEncoding.DecodeString(rawToken1)
+	if err != nil {
+		t.Errorf("rawToken should be valid base64 URL encoding: %v", err)
+	}
+	if len(decoded) != 32 {
+		t.Errorf("decoded token should be 32 bytes, got %d", len(decoded))
+	}
+
+	// Hash should match the hashToken function output
+	expectedHash := hashToken(rawToken1)
+	if hash1 != expectedHash {
+		t.Errorf("hash mismatch: expected %s, got %s", expectedHash, hash1)
+	}
+
+	// Each call should generate different tokens
+	rawToken2, hash2, err := generateResetToken()
+	if err != nil {
+		t.Fatalf("second generateResetToken failed: %v", err)
+	}
+	if rawToken1 == rawToken2 {
+		t.Error("tokens should be unique")
+	}
+	if hash1 == hash2 {
+		t.Error("hashes should be unique")
+	}
+}
+
+func TestGenerateResetToken_Uniqueness(t *testing.T) {
+	// Generate multiple tokens and verify uniqueness
+	tokens := make(map[string]bool)
+	hashes := make(map[string]bool)
+
+	for i := 0; i < 100; i++ {
+		rawToken, hash, err := generateResetToken()
+		if err != nil {
+			t.Fatalf("generateResetToken failed on iteration %d: %v", i, err)
+		}
+
+		if tokens[rawToken] {
+			t.Errorf("duplicate token generated on iteration %d", i)
+		}
+		if hashes[hash] {
+			t.Errorf("duplicate hash generated on iteration %d", i)
+		}
+
+		tokens[rawToken] = true
+		hashes[hash] = true
+	}
+}

--- a/pkg/httpserver/routes.go
+++ b/pkg/httpserver/routes.go
@@ -111,6 +111,9 @@ func (s *Server) registerRoutes() {
 		r.Post("/forgot-password", s.HandleForgotPasswordPost)
 		r.Get("/reset-password", s.HandleResetPasswordGet)
 		r.Post("/reset-password", s.HandleResetPasswordPost)
+		// Username reminder
+		r.Get("/forgot-username", s.HandleForgotUsernameGet)
+		r.Post("/forgot-username", s.HandleForgotUsernamePost)
 	})
 
 	// Swagger

--- a/pkg/httpserver/server.go
+++ b/pkg/httpserver/server.go
@@ -36,6 +36,7 @@ type Server struct {
 	mfaSetupTemplate        *template.Template
 	forgotPasswordTemplate  *template.Template
 	resetPasswordTemplate   *template.Template
+	forgotUsernameTemplate  *template.Template
 }
 
 func New(config *config.Config, datastore *store.Store, emailSender email.Sender) *Server {
@@ -52,6 +53,7 @@ func New(config *config.Config, datastore *store.Store, emailSender email.Sender
 	mfaSetupTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/mfa-setup.html"))
 	forgotPasswordTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/forgot-password.html"))
 	resetPasswordTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/reset-password.html"))
+	forgotUsernameTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/forgot-username.html"))
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.RealIP)
@@ -92,6 +94,7 @@ func New(config *config.Config, datastore *store.Store, emailSender email.Sender
 		mfaSetupTemplate:        mfaSetupTemplate,
 		forgotPasswordTemplate:  forgotPasswordTemplate,
 		resetPasswordTemplate:   resetPasswordTemplate,
+		forgotUsernameTemplate:  forgotUsernameTemplate,
 	}
 	s.registerRoutes()
 

--- a/templates/forgot-username.html
+++ b/templates/forgot-username.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Forgot Username</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-lg p-10 w-full max-w-md">
+        <div class="text-center mb-8">
+            <h1 class="text-2xl font-semibold text-gray-900 dark:text-gray-50 mb-2">Forgot Username</h1>
+            <p class="text-sm text-gray-500 dark:text-gray-400">Enter your email to receive your username</p>
+        </div>
+
+        {{if .Error}}
+        <div class="p-4 rounded-lg text-sm flex items-start gap-2.5 mb-6 bg-red-50 text-red-800 border border-red-200 dark:bg-red-900/20 dark:text-red-300 dark:border-red-800/30">
+            <svg class="flex-shrink-0 mt-px" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
+            </svg>
+            <span>{{.Error}}</span>
+        </div>
+        {{end}}
+
+        {{if .Success}}
+        <div class="p-4 rounded-lg text-sm flex items-start gap-2.5 mb-6 bg-green-50 text-green-800 border border-green-200 dark:bg-green-900/20 dark:text-green-300 dark:border-green-800/30">
+            <svg class="flex-shrink-0 mt-px" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
+            </svg>
+            <span>{{.Success}}</span>
+        </div>
+        {{else}}
+        <form method="POST" action="/oauth/forgot-username">
+            <div class="mb-5">
+                <label for="email" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Email Address</label>
+                <input
+                    type="email"
+                    id="email"
+                    name="email"
+                    placeholder="Enter your email address"
+                    required
+                    autofocus
+                    autocomplete="email"
+                    class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+                >
+            </div>
+
+            <button type="submit" class="w-full px-6 py-3 text-base font-medium rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 cursor-pointer">Send Username</button>
+        </form>
+        {{end}}
+
+        <div class="text-center mt-6 text-sm text-gray-500 dark:text-gray-400">
+            Remember your username? <a href="/oauth/login" class="text-indigo-600 dark:text-indigo-400 hover:underline font-medium">Sign in</a>
+        </div>
+
+        <div class="text-center mt-6 pt-6 border-t border-gray-200 dark:border-gray-700 text-xs text-gray-400 dark:text-gray-500">
+            Identity Service
+        </div>
+    </div>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -71,8 +71,9 @@
             <button type="submit" class="w-full px-6 py-3 text-base font-medium rounded-lg bg-indigo-600 text-white hover:bg-indigo-700 dark:bg-indigo-500 dark:hover:bg-indigo-600 cursor-pointer">Sign In</button>
         </form>
 
-        <div class="text-center mt-4 text-sm">
+        <div class="text-center mt-4 text-sm space-x-4">
             <a href="/oauth/forgot-password" class="text-indigo-600 dark:text-indigo-400 hover:underline font-medium">Forgot password?</a>
+            <a href="/oauth/forgot-username" class="text-indigo-600 dark:text-indigo-400 hover:underline font-medium">Forgot username?</a>
         </div>
 
         <div class="text-center mt-6 text-sm text-gray-500 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- Add integration tests for password reset flow (7 new tests covering full flow, invalid/missing tokens, validation errors, no email enumeration)
- Add unit tests for password reset token generation (uniqueness, format validation)
- Add "Forgot username" feature that emails username to user
- Add "Forgot username?" link to login page

## New Endpoints
- `GET /oauth/forgot-username` - Display forgot username form
- `POST /oauth/forgot-username` - Send username reminder email

## Security
- No email enumeration: same success message shown regardless of whether email exists
- Reuses existing email infrastructure from password reset

## Test plan
- [x] All existing tests pass
- [x] New password reset tests pass
- [x] New forgot username tests pass
- [x] Manual test: navigate to `/oauth/forgot-username`, enter email, check logs for username email

🤖 Generated with [Claude Code](https://claude.com/claude-code)