### PR TITLE
Add container security context to K8s deployment

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -48,6 +48,12 @@ spec:
             limits:
               memory: "256Mi"
               cpu: "200m"
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: secrets-store
               mountPath: "/mnt/secrets"


### PR DESCRIPTION
## Summary
- Add securityContext to container spec: runAsNonRoot, allowPrivilegeEscalation: false, drop ALL capabilities
- Defense in depth alongside the non-root USER in the Dockerfile

## Test plan
- [ ] `kubectl apply --dry-run=client -f k8s/base/deployment.yaml` passes
- [ ] Pods start successfully after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)