### PR TITLE
Speed up Cloud Build via registry-backed caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,30 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 
+# Pre-compile the heavy dependencies so they land in the Go build cache in a
+# layer that only invalidates when go.mod/go.sum change. Env and flags must
+# match the final go build exactly, or the cache entries won't be reused.
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    github.com/aws/aws-sdk-go-v2/service/s3 \
+    github.com/aws/aws-sdk-go-v2/credentials \
+    github.com/jackc/pgx/v5/stdlib \
+    github.com/golang-migrate/migrate/v4 \
+    github.com/swaggo/swag \
+    github.com/swaggo/http-swagger \
+    github.com/disintegration/imaging \
+    github.com/golang-jwt/jwt/v5 \
+    github.com/go-chi/chi/v5 \
+    github.com/pquerna/otp/totp \
+    github.com/resend/resend-go/v2 \
+    github.com/spf13/cobra \
+    github.com/lib/pq \
+    golang.org/x/crypto/argon2
+
 # Copy source code
 COPY . .
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o auth-service ./cmd/auth-service
+RUN CGO_ENABLED=0 GOOS=linux go build -o auth-service ./cmd/auth-service
 
 # Runtime stage
 FROM alpine:latest

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,22 +1,20 @@
+steps:
+  # Build with BuildKit, persisting the layer cache (all stages, via mode=max)
+  # to a `buildcache` tag in Artifact Registry. Cloud Build workers are
+  # ephemeral, so without a registry-backed cache every build starts cold.
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        docker buildx create --use --driver docker-container
+        docker buildx build \
+          --cache-from type=registry,ref=us-central1-docker.pkg.dev/ethans-services/containers/identity:buildcache \
+          --cache-to type=registry,ref=us-central1-docker.pkg.dev/ethans-services/containers/identity:buildcache,mode=max \
+          -t us-central1-docker.pkg.dev/ethans-services/containers/identity:$SHORT_SHA \
+          -t us-central1-docker.pkg.dev/ethans-services/containers/identity:latest \
+          --push \
+          .
+
 options:
   logging: CLOUD_LOGGING_ONLY
-
-steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      - 'build'
-      - '-t'
-      - 'us-central1-docker.pkg.dev/ethans-services/containers/identity:$SHORT_SHA'
-      - '-t'
-      - 'us-central1-docker.pkg.dev/ethans-services/containers/identity:latest'
-      - '.'
-
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      - 'push'
-      - '--all-tags'
-      - 'us-central1-docker.pkg.dev/ethans-services/containers/identity'
-
-images:
-  - 'us-central1-docker.pkg.dev/ethans-services/containers/identity:$SHORT_SHA'
-  - 'us-central1-docker.pkg.dev/ethans-services/containers/identity:latest'


### PR DESCRIPTION
Applies the caching setup proven in bifrost (eswan18/bifrost#8, builds went ~2.5min → 58s):

- **Drop `-a -installsuffix cgo`** — obsolete flags; `-a` force-rebuilds everything and defeats caching.
- **Pre-compile heavy deps** (aws-sdk s3, pgx, migrate, swaggo, imaging, etc.) in a layer before `COPY . .`, so compiled artifacts are cached keyed only on `go.mod`/`go.sum`. Validated locally that the step compiles with only go.mod/go.sum present (235MB build cache).
- **buildx with registry cache** (`identity:buildcache`, `mode=max` so intermediate stages are cached). Image pushed by buildx directly, replacing the separate push step.

The `buildcache` tag doesn't match image-updater's `allowTags` SHA regexp, so staging auto-deploy is unaffected.

**The first build after merge runs cold** (it populates the cache) — judge by the second build. Expected steady state: ~2.4min → roughly 60s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)