### PR TITLE
Make authorization code and password reset token consumption atomic

### DIFF
--- a/db/queries/auth.sql
+++ b/db/queries/auth.sql
@@ -84,10 +84,13 @@ SELECT *
 FROM oauth_authorization_codes
 WHERE code = $1;
 
--- name: ConsumeAuthorizationCode :exec
+-- name: ConsumeAuthorizationCode :execrows
+-- Atomically consume an authorization code. Returns 1 if the code was consumed,
+-- 0 if it was already consumed (or doesn't exist). Callers MUST check the row
+-- count to prevent token issuance on a replayed code — see RFC 6749 §10.5.
 UPDATE oauth_authorization_codes
 SET consumed_at = now()
-WHERE code = $1;
+WHERE code = $1 AND consumed_at IS NULL;
 
 -- name: InsertToken :one
 INSERT INTO oauth_tokens (
@@ -275,10 +278,14 @@ WHERE et.token_hash = $1
   AND et.expires_at > now()
   AND et.used_at IS NULL;
 
--- name: MarkPasswordResetTokenUsed :exec
+-- name: MarkPasswordResetTokenUsed :execrows
+-- Atomically mark a password reset token as used. Returns 1 if the token was
+-- marked, 0 if it was already used (or doesn't exist / wrong type). Callers
+-- MUST check the row count and refuse the reset if 0 — otherwise a replayed
+-- token can reset the password more than once.
 UPDATE auth_email_tokens
 SET used_at = now()
-WHERE token_hash = $1 AND token_type = 'password_reset';
+WHERE token_hash = $1 AND token_type = 'password_reset' AND used_at IS NULL;
 
 -- name: DeleteExpiredPasswordResetTokens :exec
 DELETE FROM auth_email_tokens

--- a/pkg/db/auth.sql.go
+++ b/pkg/db/auth.sql.go
@@ -14,15 +14,21 @@ import (
 	"github.com/lib/pq"
 )
 
-const consumeAuthorizationCode = `-- name: ConsumeAuthorizationCode :exec
+const consumeAuthorizationCode = `-- name: ConsumeAuthorizationCode :execrows
 UPDATE oauth_authorization_codes
 SET consumed_at = now()
-WHERE code = $1
+WHERE code = $1 AND consumed_at IS NULL
 `
 
-func (q *Queries) ConsumeAuthorizationCode(ctx context.Context, code string) error {
-	_, err := q.db.ExecContext(ctx, consumeAuthorizationCode, code)
-	return err
+// Atomically consume an authorization code. Returns 1 if the code was consumed,
+// 0 if it was already consumed (or doesn't exist). Callers MUST check the row
+// count to prevent token issuance on a replayed code — see RFC 6749 §10.5.
+func (q *Queries) ConsumeAuthorizationCode(ctx context.Context, code string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, consumeAuthorizationCode, code)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const countUsers = `-- name: CountUsers :one
@@ -976,15 +982,22 @@ func (q *Queries) MarkEmailTokenUsed(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
-const markPasswordResetTokenUsed = `-- name: MarkPasswordResetTokenUsed :exec
+const markPasswordResetTokenUsed = `-- name: MarkPasswordResetTokenUsed :execrows
 UPDATE auth_email_tokens
 SET used_at = now()
-WHERE token_hash = $1 AND token_type = 'password_reset'
+WHERE token_hash = $1 AND token_type = 'password_reset' AND used_at IS NULL
 `
 
-func (q *Queries) MarkPasswordResetTokenUsed(ctx context.Context, tokenHash string) error {
-	_, err := q.db.ExecContext(ctx, markPasswordResetTokenUsed, tokenHash)
-	return err
+// Atomically mark a password reset token as used. Returns 1 if the token was
+// marked, 0 if it was already used (or doesn't exist / wrong type). Callers
+// MUST check the row count and refuse the reset if 0 — otherwise a replayed
+// token can reset the password more than once.
+func (q *Queries) MarkPasswordResetTokenUsed(ctx context.Context, tokenHash string) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markPasswordResetTokenUsed, tokenHash)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const reactivateUser = `-- name: ReactivateUser :exec

--- a/pkg/httpserver/oauth.go
+++ b/pkg/httpserver/oauth.go
@@ -277,10 +277,18 @@ func (s *Server) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	// Mark the authorization code as consumed
-	err = s.datastore.Q.ConsumeAuthorizationCode(r.Context(), code)
+	// Atomically mark the authorization code as consumed. The WHERE clause
+	// guards against TOCTOU: if the earlier `authCode.ConsumedAt.Valid` check
+	// passed but a concurrent request already consumed the code in the meantime,
+	// this UPDATE affects 0 rows and we refuse to issue tokens. RFC 6749 §10.5
+	// requires that an authorization code be usable at most once.
+	rowsAffected, err := s.datastore.Q.ConsumeAuthorizationCode(r.Context(), code)
 	if err != nil {
 		s.writeTokenError(w, "server_error", "Failed to consume authorization code")
+		return
+	}
+	if rowsAffected == 0 {
+		s.writeTokenError(w, "invalid_grant", "Authorization code has already been used")
 		return
 	}
 

--- a/pkg/httpserver/oauth_integration_test.go
+++ b/pkg/httpserver/oauth_integration_test.go
@@ -856,6 +856,110 @@ func (s *OAuthFlowSuite) TestIDTokenIncludesNonceThroughBrowserFlow() {
 	s.Equal(nonce, claims["nonce"], "nonce must survive the full browser login flow")
 }
 
+// TestAuthorizationCodeCannotBeReused verifies that an authorization code is
+// single-use: the first token exchange succeeds, the second with the same code
+// is rejected with invalid_grant. Guards against the TOCTOU where two concurrent
+// token requests could both consume the same code.
+func (s *OAuthFlowSuite) TestAuthorizationCodeCannotBeReused() {
+	clientCallbackURI := "http://localhost:8080/callback"
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: "", Valid: false},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{clientCallbackURI},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: false,
+		Audience:       "http://localhost:8080",
+	})
+	user := s.mustRegisterUser(
+		s.mustGenerateAlphanumericString(12),
+		s.mustGenerateRandomString(16),
+		fmt.Sprintf("%s@example.com", s.mustGenerateAlphanumericString(8)),
+	)
+	scv := s.mustCreateStateAndCodeVerifier()
+
+	code := s.mustLoginAndConsent(user, client.ClientID, clientCallbackURI, "openid profile email", scv)
+
+	tokenForm := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {clientCallbackURI},
+		"client_id":     {client.ClientID},
+		"code_verifier": {scv.CodeVerifier},
+	}
+
+	// First exchange: succeeds.
+	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/token", tokenForm)
+	s.Require().NoError(err)
+	s.Require().NoError(resp.Body.Close())
+	s.Require().Equal(http.StatusOK, resp.StatusCode, "first code exchange should succeed")
+
+	// Second exchange with the same code: must be rejected.
+	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/token", tokenForm)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusBadRequest, resp.StatusCode, "replayed code must be rejected")
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	var errResp map[string]string
+	s.Require().NoError(json.Unmarshal(body, &errResp))
+	s.Equal("invalid_grant", errResp["error"], "replay should return invalid_grant")
+}
+
+// TestPasswordResetTokenCannotBeReused verifies that a password reset token is
+// single-use: the first reset succeeds, the second attempt with the same token
+// is rejected. Guards against the TOCTOU on auth_email_tokens.used_at.
+func (s *OAuthFlowSuite) TestPasswordResetTokenCannotBeReused() {
+	username := s.mustGenerateAlphanumericString(12)
+	password := s.mustGenerateRandomString(16)
+	user := s.mustRegisterUser(username, password, fmt.Sprintf("%s@example.com", username))
+
+	// Insert a password reset token directly (skips the "forgot password" email flow).
+	rawToken, tokenHash, err := generateResetToken()
+	s.Require().NoError(err)
+	err = s.datastore.Q.CreatePasswordResetToken(s.T().Context(), db.CreatePasswordResetTokenParams{
+		UserID:    user.ID,
+		TokenHash: tokenHash,
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	})
+	s.Require().NoError(err)
+
+	// auth.ValidatePassword rejects passwords containing the username, so keep them distinct.
+	newPassword := "NewS3cure-" + s.mustGenerateRandomString(16)
+
+	// First reset: succeeds and redirects to login.
+	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/reset-password", url.Values{
+		"token":            {rawToken},
+		"new_password":     {newPassword},
+		"confirm_password": {newPassword},
+	})
+	s.Require().NoError(err)
+	s.Require().NoError(resp.Body.Close())
+	s.Require().Equal(http.StatusFound, resp.StatusCode, "first reset should redirect to login")
+
+	// Second reset with same token: must be rejected.
+	secondPassword := "Another-" + s.mustGenerateRandomString(16)
+	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/reset-password", url.Values{
+		"token":            {rawToken},
+		"password":         {secondPassword},
+		"confirm_password": {secondPassword},
+	})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusBadRequest, resp.StatusCode, "replayed reset token must be rejected")
+
+	// Verify the first password still works (i.e. the replay attempt did NOT change it).
+	dbUser, err := s.datastore.Q.GetUserByUsername(s.T().Context(), username)
+	s.Require().NoError(err)
+	firstMatches, err := auth.VerifyPassword(newPassword, dbUser.PasswordHash)
+	s.Require().NoError(err)
+	s.True(firstMatches, "first reset password should still be valid after replay attempt")
+	secondMatches, err := auth.VerifyPassword(secondPassword, dbUser.PasswordHash)
+	s.Require().NoError(err)
+	s.False(secondMatches, "second reset attempt must not have changed the password")
+}
+
 // TestLogoutAcceptsGET verifies that the logout endpoint (advertised as
 // end_session_endpoint in OIDC discovery) accepts GET requests per OIDC
 // RP-Initiated Logout 1.0, which expects browsers to navigate to it via redirect.

