### PR TITLE
Preserve OAuth context through the MFA step

### DIFF
--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -181,43 +181,13 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 		// Non-fatal error - continue with login
 	}
 
-	// Set secure session cookie
-	// Secure flag should be true in production (HTTPS), false for local dev
-	isSecure := strings.HasPrefix(s.config.HTTPAddress, "https://") || strings.Contains(s.config.HTTPAddress, ":443")
-	log.Printf("[DEBUG] HandleLoginPost: Setting session cookie (secure=%v)", isSecure)
-	http.SetCookie(w, &http.Cookie{
-		Name:     "session_id",
-		Value:    session.ID,
-		Path:     "/",
-		Expires:  session.ExpiresAt,
-		HttpOnly: true,
-		Secure:   isSecure,
-		SameSite: http.SameSiteLaxMode,
-	})
+	// Set the authenticated session cookie.
+	s.setSessionCookie(w, session)
 
-	// Check if this is a direct login (no OAuth flow)
-	if clientID == "" {
-		// Direct login: redirect to account settings
-		log.Printf("[DEBUG] HandleLoginPost: Direct login (no client_id), redirecting to account settings")
-		http.Redirect(w, r, "/oauth/account-settings", http.StatusFound)
-		return
-	}
-
-	// Redirect back to /oauth/authorize to handle consent and code generation.
-	// The session is now established, so authorize will find the user authenticated.
-	authorizeQuery := url.Values{
-		"client_id":             {clientID},
-		"redirect_uri":          {redirectURI},
-		"response_type":         {"code"},
-		"scope":                 {strings.Join(scope, " ")},
-		"state":                 {state},
-		"code_challenge":        {codeChallenge},
-		"code_challenge_method": {codeChallengeMethod},
-		"nonce":                 {nonce},
-	}
-	authorizeURL := "/oauth/authorize?" + authorizeQuery.Encode()
-	log.Printf("[DEBUG] HandleLoginPost: Redirecting to authorize: %s", authorizeURL)
-	http.Redirect(w, r, authorizeURL, http.StatusFound)
+	// Redirect onward: back into the OAuth authorize flow (which now finds the user
+	// authenticated and handles consent + code issuance), or to account settings for a
+	// direct login with no OAuth flow in progress.
+	s.redirectAfterAuth(w, r, oauthParams)
 }
 
 // renderLoginError renders the login page with an error message, preserving OAuth parameters.
@@ -248,4 +218,50 @@ func (s *Server) renderLoginError(w http.ResponseWriter, statusCode int, errorMs
 			http.Error(w, "An error occurred while rendering the error page", http.StatusInternalServerError)
 		}
 	}
