### PR TITLE
Change topology constraint to ScheduleAnyway

### DIFF
--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels:
               app: identity


### PR DESCRIPTION
## Summary
- Change `whenUnsatisfiable: DoNotSchedule` to `ScheduleAnyway` in topology spread constraint
- Prevents pods from getting stuck in Pending on a small cluster when nodes are unavailable

## Test plan
- [ ] Verify pods reschedule correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)