--- a/pkg/httpserver/password_reset.go
+++ b/pkg/httpserver/password_reset.go
@@ -251,6 +251,31 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Atomically mark the token as used BEFORE updating the password. The WHERE
+	// clause guards against TOCTOU: if another request already consumed this
+	// token between the earlier lookup and now, the UPDATE affects 0 rows and
+	// we refuse to reset. Ordering matters — if we updated the password first
+	// and the mark-used write failed or raced, the token would remain valid and
+	// could reset the password again. Failing the reset when the user has to
+	// request a new token is strictly safer than allowing replay.
+	rowsAffected, err := s.datastore.Q.MarkPasswordResetTokenUsed(r.Context(), tokenHash)
+	if err != nil {
+		log.Printf("[ERROR] HandleResetPasswordPost: Failed to mark token as used: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+			Error: "An error occurred. Please try again.",
+			Token: token,
+		})
+		return
+	}
+	if rowsAffected == 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+			Error: "This password reset link is invalid or has expired. Please request a new one.",
+		})
+		return
+	}
+
 	// Update password
 	err = s.datastore.Q.UpdateUserPasswordWithTimestamp(r.Context(), db.UpdateUserPasswordWithTimestampParams{
 		PasswordHash: passwordHash,
@@ -264,13 +289,6 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 			Token: token,
 		})
 		return
