### PR TITLE
Implement client_secret_basic (HTTP Basic Auth) for client authentication

### DIFF
--- a/pkg/httpserver/credentials.go
+++ b/pkg/httpserver/credentials.go
@@ -40,11 +40,11 @@ var (
 	ErrInvalidScope       = errors.New("invalid scope")
 )
 
-// authenticateClient extracts client_id and client_secret from the request form,
+// authenticateClient extracts client credentials from the request using either
+// client_secret_post (form values) or client_secret_basic (Authorization header),
 // looks up the client, and verifies the secret for confidential clients.
 func (s *Server) authenticateClient(r *http.Request) (db.OauthClient, error) {
-	clientID := r.FormValue("client_id")
-	clientSecret := r.FormValue("client_secret")
+	clientID, clientSecret := parseClientCredentials(r)
 
 	client, err := s.datastore.Q.GetOAuthClientByClientID(r.Context(), clientID)
 	if err != nil {
@@ -58,6 +58,16 @@ func (s *Server) authenticateClient(r *http.Request) (db.OauthClient, error) {
 	}
 
 	return client, nil
+}
+
+// parseClientCredentials extracts client_id and client_secret from the request.
+// It checks the Authorization header for Basic auth first (client_secret_basic),
+// then falls back to form values (client_secret_post).
+func parseClientCredentials(r *http.Request) (clientID, clientSecret string) {
+	if username, password, ok := r.BasicAuth(); ok {
+		return username, password
+	}
+	return r.FormValue("client_id"), r.FormValue("client_secret")
 }
 
 // validateOAuthClient validates that the client exists and the redirect URI and scopes are allowed.

--- a/pkg/httpserver/credentials_test.go
+++ b/pkg/httpserver/credentials_test.go
@@ -1,8 +1,59 @@
 package httpserver
 
 import (
+	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 )
+
+func TestParseClientCredentials_BasicAuth(t *testing.T) {
+	req, _ := http.NewRequest("POST", "/oauth/token", nil)
+	req.SetBasicAuth("my-client-id", "my-client-secret")
+
+	clientID, clientSecret := parseClientCredentials(req)
+	if clientID != "my-client-id" {
+		t.Errorf("expected client_id %q, got %q", "my-client-id", clientID)
+	}
+	if clientSecret != "my-client-secret" {
+		t.Errorf("expected client_secret %q, got %q", "my-client-secret", clientSecret)
+	}
+}
+
+func TestParseClientCredentials_FormValues(t *testing.T) {
+	form := url.Values{
+		"client_id":     {"form-client-id"},
+		"client_secret": {"form-client-secret"},
+	}
+	req, _ := http.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	clientID, clientSecret := parseClientCredentials(req)
+	if clientID != "form-client-id" {
+		t.Errorf("expected client_id %q, got %q", "form-client-id", clientID)
+	}
+	if clientSecret != "form-client-secret" {
+		t.Errorf("expected client_secret %q, got %q", "form-client-secret", clientSecret)
+	}
+}
+
+func TestParseClientCredentials_BasicAuthTakesPrecedence(t *testing.T) {
+	form := url.Values{
+		"client_id":     {"form-client-id"},
+		"client_secret": {"form-client-secret"},
+	}
+	req, _ := http.NewRequest("POST", "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("basic-client-id", "basic-client-secret")
+
+	clientID, clientSecret := parseClientCredentials(req)
+	if clientID != "basic-client-id" {
+		t.Errorf("expected Basic auth client_id %q, got %q", "basic-client-id", clientID)
+	}
+	if clientSecret != "basic-client-secret" {
+		t.Errorf("expected Basic auth client_secret %q, got %q", "basic-client-secret", clientSecret)
+	}
+}
 
 func TestGenerateRandomString(t *testing.T) {
 	// Test that it produces a string of expected length

--- a/pkg/httpserver/oauth_integration_test.go
+++ b/pkg/httpserver/oauth_integration_test.go
@@ -2062,6 +2062,83 @@ func (s *OAuthFlowSuite) TestClientCredentialsGrant() {
 	s.Nil(claims["email_verified"], "should not have email_verified claim")
 }
 
+// TestClientCredentialsGrant_BasicAuth verifies that client_secret_basic (HTTP Basic Auth)
+// works for client authentication at the token endpoint.
+func (s *OAuthFlowSuite) TestClientCredentialsGrant_BasicAuth() {
+	clientSecret := s.mustGenerateRandomString(32)
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: clientSecret, Valid: true},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"admin:users:read"},
+		IsConfidential: true,
+		Audience:       "http://localhost:8080",
+	})
+
+	// Use Basic auth instead of form values for client credentials
+	form := url.Values{
+		"grant_type": {"client_credentials"},
+		"scope":      {"admin:users:read"},
+	}
+	req, err := http.NewRequest("POST", "http://localhost:8080/oauth/token",
+		strings.NewReader(form.Encode()))
+	s.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(client.ClientID, clientSecret)
+
+	resp, err := s.httpClient.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	var tokenResponse TokenResponse
+	err = json.Unmarshal(body, &tokenResponse)
+	s.Require().NoError(err)
+
+	s.NotEmpty(tokenResponse.AccessToken, "should have access token")
+	s.Equal("Bearer", tokenResponse.TokenType)
+}
+
+// TestClientCredentialsGrant_BasicAuth_WrongSecret verifies that Basic auth
+// with a wrong secret is rejected.
+func (s *OAuthFlowSuite) TestClientCredentialsGrant_BasicAuth_WrongSecret() {
+	clientSecret := s.mustGenerateRandomString(32)
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: clientSecret, Valid: true},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"admin:users:read"},
+		IsConfidential: true,
+		Audience:       "http://localhost:8080",
+	})
+
+	form := url.Values{
+		"grant_type": {"client_credentials"},
+		"scope":      {"admin:users:read"},
+	}
+	req, err := http.NewRequest("POST", "http://localhost:8080/oauth/token",
+		strings.NewReader(form.Encode()))
+	s.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(client.ClientID, "wrong-secret")
+
+	resp, err := s.httpClient.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusBadRequest, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	var errorResponse map[string]string
+	err = json.Unmarshal(body, &errorResponse)
+	s.Require().NoError(err)
+	s.Equal("invalid_client", errorResponse["error"])
+}
+
 // TestClientCredentialsGrant_PublicClientRejected verifies public clients cannot use client credentials
 func (s *OAuthFlowSuite) TestClientCredentialsGrant_PublicClientRejected() {
 	// Create a public client (no secret)


### PR DESCRIPTION
## Summary
- `authenticateClient` now supports both `client_secret_post` (form values) and `client_secret_basic` (HTTP Basic Auth) for client authentication, matching what the OIDC discovery document advertises
- Basic auth takes precedence when both are present
- Uses Go's built-in `r.BasicAuth()` for parsing per RFC 7617

Closes #51

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] Unit tests for `parseClientCredentials`: Basic auth, form values, and precedence
- [ ] Integration tests: successful token exchange via Basic auth, rejected wrong secret via Basic auth (require Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)