### PR TITLE
Preserve nonce through login page; allow GET on end_session_endpoint

### DIFF
--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -31,6 +31,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 	scope := strings.Split(r.URL.Query().Get("scope"), " ")
 	codeChallenge := r.URL.Query().Get("code_challenge")
 	codeChallengeMethod := r.URL.Query().Get("code_challenge_method")
+	nonce := r.URL.Query().Get("nonce")
 
 	// If code_challenge_method is provided, it must be S256 -- meaning a sha256 hash of the code verifier.
 	if codeChallengeMethod != "" && codeChallengeMethod != "S256" {
@@ -52,6 +53,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 			Scope:               scope,
 			CodeChallenge:       codeChallenge,
 			CodeChallengeMethod: codeChallengeMethod,
+			Nonce:               nonce,
 		})
 		return
 	}
@@ -78,6 +80,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 		Scope:               scope,
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: codeChallengeMethod,
+		Nonce:               nonce,
 	})
 }
 
@@ -229,6 +232,7 @@ func (s *Server) renderLoginError(w http.ResponseWriter, statusCode int, errorMs
 		Scope:               oauthParams.Scope,
 		CodeChallenge:       oauthParams.CodeChallenge,
 		CodeChallengeMethod: oauthParams.CodeChallengeMethod,
+		Nonce:               oauthParams.Nonce,
 	})
 	if err != nil {
 		// Fallback to error template if login template fails

--- a/pkg/httpserver/oauth_integration_test.go
+++ b/pkg/httpserver/oauth_integration_test.go
@@ -686,6 +686,188 @@ func (s *OAuthFlowSuite) TestIDTokenOmitsNonceWhenNotProvided() {
 	s.False(hasNonce, "nonce should not be present when not sent in authorize request")
 }
 
+// TestLoginGetPreservesNonce verifies that the login page renders the nonce from
+// the query string into the hidden form field. Without this, a fresh login through
+// the browser flow (authorize → login GET → login POST) strips the nonce, and the
+// resulting ID token is missing the nonce claim — breaking clients like authlib
+// that validate the nonce.
+func (s *OAuthFlowSuite) TestLoginGetPreservesNonce() {
+	nonce := s.mustGenerateRandomString(32)
+	loginURL := "http://localhost:8080/oauth/login?" + url.Values{
+		"client_id":             {"any"},
+		"redirect_uri":          {"http://localhost:8080/callback"},
+		"state":                 {"state"},
+		"scope":                 {"openid"},
+		"code_challenge":        {"challenge"},
+		"code_challenge_method": {"S256"},
+		"nonce":                 {nonce},
+	}.Encode()
+
+	resp, err := s.httpClient.Get(loginURL)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Contains(string(body), fmt.Sprintf(`name="nonce" value="%s"`, nonce),
+		"login page should render nonce from query string into hidden form field")
+}
+
+// TestIDTokenIncludesNonceThroughBrowserFlow verifies end-to-end that a nonce sent to
+// /oauth/authorize survives the full browser flow (authorize → login GET → login POST →
+// authorize → consent → token) and appears in the ID token. This guards against the
+// earlier regression where HandleLoginGet silently dropped the nonce.
+func (s *OAuthFlowSuite) TestIDTokenIncludesNonceThroughBrowserFlow() {
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: "", Valid: false},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: false,
+		Audience:       "http://localhost:8080",
+	})
+	username := s.mustGenerateAlphanumericString(12)
+	password := s.mustGenerateRandomString(16)
+	s.mustRegisterUser(username, password, fmt.Sprintf("%s@example.com", username))
+	scv := s.mustCreateStateAndCodeVerifier()
+	nonce := s.mustGenerateRandomString(32)
+
+	jar, err := cookiejar.New(nil)
+	s.Require().NoError(err)
+	httpClient := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	// Step 1: GET /oauth/authorize — user is unauthenticated, gets redirected to /oauth/login.
+	authorizeQuery := url.Values{
+		"response_type":         {"code"},
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {"http://localhost:8080/callback"},
+		"scope":                 {"openid profile email"},
+		"state":                 {scv.State},
+		"code_challenge":        {scv.CodeChallenge},
+		"code_challenge_method": {scv.CodeChallengeMethod},
+		"nonce":                 {nonce},
+	}
+	resp, err := httpClient.Get("http://localhost:8080/oauth/authorize?" + authorizeQuery.Encode())
+	s.Require().NoError(err)
+	s.Require().NoError(resp.Body.Close())
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+	loginLocation := resp.Header.Get("Location")
+	if !strings.HasPrefix(loginLocation, "http") {
+		loginLocation = "http://localhost:8080" + loginLocation
+	}
+
+	// Step 2: GET the login page to retrieve the rendered form (the browser step).
+	resp, err = httpClient.Get(loginLocation)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+	loginBody, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Require().NoError(resp.Body.Close())
+	s.Require().Contains(string(loginBody), fmt.Sprintf(`name="nonce" value="%s"`, nonce),
+		"login form must include the nonce so the browser submits it back")
+
+	// Step 3: POST login credentials — simulate the form submit. Mirror what the
+	// rendered form would send, sourcing values from the login URL query string.
+	loginURL, err := url.Parse(loginLocation)
+	s.Require().NoError(err)
+	loginForm := url.Values{
+		"username":              {username},
+		"password":              {password},
+		"client_id":             {loginURL.Query().Get("client_id")},
+		"redirect_uri":          {loginURL.Query().Get("redirect_uri")},
+		"state":                 {loginURL.Query().Get("state")},
+		"scope":                 {loginURL.Query().Get("scope")},
+		"code_challenge":        {loginURL.Query().Get("code_challenge")},
+		"code_challenge_method": {loginURL.Query().Get("code_challenge_method")},
+		"nonce":                 {loginURL.Query().Get("nonce")},
+	}
+	resp, err = httpClient.PostForm("http://localhost:8080/oauth/login", loginForm)
+	s.Require().NoError(err)
+	s.Require().NoError(resp.Body.Close())
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	// Step 4: Follow redirect to /oauth/authorize, which now sees session and redirects to consent.
+	authorizeLocation := resp.Header.Get("Location")
+	if !strings.HasPrefix(authorizeLocation, "http") {
+		authorizeLocation = "http://localhost:8080" + authorizeLocation
+	}
+	resp, err = httpClient.Get(authorizeLocation)
+	s.Require().NoError(err)
+	s.Require().NoError(resp.Body.Close())
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	// Step 5: Approve consent.
+	consentLocation := resp.Header.Get("Location")
+	consentURL, err := url.Parse(consentLocation)
+	s.Require().NoError(err)
+	consentForm := url.Values{
+		"decision":              {"allow"},
+		"client_id":             {consentURL.Query().Get("client_id")},
+		"redirect_uri":          {consentURL.Query().Get("redirect_uri")},
+		"response_type":         {consentURL.Query().Get("response_type")},
+		"scope":                 {consentURL.Query().Get("scope")},
+		"state":                 {consentURL.Query().Get("state")},
+		"code_challenge":        {consentURL.Query().Get("code_challenge")},
+		"code_challenge_method": {consentURL.Query().Get("code_challenge_method")},
+		"nonce":                 {consentURL.Query().Get("nonce")},
+	}
+	resp, err = httpClient.PostForm("http://localhost:8080/oauth/consent", consentForm)
+	s.Require().NoError(err)
+	s.Require().NoError(resp.Body.Close())
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	// Step 6: Extract the authorization code and exchange for tokens.
+	callbackLocation := resp.Header.Get("Location")
+	callbackURL, err := url.Parse(callbackLocation)
+	s.Require().NoError(err)
+	authorizationCode := callbackURL.Query().Get("code")
+	s.Require().NotEmpty(authorizationCode)
+
+	resp, err = httpClient.PostForm("http://localhost:8080/oauth/token", url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {authorizationCode},
+		"redirect_uri":  {"http://localhost:8080/callback"},
+		"client_id":     {client.ClientID},
+		"code_verifier": {scv.CodeVerifier},
+	})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	var tokenResponse TokenResponse
+	s.Require().NoError(json.Unmarshal(body, &tokenResponse))
+	s.Require().NotEmpty(tokenResponse.IDToken)
+
+	parts := strings.Split(tokenResponse.IDToken, ".")
+	s.Require().Len(parts, 3)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	s.Require().NoError(err)
+	var claims map[string]interface{}
+	s.Require().NoError(json.Unmarshal(payload, &claims))
+	s.Equal(nonce, claims["nonce"], "nonce must survive the full browser login flow")
+}
+
+// TestLogoutAcceptsGET verifies that the logout endpoint (advertised as
+// end_session_endpoint in OIDC discovery) accepts GET requests per OIDC
+// RP-Initiated Logout 1.0, which expects browsers to navigate to it via redirect.
+func (s *OAuthFlowSuite) TestLogoutAcceptsGET() {
+	resp, err := s.httpClient.Get("http://localhost:8080/oauth/logout")
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	// Without a session cookie, we still expect a redirect to the login page
+	// rather than a 404/405. That's the signal that GET is wired up.
+	s.Equal(http.StatusFound, resp.StatusCode)
+}
+
 // TestTokenResponseIDTokenAbsentWithoutOpenID verifies that no id_token is returned
 // when the openid scope is not requested.
 func (s *OAuthFlowSuite) TestTokenResponseIDTokenAbsentWithoutOpenID() {

--- a/pkg/httpserver/routes.go
+++ b/pkg/httpserver/routes.go
@@ -71,6 +71,9 @@ func (s *Server) registerRoutes() {
 		r.Post("/register", s.HandleRegisterPost)
 		// Other stuff
 		r.Get("/success", s.HandleSuccess)
+		// Both GET and POST per OIDC RP-Initiated Logout 1.0 — browsers navigating to
+		// end_session_endpoint via redirect use GET; form posts use POST.
+		r.Get("/logout", s.HandleLogout)
 		r.Post("/logout", s.HandleLogout)
 		r.Get("/userinfo", s.HandleOauthUserInfo)
 		r.Post("/introspect", s.HandleIntrospect)


### PR DESCRIPTION
## Summary
- **Nonce bug (the main one):** `HandleLoginGet` wasn't reading `nonce` from the query string, so when an unauthenticated user was redirected from `/oauth/authorize` → `/oauth/login` the rendered hidden input was empty. The form POST submitted an empty nonce, the ID token was issued without the `nonce` claim (due to `omitempty`), and authlib-based clients (e.g. asset_manager) rejected the token for failing nonce validation. Consent and MFA flows already preserved nonce — `HandleLoginGet` was the lone outlier.
- **Logout GET:** `/oauth/logout` is advertised as `end_session_endpoint` in OIDC discovery, but was registered as POST-only. Added GET so browser redirects per OIDC RP-Initiated Logout 1.0 actually work.

## Test plan
- [x] `go test ./...` passes
- [x] New `TestLoginGetPreservesNonce` asserts the login form renders the nonce from the query string
- [x] New `TestIDTokenIncludesNonceThroughBrowserFlow` walks the full browser flow (authorize → login GET → login POST → authorize → consent → token) and verifies the nonce appears in the issued ID token
- [x] New `TestLogoutAcceptsGET` verifies GET on `/oauth/logout` returns 302 instead of 404/405
- [ ] Manually verify asset_manager login works end-to-end against staging after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)