+}
+
+// setSessionCookie writes the authenticated session cookie. The Secure attribute is
+// enabled when the configured public address is HTTPS (production) and left off for
+// plain-HTTP local development.
+func (s *Server) setSessionCookie(w http.ResponseWriter, session Session) {
+	isSecure := strings.HasPrefix(s.config.HTTPAddress, "https://") || strings.Contains(s.config.HTTPAddress, ":443")
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session_id",
+		Value:    session.ID,
+		Path:     "/",
+		Expires:  session.ExpiresAt,
+		HttpOnly: true,
+		Secure:   isSecure,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// buildAuthorizeURL builds the /oauth/authorize URL used to (re)enter the OAuth flow
+// once the user is authenticated. It mirrors the parameters originally supplied by the
+// client; the authorize endpoint re-validates client_id, redirect_uri and scope on
+// arrival, so these values are not trusted blindly.
+func buildAuthorizeURL(p LoginPageData) string {
+	q := url.Values{
+		"client_id":             {p.ClientID},
+		"redirect_uri":          {p.RedirectURI},
+		"response_type":         {"code"},
+		"scope":                 {strings.Join(p.Scope, " ")},
+		"state":                 {p.State},
+		"code_challenge":        {p.CodeChallenge},
+		"code_challenge_method": {p.CodeChallengeMethod},
+		"nonce":                 {p.Nonce},
+	}
+	return "/oauth/authorize?" + q.Encode()
+}
+
+// redirectAfterAuth sends a freshly-authenticated user onward. When an OAuth client
+// initiated the flow (client_id present) the user is routed back through
+// /oauth/authorize to handle consent and authorization-code issuance; otherwise this
+// was a direct login and the user is taken to account settings.
+func (s *Server) redirectAfterAuth(w http.ResponseWriter, r *http.Request, p LoginPageData) {
+	if p.ClientID == "" {
+		http.Redirect(w, r, "/oauth/account-settings", http.StatusFound)
+		return
+	}
+	http.Redirect(w, r, buildAuthorizeURL(p), http.StatusFound)
 }

--- a/pkg/httpserver/mfa.go
+++ b/pkg/httpserver/mfa.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"log"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -16,9 +15,53 @@ import (
 const mfaPendingExpiresIn = 5 * time.Minute
 
 // MFAPageData holds the data needed to render the MFA verification page template.
+//
+// The OAuth authorization parameters are carried through the page as hidden form
+// fields so the originating authorization request survives even if the server-side
+// pending row is gone by the time the code is submitted — because it expired during
+// code entry, or a duplicate/replayed submit already consumed it. Without this, a lost
+// pending row strips the OAuth context and the user is bounced to a context-free login
+// (and, after re-authenticating, dumped on the account page instead of the app).
 type MFAPageData struct {
-	Error     string
-	PendingID string
+	Error               string
+	PendingID           string
+	ClientID            string
+	RedirectURI         string
+	State               string
+	Scope               []string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Nonce               string
+}
+
+// oauthParamsFromPending lifts the OAuth authorization parameters stored on a pending
+// MFA row into the common LoginPageData carrier.
+func oauthParamsFromPending(p db.AuthMfaPending) LoginPageData {
+	return LoginPageData{
+		ClientID:            p.ClientID.String,
+		RedirectURI:         p.RedirectUri.String,
+		State:               p.State.String,
+		Scope:               p.Scope,
+		CodeChallenge:       p.CodeChallenge.String,
+		CodeChallengeMethod: p.CodeChallengeMethod.String,
+		Nonce:               p.Nonce.String,
+	}
+}
+
+// mfaPageData assembles the MFA template data from the pending ID, the OAuth context,
+// and an optional error message.
+func mfaPageData(pendingID string, p LoginPageData, errMsg string) MFAPageData {
+	return MFAPageData{
+		Error:               errMsg,
+		PendingID:           pendingID,
+		ClientID:            p.ClientID,
+		RedirectURI:         p.RedirectURI,
+		State:               p.State,
+		Scope:               p.Scope,
+		CodeChallenge:       p.CodeChallenge,
+		CodeChallengeMethod: p.CodeChallengeMethod,
+		Nonce:               p.Nonce,
+	}
 }
 
 // HandleMFAGet displays the MFA code entry form.
@@ -29,17 +72,16 @@ func (s *Server) HandleMFAGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Verify the pending MFA session exists and is valid
-	_, err := s.datastore.Q.GetMFAPending(r.Context(), pendingID)
+	// Verify the pending MFA session exists and is valid, and source the OAuth context
+	// from it (server-side, authoritative) so the rendered form can carry it on submit.
+	pending, err := s.datastore.Q.GetMFAPending(r.Context(), pendingID)
 	if err != nil {
 		log.Printf("[DEBUG] HandleMFAGet: Invalid or expired pending MFA session: %v", err)
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
 
-	s.mfaTemplate.Execute(w, MFAPageData{
-		PendingID: pendingID,
-	})
+	s.mfaTemplate.Execute(w, mfaPageData(pendingID, oauthParamsFromPending(pending), ""))
 }
 
 // HandleMFAPost validates the MFA code and completes the login flow.
@@ -47,92 +89,108 @@ func (s *Server) HandleMFAPost(w http.ResponseWriter, r *http.Request) {
 	pendingID := r.FormValue("pending_id")
 	code := r.FormValue("code")
 
+	// OAuth context echoed back by the MFA form (rendered there from the pending row).
+	// This is used only as a fallback to keep the flow alive when the pending row can no
+	// longer be found; whenever the row is present it remains the authoritative source.
+	// Either way, /oauth/authorize re-validates client_id, redirect_uri and scope, so a
+	// tampered field cannot escalate — it just produces a validation error.
+	formParams := LoginPageData{
+		ClientID:            r.FormValue("client_id"),
+		RedirectURI:         r.FormValue("redirect_uri"),
+		State:               r.FormValue("state"),
+		Scope:               strings.Split(r.FormValue("scope"), " "),
+		CodeChallenge:       r.FormValue("code_challenge"),
+		CodeChallengeMethod: r.FormValue("code_challenge_method"),
+		Nonce:               r.FormValue("nonce"),
+	}
+
 	if pendingID == "" {
-		http.Redirect(w, r, "/oauth/login", http.StatusFound)
+		s.resumeMFAFlow(w, r, formParams)
 		return
 	}
 
-	// Get the pending MFA session
+	// Get the pending MFA session.
 	pending, err := s.datastore.Q.GetMFAPending(r.Context(), pendingID)
 	if err != nil {
-		log.Printf("[DEBUG] HandleMFAPost: Invalid or expired pending MFA session: %v", err)
-		http.Redirect(w, r, "/oauth/login", http.StatusFound)
+		// The pending row is gone: it expired while the user entered their code, or a
+		// duplicate/replayed submit already consumed it. Do NOT discard the OAuth
+		// context — resume the flow so the user returns to the originating app instead
+		// of being stranded on a context-free login (and then the account page).
+		log.Printf("[DEBUG] HandleMFAPost: pending MFA session missing/expired (%v); resuming with carried OAuth context", err)
+		s.resumeMFAFlow(w, r, formParams)
 		return
 	}
 
-	// Get the user's MFA secret
+	// With the pending row in hand, it is the authoritative source of OAuth params.
+	pendingParams := oauthParamsFromPending(pending)
+
+	// Get the user's MFA secret.
 	mfaStatus, err := s.datastore.Q.GetUserMFAStatus(r.Context(), pending.UserID)
 	if err != nil {
 		log.Printf("[ERROR] HandleMFAPost: Failed to get MFA status: %v", err)
-		s.renderMFAError(w, http.StatusInternalServerError, "An error occurred", pendingID)
+		s.renderMFAError(w, http.StatusInternalServerError, "An error occurred", pendingID, pendingParams)
 		return
 	}
 
 	if !mfaStatus.MfaEnabled || !mfaStatus.MfaSecret.Valid {
 		log.Printf("[ERROR] HandleMFAPost: MFA not enabled for user")
-		http.Redirect(w, r, "/oauth/login", http.StatusFound)
+		s.resumeMFAFlow(w, r, pendingParams)
 		return
 	}
 
-	// Validate the TOTP code
+	// Validate the TOTP code. A wrong code leaves the pending row intact so the user can
+	// retry within the validity window.
 	if !mfa.ValidateCode(mfaStatus.MfaSecret.String, code) {
 		log.Printf("[DEBUG] HandleMFAPost: Invalid MFA code for user: %v", pending.UserID)
-		s.renderMFAError(w, http.StatusUnauthorized, "Invalid verification code", pendingID)
+		s.renderMFAError(w, http.StatusUnauthorized, "Invalid verification code", pendingID, pendingParams)
 		return
 	}
 
-	// Delete the pending MFA session
+	// Consume the pending MFA session (single use).
 	if err := s.datastore.Q.DeleteMFAPending(r.Context(), pendingID); err != nil {
 		log.Printf("[ERROR] HandleMFAPost: Failed to delete pending MFA session: %v", err)
 	}
 
-	// Create authenticated session
+	// Create authenticated session.
 	session, err := s.createSession(r.Context(), pending.UserID)
 	if err != nil {
 		log.Printf("[ERROR] HandleMFAPost: Failed to create session: %v", err)
-		http.Redirect(w, r, "/oauth/login", http.StatusFound)
+		s.renderMFAError(w, http.StatusInternalServerError, "An error occurred", pendingID, pendingParams)
 		return
 	}
 
-	// Update last login timestamp
+	// Update last login timestamp (non-fatal on error).
 	if err := s.datastore.Q.UpdateUserLastLogin(r.Context(), pending.UserID); err != nil {
 		log.Printf("[ERROR] HandleMFAPost: Failed to update last login time: %v", err)
-		// Non-fatal error - continue with login
 	}
 
-	// Set secure session cookie
-	isSecure := strings.HasPrefix(s.config.HTTPAddress, "https://") || strings.Contains(s.config.HTTPAddress, ":443")
-	http.SetCookie(w, &http.Cookie{
-		Name:     "session_id",
-		Value:    session.ID,
-		Path:     "/",
-		Expires:  session.ExpiresAt,
-		HttpOnly: true,
-		Secure:   isSecure,
-		SameSite: http.SameSiteLaxMode,
-	})
+	s.setSessionCookie(w, session)
 
-	// Check if this is a direct login (no OAuth flow)
-	if !pending.ClientID.Valid || pending.ClientID.String == "" {
-		log.Printf("[DEBUG] HandleMFAPost: Direct login, redirecting to account settings")
+	// Resume using the pending row's authoritative OAuth params.
+	s.redirectAfterAuth(w, r, pendingParams)
+}
+
+// resumeMFAFlow recovers the login flow when the pending MFA row is no longer available
+// at submit time. It must never discard the OAuth context.
+//
+// When a client initiated the flow, the user is routed back through /oauth/authorize:
+//   - if a session already exists (a duplicate submit already completed OTP), authorize
+//     finishes the flow and returns the user to the app;
+//   - otherwise authorize sends them to the login page with the OAuth parameters
+//     preserved, so a fresh password + OTP still lands them back on the app.
+//
+// For a direct (non-OAuth) login there is no app context to preserve, so the user goes
+// to account settings if already authenticated, or the login page if not.
+func (s *Server) resumeMFAFlow(w http.ResponseWriter, r *http.Request, p LoginPageData) {
+	if p.ClientID != "" {
+		http.Redirect(w, r, buildAuthorizeURL(p), http.StatusFound)
+		return
+	}
+	if _, err := s.getSessionFromCookie(r); err == nil {
 		http.Redirect(w, r, "/oauth/account-settings", http.StatusFound)
 		return
 	}
-
-	// Redirect back to /oauth/authorize to handle consent and code generation.
-	authorizeQuery := url.Values{
-		"client_id":             {pending.ClientID.String},
-		"redirect_uri":          {pending.RedirectUri.String},
-		"response_type":         {"code"},
-		"scope":                 {strings.Join(pending.Scope, " ")},
-		"state":                 {pending.State.String},
-		"code_challenge":        {pending.CodeChallenge.String},
-		"code_challenge_method": {pending.CodeChallengeMethod.String},
-		"nonce":                 {pending.Nonce.String},
-	}
-	authorizeURL := "/oauth/authorize?" + authorizeQuery.Encode()
-	log.Printf("[DEBUG] HandleMFAPost: Redirecting to authorize: %s", authorizeURL)
-	http.Redirect(w, r, authorizeURL, http.StatusFound)
+	http.Redirect(w, r, "/oauth/login", http.StatusFound)
 }
 
 // createMFAPendingSession creates a pending MFA session after password validation.
@@ -162,11 +220,9 @@ func (s *Server) createMFAPendingSession(r *http.Request, userID uuid.UUID, oaut
 	return pendingID, nil
 }
 
-// renderMFAError renders the MFA page with an error message.
-func (s *Server) renderMFAError(w http.ResponseWriter, statusCode int, errorMsg string, pendingID string) {
+// renderMFAError renders the MFA page with an error message, preserving the OAuth
+// context so a retry keeps the originating authorization request intact.
+func (s *Server) renderMFAError(w http.ResponseWriter, statusCode int, errorMsg string, pendingID string, p LoginPageData) {
 	w.WriteHeader(statusCode)
-	s.mfaTemplate.Execute(w, MFAPageData{
-		Error:     errorMsg,
-		PendingID: pendingID,
-	})
+	s.mfaTemplate.Execute(w, mfaPageData(pendingID, p, errorMsg))
 }

--- a/pkg/httpserver/oauth_integration_test.go
+++ b/pkg/httpserver/oauth_integration_test.go
@@ -1504,6 +1504,252 @@ func (s *OAuthFlowSuite) TestMFAWithInvalidCode() {
 	s.Contains(string(body), "Invalid verification code")
 }
 
+// TestMFAPageRendersOAuthContext verifies the MFA verification page echoes the OAuth
+// authorization parameters into hidden form fields. Without this, a pending row that
+// expires or is consumed before the code is submitted strips the OAuth context, and the
+// user is bounced to a context-free login (and then the account page).
+func (s *OAuthFlowSuite) TestMFAPageRendersOAuthContext() {
+	clientCallbackURI := "http://localhost:8080/callback"
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: "", Valid: false},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{clientCallbackURI},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: false,
+		Audience:       "http://localhost:8000",
+	})
+	user := s.mustRegisterUser(
+		s.mustGenerateRandomString(8),
+		s.mustGenerateRandomString(8),
+		fmt.Sprintf("%s@example.com", s.mustGenerateRandomString(8)),
+	)
+	totpKey, err := mfa.GenerateSecret(user.Username)
+	s.Require().NoError(err)
+	s.mustEnableMFAForUser(user, mfa.GetSecret(totpKey))
+
+	scv := s.mustCreateStateAndCodeVerifier()
+	nonce := s.mustGenerateRandomString(16)
+	host := "localhost:8080"
+
+	// Login to reach the MFA page.
+	resp, err := s.httpClient.PostForm(fmt.Sprintf("http://%s/oauth/login", host), url.Values{
+		"username":              {user.Username},
+		"password":              {user.Password},
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {clientCallbackURI},
+		"state":                 {scv.State},
+		"scope":                 {"openid profile email"},
+		"code_challenge":        {scv.CodeChallenge},
+		"code_challenge_method": {scv.CodeChallengeMethod},
+		"nonce":                 {nonce},
+	})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+	location := resp.Header.Get("Location")
+	s.Require().Contains(location, "/oauth/mfa")
+
+	mfaURL := location
+	if !strings.HasPrefix(mfaURL, "http") {
+		mfaURL = fmt.Sprintf("http://%s%s", host, mfaURL)
+	}
+	resp, err = s.httpClient.Get(mfaURL)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	html := string(body)
+
+	s.Contains(html, fmt.Sprintf(`name="client_id" value="%s"`, client.ClientID))
+	s.Contains(html, fmt.Sprintf(`name="redirect_uri" value="%s"`, clientCallbackURI))
+	s.Contains(html, fmt.Sprintf(`name="state" value="%s"`, scv.State))
+	s.Contains(html, fmt.Sprintf(`name="code_challenge" value="%s"`, scv.CodeChallenge))
+	s.Contains(html, fmt.Sprintf(`name="nonce" value="%s"`, nonce))
+}
+
+// TestMFAPostWithExpiredPendingPreservesContext is the core regression test for the
+// reported bug. When the pending MFA row is gone at code-submit time (here simulated by
+// deleting it, as expiry would), the submit must resume the OAuth flow rather than
+// strand the user on a context-free login that, on re-auth, lands on the account page.
+func (s *OAuthFlowSuite) TestMFAPostWithExpiredPendingPreservesContext() {
+	clientCallbackURI := "http://localhost:8080/callback"
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: "", Valid: false},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{clientCallbackURI},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: false,
+		Audience:       "http://localhost:8000",
+	})
+	user := s.mustRegisterUser(
+		s.mustGenerateRandomString(8),
+		s.mustGenerateRandomString(8),
+		fmt.Sprintf("%s@example.com", s.mustGenerateRandomString(8)),
+	)
+	totpKey, err := mfa.GenerateSecret(user.Username)
+	s.Require().NoError(err)
+	totpSecret := mfa.GetSecret(totpKey)
+	s.mustEnableMFAForUser(user, totpSecret)
+
+	scv := s.mustCreateStateAndCodeVerifier()
+	nonce := s.mustGenerateRandomString(16)
+	host := "localhost:8080"
+
+	resp, err := s.httpClient.PostForm(fmt.Sprintf("http://%s/oauth/login", host), url.Values{
+		"username":              {user.Username},
+		"password":              {user.Password},
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {clientCallbackURI},
+		"state":                 {scv.State},
+		"scope":                 {"openid profile email"},
+		"code_challenge":        {scv.CodeChallenge},
+		"code_challenge_method": {scv.CodeChallengeMethod},
+		"nonce":                 {nonce},
+	})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+	redirectURL, err := url.ParseRequestURI(resp.Header.Get("Location"))
+	s.Require().NoError(err)
+	pendingID := redirectURL.Query().Get("pending")
+	s.Require().NotEmpty(pendingID)
+
+	// Simulate the pending row vanishing before the code is submitted (expiry / replay).
+	err = s.datastore.Q.DeleteMFAPending(s.T().Context(), pendingID)
+	s.Require().NoError(err)
+
+	validCode, err := generateTOTPCode(totpSecret)
+	s.Require().NoError(err)
+
+	// Submit the code together with the OAuth context the rendered page would carry.
+	resp, err = s.httpClient.PostForm(fmt.Sprintf("http://%s/oauth/mfa", host), url.Values{
+		"pending_id":            {pendingID},
+		"code":                  {validCode},
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {clientCallbackURI},
+		"state":                 {scv.State},
+		"scope":                 {"openid profile email"},
+		"code_challenge":        {scv.CodeChallenge},
+		"code_challenge_method": {scv.CodeChallengeMethod},
+		"nonce":                 {nonce},
+	})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+
+	loc, err := url.Parse(resp.Header.Get("Location"))
+	s.Require().NoError(err)
+	// The OAuth context must be preserved: resume the authorize flow, NOT drop to the
+	// account-settings page (the original bug).
+	s.Equal("/oauth/authorize", loc.Path, "should resume the OAuth flow, not land on account settings")
+	s.Equal(client.ClientID, loc.Query().Get("client_id"), "client_id must be preserved")
+	s.Equal(clientCallbackURI, loc.Query().Get("redirect_uri"), "redirect_uri must be preserved")
+	s.Equal(nonce, loc.Query().Get("nonce"), "nonce must be preserved")
+}
+
+// TestMFADoubleSubmitPreservesContext verifies that a duplicate/replayed MFA submit
+// (the first already consumed the pending row and established the session) does not lose
+// the OAuth context and strand the user on the account page.
+func (s *OAuthFlowSuite) TestMFADoubleSubmitPreservesContext() {
+	clientCallbackURI := "http://localhost:8080/callback"
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: "", Valid: false},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{clientCallbackURI},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: false,
+		Audience:       "http://localhost:8000",
+	})
+	user := s.mustRegisterUser(
+		s.mustGenerateRandomString(8),
+		s.mustGenerateRandomString(8),
+		fmt.Sprintf("%s@example.com", s.mustGenerateRandomString(8)),
+	)
+	totpKey, err := mfa.GenerateSecret(user.Username)
+	s.Require().NoError(err)
+	totpSecret := mfa.GetSecret(totpKey)
+	s.mustEnableMFAForUser(user, totpSecret)
+
+	scv := s.mustCreateStateAndCodeVerifier()
+	nonce := s.mustGenerateRandomString(16)
+	host := "localhost:8080"
+
+	jar, err := cookiejar.New(nil)
+	s.Require().NoError(err)
+	httpClient := &http.Client{
+		Jar: jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+
+	resp, err := httpClient.PostForm(fmt.Sprintf("http://%s/oauth/login", host), url.Values{
+		"username":              {user.Username},
+		"password":              {user.Password},
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {clientCallbackURI},
+		"state":                 {scv.State},
+		"scope":                 {"openid profile email"},
+		"code_challenge":        {scv.CodeChallenge},
+		"code_challenge_method": {scv.CodeChallengeMethod},
+		"nonce":                 {nonce},
+	})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+	redirectURL, err := url.ParseRequestURI(resp.Header.Get("Location"))
+	s.Require().NoError(err)
+	pendingID := redirectURL.Query().Get("pending")
+	s.Require().NotEmpty(pendingID)
+
+	validCode, err := generateTOTPCode(totpSecret)
+	s.Require().NoError(err)
+
+	mfaForm := url.Values{
+		"pending_id":            {pendingID},
+		"code":                  {validCode},
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {clientCallbackURI},
+		"state":                 {scv.State},
+		"scope":                 {"openid profile email"},
+		"code_challenge":        {scv.CodeChallenge},
+		"code_challenge_method": {scv.CodeChallengeMethod},
+		"nonce":                 {nonce},
+	}
+
+	// First submit: succeeds, consumes the pending row, and sets the session cookie.
+	resp, err = httpClient.PostForm(fmt.Sprintf("http://%s/oauth/mfa", host), mfaForm)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+	loc1, err := url.Parse(resp.Header.Get("Location"))
+	s.Require().NoError(err)
+	s.Equal("/oauth/authorize", loc1.Path)
+	s.Equal(client.ClientID, loc1.Query().Get("client_id"))
+	var hasSession bool
+	for _, c := range resp.Cookies() {
+		if c.Name == "session_id" && c.Value != "" {
+			hasSession = true
+		}
+	}
+	s.True(hasSession, "first MFA submit should establish a session")
+
+	// Second submit (replay): the pending row is already gone. The flow must still be
+	// preserved — resume authorize, not bounce to account settings.
+	resp, err = httpClient.PostForm(fmt.Sprintf("http://%s/oauth/mfa", host), mfaForm)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusFound, resp.StatusCode)
+	loc2, err := url.Parse(resp.Header.Get("Location"))
+	s.Require().NoError(err)
+	s.Equal("/oauth/authorize", loc2.Path, "replayed submit must not drop to account settings")
+	s.Equal(client.ClientID, loc2.Query().Get("client_id"), "client_id must be preserved on replay")
+}
+
 // generateTOTPCode generates a valid TOTP code for the given secret.
 // This uses the same library as the server to ensure compatibility.
 func generateTOTPCode(secret string) (string, error) {

--- a/templates/mfa.html
+++ b/templates/mfa.html
@@ -42,6 +42,13 @@
                 </fieldset>
 
                 <input type="hidden" name="pending_id" value="{{.PendingID}}">
+                <input type="hidden" name="client_id" value="{{.ClientID}}">
+                <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}">
+                <input type="hidden" name="state" value="{{.State}}">
+                <input type="hidden" name="scope" value="{{range $i, $s := .Scope}}{{if $i}} {{end}}{{$s}}{{end}}">
+                <input type="hidden" name="code_challenge" value="{{.CodeChallenge}}">
+                <input type="hidden" name="code_challenge_method" value="{{.CodeChallengeMethod}}">
+                <input type="hidden" name="nonce" value="{{.Nonce}}">
 
                 <button type="submit" class="btn btn-primary w-full">Verify</button>
             </form>


