### PR TITLE
Implement token revocation endpoint (RFC 7009)

### DIFF
--- a/db/queries/auth.sql
+++ b/db/queries/auth.sql
@@ -121,6 +121,12 @@ SET revoked_at = now()
 WHERE refresh_token = $1
   AND revoked_at IS NULL;
 
+-- name: RevokeTokenByAccessToken :exec
+UPDATE oauth_tokens
+SET revoked_at = now()
+WHERE access_token = $1
+  AND revoked_at IS NULL;
+
 -- name: RevokeAllUserTokens :exec
 UPDATE oauth_tokens
 SET revoked_at = now()

--- a/pkg/db/auth.sql.go
+++ b/pkg/db/auth.sql.go
@@ -868,6 +868,18 @@ func (q *Queries) RevokeAllUserTokens(ctx context.Context, userID uuid.NullUUID)
 	return err
 }
 
+const revokeTokenByAccessToken = `-- name: RevokeTokenByAccessToken :exec
+UPDATE oauth_tokens
+SET revoked_at = now()
+WHERE access_token = $1
+  AND revoked_at IS NULL
+`
+
+func (q *Queries) RevokeTokenByAccessToken(ctx context.Context, accessToken sql.NullString) error {
+	_, err := q.db.ExecContext(ctx, revokeTokenByAccessToken, accessToken)
+	return err
+}
+
 const revokeTokenByRefreshToken = `-- name: RevokeTokenByRefreshToken :exec
 UPDATE oauth_tokens
 SET revoked_at = now()


### PR DESCRIPTION
## Summary
- Implement `/oauth/revoke` endpoint per RFC 7009
- Revoke both access tokens and refresh tokens
- Add comprehensive integration tests

## Changes

### Token Revocation (`/oauth/revoke`)
- Extracts JTI from JWT access tokens for revocation
- Revokes refresh tokens by value
- Requires client authentication (client_id/client_secret for confidential clients)
- Returns 200 OK regardless of token validity (prevents enumeration per RFC 7009)
- Supports `token_type_hint` to optimize revocation order

### Database
- Added `RevokeTokenByAccessToken` query

## Test plan
- [x] `TestTokenRevocationAccessToken` - Full flow: get token, verify active, revoke, verify inactive
- [x] `TestTokenRevocationRefreshToken` - Full flow for refresh token revocation
- [x] `TestTokenRevocationInvalidToken` - Returns 200 OK for invalid tokens (per RFC 7009)
- [x] `TestTokenRevocationInvalidClientCredentials` - Returns 401 for wrong credentials
- [x] `TestTokenRevocationMissingToken` - Returns 400 for missing token parameter

🤖 Generated with [Claude Code](https://claude.com/claude-code)