### PR TITLE
Add client credentials grant and admin API for user creation

### DIFF
--- a/pkg/httpserver/admin.go
+++ b/pkg/httpserver/admin.go
@@ -1,0 +1,129 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/eswan18/identity/pkg/auth"
+	"github.com/eswan18/identity/pkg/db"
+)
+
+// CreateUserRequest represents the request body for admin user creation
+type CreateUserRequest struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// CreateUserResponse represents the response for admin user creation (excludes password hash)
+type CreateUserResponse struct {
+	ID            string `json:"id"`
+	Username      string `json:"username"`
+	Email         string `json:"email"`
+	IsActive      bool   `json:"is_active"`
+	EmailVerified bool   `json:"email_verified"`
+	CreatedAt     string `json:"created_at"`
+}
+
+// HandleAdminCreateUser godoc
+// @Summary      Create a new user (Admin API)
+// @Description  Creates a new user account. Requires admin:users:write scope.
+// @Tags         admin
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        request body CreateUserRequest true "User creation request"
+// @Success      201 {object} CreateUserResponse "User created successfully"
+// @Failure      400 {object} map[string]string "Invalid request"
+// @Failure      401 {object} map[string]string "Unauthorized"
+// @Failure      403 {object} map[string]string "Insufficient scope"
+// @Failure      409 {object} map[string]string "Username or email already exists"
+// @Router       /admin/users [post]
+func (s *Server) HandleAdminCreateUser(w http.ResponseWriter, r *http.Request) {
+	var req CreateUserRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeAdminError(w, http.StatusBadRequest, "invalid_request", "Invalid JSON body")
+		return
+	}
+
+	// Validate required fields
+	if req.Username == "" {
+		s.writeAdminError(w, http.StatusBadRequest, "invalid_request", "Username is required")
+		return
+	}
+	if req.Email == "" {
+		s.writeAdminError(w, http.StatusBadRequest, "invalid_request", "Email is required")
+		return
+	}
+	if req.Password == "" {
+		s.writeAdminError(w, http.StatusBadRequest, "invalid_request", "Password is required")
+		return
+	}
+
+	// Validate username format (alphanumeric + underscore, 3-50 chars)
+	usernameRegex := regexp.MustCompile(`^[a-zA-Z0-9_]{3,50}$`)
+	if !usernameRegex.MatchString(req.Username) {
+		s.writeAdminError(w, http.StatusBadRequest, "invalid_request",
+			"Username must be 3-50 alphanumeric characters or underscores")
+		return
+	}
+
+	// Validate email format
+	emailRegex := regexp.MustCompile(`^[^\s@]+@[^\s@]+\.[^\s@]+$`)
+	if !emailRegex.MatchString(req.Email) {
+		s.writeAdminError(w, http.StatusBadRequest, "invalid_request", "Invalid email format")
+		return
+	}
+
+	// Validate password using centralized validation (includes common password check)
+	if err := auth.ValidatePassword(req.Password, req.Username); err != nil {
+		s.writeAdminError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+
+	// Hash password
+	passwordHash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		log.Printf("Admin create user: failed to hash password: %v", err)
+		s.writeAdminError(w, http.StatusInternalServerError, "server_error", "Failed to process password")
+		return
+	}
+
+	// Create user in database
+	user, err := s.datastore.Q.CreateUser(r.Context(), db.CreateUserParams{
+		Username:     req.Username,
+		Email:        strings.ToLower(req.Email),
+		PasswordHash: passwordHash,
+	})
+	if err != nil {
+		// Check for unique constraint violations
+		if strings.Contains(err.Error(), "auth_users_username_key") {
+			s.writeAdminError(w, http.StatusConflict, "conflict", "Username already exists")
+			return
+		}
+		if strings.Contains(err.Error(), "auth_users_email_key") {
+			s.writeAdminError(w, http.StatusConflict, "conflict", "Email already exists")
+			return
+		}
+		log.Printf("Admin create user: database error: %v", err)
+		s.writeAdminError(w, http.StatusInternalServerError, "server_error", "Failed to create user")
+		return
+	}
+
+	// Return created user (without password hash)
+	response := CreateUserResponse{
+		ID:            user.ID.String(),
+		Username:      user.Username,
+		Email:         user.Email,
+		IsActive:      user.IsActive,
+		EmailVerified: user.EmailVerified,
+		CreatedAt:     user.CreatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(response)
+}

