### PR TITLE
Add namespace.yaml and fix CLAUDE.md HEALTHCHECK reference

### DIFF
--- a/k8s/prod/kustomization.yaml
+++ b/k8s/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: identity-prod
 
 resources:
   - ../base
+  - namespace.yaml
   - secret-provider-class.yaml
   - configmap-env.yaml
 

--- a/k8s/prod/namespace.yaml
+++ b/k8s/prod/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: identity-prod

--- a/k8s/staging/kustomization.yaml
+++ b/k8s/staging/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: identity-staging
 
 resources:
   - ../base
+  - namespace.yaml
   - secret-provider-class.yaml
   - configmap-env.yaml
 

--- a/k8s/staging/namespace.yaml
+++ b/k8s/staging/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: identity-staging


### PR DESCRIPTION
## Summary
- Add `namespace.yaml` files to staging/prod kustomizations (matches fitness-api and fitness-dashboard pattern)
- Note: the CLAUDE.md fix for the incorrect HEALTHCHECK reference is in the parent repo, not this one

## Test plan
- [ ] Verify `kustomize build k8s/staging` and `kustomize build k8s/prod` include the Namespace resource
- [ ] Confirm ArgoCD syncs without issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)