-	}
-
-	// Mark token as used
-	err = s.datastore.Q.MarkPasswordResetTokenUsed(r.Context(), tokenHash)
-	if err != nil {
-		// Log but don't fail - password was already updated
-		log.Printf("[ERROR] HandleResetPasswordPost: Failed to mark token as used: %v", err)
 	}
 
 	log.Printf("[DEBUG] HandleResetPasswordPost: Password reset successfully for user %s", tokenRecord.Username)


### PR DESCRIPTION
## Summary
Two endpoints had a TOCTOU where the "already used?" check and the mark-used write were separate statements. Concurrent requests with the same code/token could both pass the check and both proceed — minting two token sets from one auth code, or resetting a password twice from one reset token.

**Fixes:**
- `ConsumeAuthorizationCode` and `MarkPasswordResetTokenUsed` now include `AND consumed_at IS NULL` / `AND used_at IS NULL` in their WHERE clauses and return the row count (`:execrows`).
- Handlers check `rowsAffected == 1` before issuing tokens / changing the password. 0 rows ⇒ concurrent request won ⇒ refuse.
- Reorder `HandleResetPasswordPost`: mark the token used *before* updating the password. Previously the order was reversed with an explicit "log but don't fail" on the mark-used write, meaning a transient DB error after a successful password update would leave the token valid for replay.

Auth code fix matches RFC 6749 §10.5 (codes MUST be usable at most once).

## Test plan
- [x] `go test ./...` passes
- [x] New `TestAuthorizationCodeCannotBeReused` — exchange code twice, second attempt returns 400 `invalid_grant`
- [x] New `TestPasswordResetTokenCannotBeReused` — reset twice with same token, second attempt returns 400; verifies DB password hash is still the first one (second attempt didn't overwrite)
- [ ] After deploy, manually verify login / password reset still work end-to-end against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)