### PR TITLE
Add test and lint targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,12 @@ migrate-down:
 	fi
 	migrate -database "${DATABASE_URL}" -path db/migrations down
 
+test:
+	go test ./...
+
+lint:
+	go vet ./...
+
 sqlc: db/schema.sql
 	sqlc generate
 


### PR DESCRIPTION
## Summary
- Add `make test` target (`go test ./...`)
- Add `make lint` target (`go vet ./...`)
- Matches what the GitHub Actions PR workflow already runs

## Test plan
- [x] `make lint` passes locally
- [x] `make test` passes locally (8 packages tested, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)