### PR DESCRIPTION
When MFA verification couldn't find the pending row, the handlers redirected
to a bare /oauth/login, discarding the OAuth authorization request (client_id,
redirect_uri, state, scope, PKCE challenge, nonce) — which during MFA lives only
in the auth_mfa_pending row. That produced a confusing two-stage failure:

  1. The pending row is gone at OTP-submit time — it expired during code entry
     (5-min window), or a duplicate/replayed submit already consumed it — so the
     user is bounced back to the username/password page despite completing the
     full flow.
  2. The bare login has no client_id, so the next successful login is treated as
     a direct login and lands on the account-settings page instead of redirecting
     back to the originating app.

Fix: carry the OAuth parameters through the MFA page as hidden fields (sourced
from the pending row, which stays authoritative when present), and on a missing/
expired/replayed pending row resume the flow via /oauth/authorize instead of a
context-free login. Routing through authorize re-validates client_id/redirect_uri/
scope and transparently completes the flow when a session already exists (the
duplicate-submit case) or re-prompts login with context preserved otherwise.

The single-use pending row and 5-minute window are unchanged — the OTP gate is
not weakened; only the non-secret navigation context is preserved.

Also extract shared setSessionCookie / buildAuthorizeURL / redirectAfterAuth
helpers so the login and MFA success paths can't drift apart again.

Adds integration tests covering: the MFA page rendering the OAuth context,
an expired/missing pending row preserving context, and a duplicate submit not
dropping to the account page.