### PR TITLE
fix: image-updater allowTags in the CR (stop pinning :latest/:staging)

### DIFF
--- a/k8s/argocd/applications.yaml
+++ b/k8s/argocd/applications.yaml
@@ -6,9 +6,6 @@ metadata:
   annotations:
     argocd-image-updater.argoproj.io/image-list: identity=us-central1-docker.pkg.dev/ethans-services/containers/identity
     argocd-image-updater.argoproj.io/identity.update-strategy: newest-build
-    # Exclude the mutable `latest` tag so image-updater pins the immutable
-    # SHA tag instead of `:latest` (which it otherwise ties on by build time).
-    argocd-image-updater.argoproj.io/identity.allow-tags: "regexp:^[a-f0-9]{7,}$"
 spec:
   project: default
   source:

--- a/k8s/argocd/image-updater.yaml
+++ b/k8s/argocd/image-updater.yaml
@@ -14,3 +14,4 @@ spec:
           imageName: us-central1-docker.pkg.dev/ethans-services/containers/identity
           commonUpdateSettings:
             updateStrategy: newest-build
+            allowTags: "regexp:^[a-f0-9]{7,}$"


### PR DESCRIPTION
## Problem

Staging keeps showing `:latest` (plain taggers) / `:staging` (suffix taggers) instead of a SHA, so the bifrost dashboard reads it as "unknown" and image-updater never advances staging on new builds.

Root cause: this cluster runs the **CRD/controller** build of `argocd-image-updater` (v1.1.1) with `useAnnotations: false`, so it reads config **only** from the `ImageUpdater` CR. The `allow-tags` *annotation* we'd added to the Application was silently ignored — with no tag filter, `newest-build` considered the mutable tag (which aliases the newest image) and pinned it. The controller even logged the malformed-and-ignored filter:

```
level=warning msg="Invalid match option syntax '^[a-f0-9]{7,}$', ignoring"
```

(The CR's `allowTags` field also requires the `regexp:` prefix.)

## Fix

- Add `allowTags: "regexp:..."` to the `ImageUpdater` CR's `commonUpdateSettings`, where the controller actually reads it.
- Remove the now-dead `allow-tags` annotation (and its misleading comment) from the Application.

Verified on bifrost: with the filter in the **CR**, image-updater self-healed staging from `:latest` to the newest SHA with no manual pin.

**After merge:** apply the CR to the cluster — there's no app-of-apps, so merging alone doesn't update the live CR:
```
kubectl apply -f k8s/argocd/image-updater.yaml
```
image-updater then pins the newest SHA within ~2 minutes. Staging-only; prod is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