--- a/pkg/httpserver/admin_middleware.go
+++ b/pkg/httpserver/admin_middleware.go
@@ -1,0 +1,70 @@
+package httpserver
+
+import (
+	"database/sql"
+	"encoding/json"
+	"log"
+	"net/http"
+	"slices"
+	"strings"
+)
+
+// AdminAuthMiddleware creates middleware that validates Bearer tokens and required scopes.
+// It extracts the token from the Authorization header, validates it, checks for revocation,
+// and verifies that all required scopes are present.
+func (s *Server) AdminAuthMiddleware(requiredScopes ...string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Extract Bearer token from Authorization header
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+				s.writeAdminError(w, http.StatusUnauthorized, "invalid_token", "Missing or invalid Authorization header")
+				return
+			}
+			accessToken := strings.TrimPrefix(authHeader, "Bearer ")
+
+			// Validate JWT - use empty audience since this is the identity provider itself
+			claims, err := s.jwtGenerator.ValidateToken(accessToken, "")
+			if err != nil {
+				log.Printf("Admin auth: JWT validation failed: %v", err)
+				s.writeAdminError(w, http.StatusUnauthorized, "invalid_token", "Invalid or expired access token")
+				return
+			}
+
+			// Check if token has been revoked (by looking up JTI in database)
+			if claims.ID != "" {
+				_, err := s.datastore.Q.GetTokenByAccessToken(r.Context(), sql.NullString{String: claims.ID, Valid: true})
+				if err == sql.ErrNoRows {
+					// Token not found could mean it was revoked or never existed
+					s.writeAdminError(w, http.StatusUnauthorized, "invalid_token", "Token has been revoked or is invalid")
+					return
+				}
+				// Note: If err != nil but not ErrNoRows, we allow through - the DB might be temporarily unavailable
+			}
+
+			// Validate required scopes
+			tokenScopes := strings.Split(claims.Scope, " ")
+			for _, requiredScope := range requiredScopes {
+				if !slices.Contains(tokenScopes, requiredScope) {
+					log.Printf("Admin auth: Token missing required scope %s (has: %v)", requiredScope, tokenScopes)
+					s.writeAdminError(w, http.StatusForbidden, "insufficient_scope",
+						"Token missing required scope: "+requiredScope)
+					return
+				}
+			}
+
+			// Token is valid and has required scopes, proceed with request
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// writeAdminError writes an OAuth2-format error response for admin endpoints
+func (s *Server) writeAdminError(w http.ResponseWriter, statusCode int, errorCode, description string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	json.NewEncoder(w).Encode(map[string]string{
+		"error":             errorCode,
+		"error_description": description,
+	})
+}

--- a/pkg/httpserver/routes.go
+++ b/pkg/httpserver/routes.go
@@ -119,6 +119,18 @@ func (s *Server) registerRoutes() {
 		r.Post("/forgot-username", s.HandleForgotUsernamePost)
 	})
 
+	// Admin API endpoints (require Bearer token with admin scopes)
+	s.router.Route("/admin", func(r chi.Router) {
+		// Apply CORS middleware for API access
+		r.Use(oauthCorsMiddleware)
+
+		// User management
+		r.With(s.AdminAuthMiddleware("admin:users:write")).Post("/users", s.HandleAdminCreateUser)
+		// Future endpoints:
+		// r.With(s.AdminAuthMiddleware("admin:users:read")).Get("/users", s.HandleAdminListUsers)
+		// r.With(s.AdminAuthMiddleware("admin:users:read")).Get("/users/{id}", s.HandleAdminGetUser)
+	})
+
 	// Swagger
 	s.router.Get("/openapi/*", httpSwagger.Handler(
 		httpSwagger.URL("http://localhost:8080/openapi.json"),


### PR DESCRIPTION
## Summary

- Add OAuth2 client credentials grant for service-to-service authentication
- Add admin API endpoint `POST /admin/users` for programmatic user creation
- Enables migrating existing users from legacy systems

## Changes

**Client Credentials Grant:**
- Confidential clients can now authenticate using `grant_type=client_credentials`
- Returns 15-minute access tokens (no refresh token per OAuth2 spec)
- JWT `sub` claim is set to `client_id`

**Admin API:**
- `POST /admin/users` creates users with username/email/password
- Protected by Bearer token with `admin:users:write` scope
- Returns 409 for duplicate username/email

**New Files:**
- `pkg/httpserver/admin.go` - User creation endpoint
- `pkg/httpserver/admin_middleware.go` - Bearer token auth middleware

**Documentation:**
- Updated `docs/client-integration.md` with migration guide and examples

## Test plan

- [x] 9 new integration tests added and passing
- [x] All existing tests pass
- [ ] Manual test: Create confidential client with admin scopes
- [ ] Manual test: Get token via client credentials, create user via admin API

🤖 Generated with [Claude Code](https://claude.com/claude-code)