### PR TITLE
Expose staging identity service on tailnet

### DIFF
--- a/k8s/staging/configmap-env.yaml
+++ b/k8s/staging/configmap-env.yaml
@@ -3,6 +3,6 @@ kind: ConfigMap
 metadata:
   name: identity-staging-env-config
 data:
-  JWT_ISSUER: "https://identity-staging.ethanswan.com"
+  JWT_ISSUER: "https://identity-staging.tailc06f30.ts.net"
   STORAGE_BUCKET: "identity-dev"
   STORAGE_PUBLIC_URL: "https://pub-c93149aa99214d2ab2fb3d1e01b7ef4f.r2.dev"

--- a/k8s/staging/kustomization.yaml
+++ b/k8s/staging/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - secret-provider-class.yaml
   - service-account.yaml
   - configmap-env.yaml
+  - tailscale-ingress.yaml
 
 patches:
   - path: deployment-patch.yaml

--- a/k8s/staging/tailscale-ingress.yaml
+++ b/k8s/staging/tailscale-ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: identity-staging-ts
+spec:
+  defaultBackend:
+    service:
+      name: identity
+      port:
+        number: 80
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - identity-staging


### PR DESCRIPTION
## Summary
- Add a Tailscale Ingress resource (`k8s/staging/tailscale-ingress.yaml`) so the identity staging service is reachable over the tailnet at `identity-staging.tailc06f30.ts.net`.
- Update `JWT_ISSUER` in the staging configmap from the public `ethanswan.com` domain to the tailnet domain.
- Register the new ingress manifest in the staging `kustomization.yaml`.

## Test plan
- [ ] Verify ArgoCD syncs the new Tailscale Ingress resource in the `identity-staging` namespace.
- [ ] Confirm `identity-staging.tailc06f30.ts.net` is accessible from a device on the tailnet.
- [ ] Validate JWT tokens are issued with the new tailnet issuer URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)