### PR TITLE
identity-cli: add --add-redirect-uris; bring CLI source into version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 .env
 .env.*
 db/schema.sql
-identity
-identity-cli
-auth-service
+# Compiled binaries at the repo root (anchored: unanchored patterns would
+# also ignore source dirs like cmd/identity-cli/, which kept the CLI source
+# out of version control entirely until July 2026)
+/identity
+/identity-cli
+/auth-service
 
 # Generated CSS (built from Tailwind)
 static/style.css

--- a/cmd/identity-cli/cmd/client.go
+++ b/cmd/identity-cli/cmd/client.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/eswan18/identity/cmd/identity-cli/internal"
+	"github.com/eswan18/identity/pkg/store"
+	"github.com/spf13/cobra"
+)
+
+// datastore is shared across all client subcommands
+var datastore *store.Store
+
+var clientCmd = &cobra.Command{
+	Use:   "client",
+	Short: "Manage OAuth clients",
+	Long:  `Create, list, get, update, and delete OAuth clients.`,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		var err error
+		datastore, err = internal.GetDatastore()
+		if err != nil {
+			return fmt.Errorf("failed to connect to database: %w", err)
+		}
+		return nil
+	},
+	PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+		if datastore != nil {
+			return datastore.DB.Close()
+		}
+		return nil
+	},
+}
+
+// getDatastore returns the shared datastore instance
+func getDatastore() *store.Store {
+	return datastore
+}
+
+func init() {
+	clientCmd.AddCommand(clientCreateCmd)
+	clientCmd.AddCommand(clientListCmd)
+	clientCmd.AddCommand(clientGetCmd)
+	clientCmd.AddCommand(clientUpdateCmd)
+	clientCmd.AddCommand(clientDeleteCmd)
+}

--- a/cmd/identity-cli/cmd/client_create.go
+++ b/cmd/identity-cli/cmd/client_create.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/eswan18/identity/cmd/identity-cli/internal"
+	"github.com/eswan18/identity/pkg/db"
+	"github.com/spf13/cobra"
+)
+
+var (
+	createName           string
+	createRedirectURIs   string
+	createAllowedScopes  string
+	createIsConfidential bool
+	createAudience       string
+)
+
+var clientCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new OAuth client",
+	Long: `Create a new OAuth client in the identity service database.
+Generates a client_id and optionally a client_secret for confidential clients.`,
+	Example: `  # Register a public client (web app)
+  identity-client client create --name "My Web App" --redirect-uris "http://localhost:3000/callback" --scopes "openid,profile,email" --audience "https://myapp.com"
+
+  # Register a confidential client (backend service)
+  identity-client client create --name "My Backend" --redirect-uris "http://localhost:3000/callback" --scopes "openid" --confidential --audience "https://api.myapp.com"`,
+	RunE: runClientCreate,
+}
+
+func init() {
+	clientCreateCmd.Flags().StringVar(&createName, "name", "", "Client name (required)")
+	clientCreateCmd.Flags().StringVar(&createRedirectURIs, "redirect-uris", "", "Comma-separated list of redirect URIs (required)")
+	clientCreateCmd.Flags().StringVar(&createAllowedScopes, "scopes", "openid", "Comma-separated list of allowed scopes (default: openid)")
+	clientCreateCmd.Flags().BoolVar(&createIsConfidential, "confidential", false, "Whether the client is confidential (requires client_secret)")
+	clientCreateCmd.Flags().StringVar(&createAudience, "audience", "", "JWT audience claim for this client (required)")
+
+	clientCreateCmd.MarkFlagRequired("name")
+	clientCreateCmd.MarkFlagRequired("redirect-uris")
+	clientCreateCmd.MarkFlagRequired("audience")
+}
+
+func runClientCreate(cmd *cobra.Command, args []string) error {
+	// Parse comma-separated lists
+	redirectURIList := internal.ParseList(createRedirectURIs)
+	scopeList := internal.ParseList(createAllowedScopes)
+
+	// Get shared datastore
+	datastore := getDatastore()
+	if datastore == nil {
+		log.Fatal("Failed to get database connection")
+	}
+
+	// Generate client_id (random 32-byte string, base64 encoded = 44 chars)
+	clientID, err := internal.GenerateRandomString(32)
+	if err != nil {
+		log.Fatalf("Failed to generate client_id: %v", err)
+	}
+
+	// Generate client_secret if confidential
+	var clientSecret sql.NullString
+	if createIsConfidential {
+		secret, err := internal.GenerateRandomString(32)
+		if err != nil {
+			log.Fatalf("Failed to generate client_secret: %v", err)
+		}
+		clientSecret = sql.NullString{String: secret, Valid: true}
+	}
+
+	// Create the client
+	ctx := context.Background()
+	client, err := datastore.Q.CreateOAuthClient(ctx, db.CreateOAuthClientParams{
+		ClientID:       clientID,
+		ClientSecret:   clientSecret,
+		Name:           createName,
+		RedirectUris:   redirectURIList,
+		AllowedScopes:  scopeList,
+		IsConfidential: createIsConfidential,
+		Audience:       createAudience,
+	})
+	if err != nil {
+		log.Fatalf("Failed to create OAuth client: %v", err)
+	}
+
+	// Output credentials
+	fmt.Println("\n✅ OAuth client registered successfully!")
+	fmt.Println("\nClient Details:")
+	fmt.Printf("  Name:           %s\n", client.Name)
+	fmt.Printf("  Client ID:      %s\n", client.ClientID)
+	if client.ClientSecret.Valid {
+		fmt.Printf("  Client Secret:  %s\n", client.ClientSecret.String)
+		fmt.Println("\n⚠️  IMPORTANT: Save the client_secret now - it cannot be retrieved later!")
+	} else {
+		fmt.Println("  Client Secret:  (none - public client)")
+	}
+	fmt.Printf("  Redirect URIs:  %s\n", strings.Join(client.RedirectUris, ", "))
+	fmt.Printf("  Allowed Scopes: %s\n", strings.Join(client.AllowedScopes, ", "))
+	fmt.Printf("  Audience:       %s\n", client.Audience)
+	fmt.Printf("  Confidential:   %v\n", client.IsConfidential)
+	fmt.Printf("  Created:        %s\n", client.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/identity-cli/cmd/client_delete.go
+++ b/cmd/identity-cli/cmd/client_delete.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	deleteForce bool
+)
+
+var clientDeleteCmd = &cobra.Command{
+	Use:   "delete <client-id>",
+	Short: "Delete an OAuth client",
+	Long:  `Delete an OAuth client from the identity service database.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runClientDelete,
+	Example: `  # Delete a client (with confirmation)
+  identity-client client delete abc123
+
+  # Delete a client without confirmation
+  identity-client client delete abc123 --force`,
+}
+
+func init() {
+	clientDeleteCmd.Flags().BoolVar(&deleteForce, "force", false, "Skip confirmation prompt")
+}
+
+func runClientDelete(cmd *cobra.Command, args []string) error {
+	clientID := args[0]
+
+	datastore := getDatastore()
+	if datastore == nil {
+		log.Fatal("Failed to get database connection")
+	}
+
+	ctx := context.Background()
+
+	// Get client to show what we're deleting
+	client, err := datastore.Q.GetOAuthClientByClientID(ctx, clientID)
+	if err != nil {
+		log.Fatalf("Failed to get OAuth client: %v", err)
+	}
+
+	// Confirm deletion unless --force
+	if !deleteForce {
+		fmt.Printf("Are you sure you want to delete client '%s' (%s)? [y/N]: ", client.Name, clientID)
+		reader := bufio.NewReader(os.Stdin)
+		response, err := reader.ReadString('\n')
+		if err != nil {
+			log.Fatalf("Failed to read input: %v", err)
+		}
+		response = strings.TrimSpace(strings.ToLower(response))
+		if response != "y" && response != "yes" {
+			fmt.Println("Deletion cancelled.")
+			return nil
+		}
+	}
+
+	// Delete the client
+	err = datastore.Q.DeleteOAuthClient(ctx, clientID)
+	if err != nil {
+		log.Fatalf("Failed to delete OAuth client: %v", err)
+	}
+
+	fmt.Printf("\n✅ OAuth client '%s' (%s) deleted successfully!\n\n", client.Name, clientID)
+	return nil
+}

--- a/cmd/identity-cli/cmd/client_get.go
+++ b/cmd/identity-cli/cmd/client_get.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var clientGetCmd = &cobra.Command{
+	Use:   "get <client-id>",
+	Short: "Get details of an OAuth client",
+	Long:  `Get detailed information about a specific OAuth client by its client_id.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runClientGet,
+}
+
+func runClientGet(cmd *cobra.Command, args []string) error {
+	clientID := args[0]
+
+	datastore := getDatastore()
+	if datastore == nil {
+		log.Fatal("Failed to get database connection")
+	}
+
+	ctx := context.Background()
+	client, err := datastore.Q.GetOAuthClientByClientID(ctx, clientID)
+	if err != nil {
+		log.Fatalf("Failed to get OAuth client: %v", err)
+	}
+
+	fmt.Println("\nClient Details:")
+	fmt.Printf("  ID:             %s\n", client.ID)
+	fmt.Printf("  Client ID:      %s\n", client.ClientID)
+	fmt.Printf("  Name:           %s\n", client.Name)
+	if client.ClientSecret.Valid {
+		fmt.Println("  Client Secret:  (hidden - cannot be retrieved)")
+	} else {
+		fmt.Println("  Client Secret:  (none - public client)")
+	}
+	fmt.Printf("  Redirect URIs:  %s\n", strings.Join(client.RedirectUris, ", "))
+	fmt.Printf("  Allowed Scopes: %s\n", strings.Join(client.AllowedScopes, ", "))
+	fmt.Printf("  Audience:       %s\n", client.Audience)
+	fmt.Printf("  Confidential:   %v\n", client.IsConfidential)
+	fmt.Printf("  Created:        %s\n", client.CreatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Printf("  Updated:        %s\n", client.UpdatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/identity-cli/cmd/client_list.go
+++ b/cmd/identity-cli/cmd/client_list.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+var clientListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all OAuth clients",
+	Long:  `List all OAuth clients in the identity service database.`,
+	RunE:  runClientList,
+}
+
+func runClientList(cmd *cobra.Command, args []string) error {
+	datastore := getDatastore()
+	if datastore == nil {
+		log.Fatal("Failed to get database connection")
+	}
+
+	ctx := context.Background()
+	clients, err := datastore.Q.ListOAuthClients(ctx)
+	if err != nil {
+		log.Fatalf("Failed to list OAuth clients: %v", err)
+	}
+
+	if len(clients) == 0 {
+		fmt.Println("No OAuth clients found.")
+		return nil
+	}
+
+	// Print table
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "CLIENT ID\tNAME\tAUDIENCE\tCONFIDENTIAL\tCREATED")
+	fmt.Fprintln(w, "---------\t----\t--------\t------------\t-------")
+
+	for _, client := range clients {
+		confidential := "No"
+		if client.IsConfidential {
+			confidential = "Yes"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+			client.ClientID,
+			client.Name,
+			client.Audience,
+			confidential,
+			client.CreatedAt.Format("2006-01-02 15:04:05"),
+		)
+	}
+
+	w.Flush()
+	return nil
+}

--- a/cmd/identity-cli/cmd/client_update.go
+++ b/cmd/identity-cli/cmd/client_update.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/eswan18/identity/cmd/identity-cli/internal"
+	"github.com/eswan18/identity/pkg/db"
+	"github.com/spf13/cobra"
+)
+
+var (
+	updateName            string
+	updateRedirectURIs    string
+	updateAddRedirectURIs string
+	updateAllowedScopes   string
+	updateIsConfidential  bool
+	updateAudience        string
+)
+
+var clientUpdateCmd = &cobra.Command{
+	Use:   "update <client-id>",
+	Short: "Update an OAuth client",
+	Long: `Update an OAuth client. Only provided fields will be updated.
+Use --confidential=true or --confidential=false to change confidentiality status.
+--redirect-uris REPLACES the client's full redirect-URI list; use
+--add-redirect-uris to append to it instead (already-present URIs are skipped).`,
+	Args: cobra.ExactArgs(1),
+	RunE: runClientUpdate,
+	Example: `  # Update client name
+  identity-client client update abc123 --name "New Name"
+
+  # Replace the full redirect-URI list
+  identity-client client update abc123 --redirect-uris "https://example.com/callback"
+
+  # Append redirect URIs, keeping the existing ones
+  identity-client client update abc123 --add-redirect-uris "https://example.com/"
+
+  # Update multiple fields
+  identity-client client update abc123 --name "New Name" --scopes "openid,profile"`,
+}
+
+func init() {
+	clientUpdateCmd.Flags().StringVar(&updateName, "name", "", "Client name")
+	clientUpdateCmd.Flags().StringVar(&updateRedirectURIs, "redirect-uris", "", "Comma-separated list of redirect URIs (replaces the full list)")
+	clientUpdateCmd.Flags().StringVar(&updateAddRedirectURIs, "add-redirect-uris", "", "Comma-separated redirect URIs to append to the existing list")
+	clientUpdateCmd.Flags().StringVar(&updateAllowedScopes, "scopes", "", "Comma-separated list of allowed scopes")
+	clientUpdateCmd.Flags().BoolVar(&updateIsConfidential, "confidential", false, "Whether the client is confidential")
+	clientUpdateCmd.Flags().StringVar(&updateAudience, "audience", "", "JWT audience claim for this client")
+	clientUpdateCmd.MarkFlagsMutuallyExclusive("redirect-uris", "add-redirect-uris")
+}
+
+func runClientUpdate(cmd *cobra.Command, args []string) error {
+	clientID := args[0]
+
+	datastore := getDatastore()
+	if datastore == nil {
+		log.Fatal("Failed to get database connection")
+	}
+
+	ctx := context.Background()
+
+	// Get current client to preserve values
+	currentClient, err := datastore.Q.GetOAuthClientByClientID(ctx, clientID)
+	if err != nil {
+		log.Fatalf("Failed to get OAuth client: %v", err)
+	}
+
+	// Build update params - only include fields that were provided
+	params := db.UpdateOAuthClientParams{
+		ClientID: clientID,
+	}
+
+	// Check which flags were set
+	flags := cmd.Flags()
+	nameSet := flags.Changed("name")
+	redirectURIsSet := flags.Changed("redirect-uris")
+	addRedirectURIsSet := flags.Changed("add-redirect-uris")
+	scopesSet := flags.Changed("scopes")
+	confidentialSet := flags.Changed("confidential")
+	audienceSet := flags.Changed("audience")
+
+	if nameSet {
+		params.Name = sql.NullString{String: updateName, Valid: true}
+	} else {
+		params.Name = sql.NullString{String: currentClient.Name, Valid: true}
+	}
+
+	if redirectURIsSet {
+		params.RedirectUris = internal.ParseList(updateRedirectURIs)
+	} else if addRedirectURIsSet {
+		params.RedirectUris = internal.AppendUnique(
+			currentClient.RedirectUris, internal.ParseList(updateAddRedirectURIs),
+		)
+	} else {
+		params.RedirectUris = currentClient.RedirectUris
+	}
+
+	if scopesSet {
+		params.AllowedScopes = internal.ParseList(updateAllowedScopes)
+	} else {
+		params.AllowedScopes = currentClient.AllowedScopes
+	}
+
+	if confidentialSet {
+		params.IsConfidential = sql.NullBool{Bool: updateIsConfidential, Valid: true}
+	} else {
+		params.IsConfidential = sql.NullBool{Bool: currentClient.IsConfidential, Valid: true}
+	}
+
+	if audienceSet {
+		params.Audience = sql.NullString{String: updateAudience, Valid: true}
+	} else {
+		params.Audience = sql.NullString{String: currentClient.Audience, Valid: true}
+	}
+
+	// Validate: confidential clients must have secrets
+	if params.IsConfidential.Bool && !currentClient.ClientSecret.Valid {
+		// Note: We can't update the secret with the current UpdateOAuthClient query
+		// This would require a separate query or updating the SQL
+		log.Fatalf("Cannot make a public client confidential - secret generation not yet supported in update")
+	}
+
+	updatedClient, err := datastore.Q.UpdateOAuthClient(ctx, params)
+	if err != nil {
+		log.Fatalf("Failed to update OAuth client: %v", err)
+	}
+
+	fmt.Println("\n✅ OAuth client updated successfully!")
+	fmt.Println("\nUpdated Client Details:")
+	fmt.Printf("  Client ID:      %s\n", updatedClient.ClientID)
+	fmt.Printf("  Name:           %s\n", updatedClient.Name)
+	fmt.Printf("  Redirect URIs:  %s\n", strings.Join(updatedClient.RedirectUris, ", "))
+	fmt.Printf("  Allowed Scopes: %s\n", strings.Join(updatedClient.AllowedScopes, ", "))
+	fmt.Printf("  Audience:       %s\n", updatedClient.Audience)
+	fmt.Printf("  Confidential:   %v\n", updatedClient.IsConfidential)
+	fmt.Printf("  Updated:        %s\n", updatedClient.UpdatedAt.Format("2006-01-02 15:04:05"))
+	fmt.Println()
+
+	return nil
+}

--- a/cmd/identity-cli/cmd/root.go
+++ b/cmd/identity-cli/cmd/root.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "identity-cli",
+	Short: "Identity service CLI for managing OAuth clients and other resources",
+	Long: `Identity service CLI provides commands for managing OAuth clients,
+users, tokens, and other resources in the identity service database.`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+func Execute() error {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return err
+	}
+	return nil
+}
+
+func init() {
+	// Add client command
+	rootCmd.AddCommand(clientCmd)
+}

--- a/cmd/identity-cli/internal/common.go
+++ b/cmd/identity-cli/internal/common.go
@@ -1,0 +1,68 @@
+package internal
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/eswan18/identity/pkg/config"
+	"github.com/eswan18/identity/pkg/store"
+)
+
+// GetDatastore connects to the database and returns a store instance
+func GetDatastore() (*store.Store, error) {
+	cfg := config.NewFromEnv()
+	datastore, err := store.New(cfg.DatabaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to database: %w", err)
+	}
+	return datastore, nil
+}
+
+// AppendUnique returns existing with any additions not already present
+// appended, preserving order. Comparison is exact string equality — no URI
+// normalization — because consumers (e.g. the OIDC logout handler) match
+// these values exactly.
+func AppendUnique(existing, additions []string) []string {
+	result := make([]string, 0, len(existing)+len(additions))
+	seen := make(map[string]bool, len(existing)+len(additions))
+	for _, v := range existing {
+		result = append(result, v)
+		seen[v] = true
+	}
+	for _, v := range additions {
+		if !seen[v] {
+			result = append(result, v)
+			seen[v] = true
+		}
+	}
+	return result
+}
+
+// ParseList splits a comma-separated string and trims whitespace
+func ParseList(s string) []string {
+	if s == "" {
+		return []string{}
+	}
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// GenerateRandomString generates a cryptographically secure random string
+func GenerateRandomString(length int) (string, error) {
+	bytes := make([]byte, length)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(bytes), nil
+}

--- a/cmd/identity-cli/internal/common_test.go
+++ b/cmd/identity-cli/internal/common_test.go
@@ -1,0 +1,76 @@
+package internal
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAppendUnique(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  []string
+		additions []string
+		want      []string
+	}{
+		{
+			name:      "appends new values in order",
+			existing:  []string{"https://a.example/callback"},
+			additions: []string{"https://a.example/", "https://b.example/"},
+			want:      []string{"https://a.example/callback", "https://a.example/", "https://b.example/"},
+		},
+		{
+			name:      "skips values already present",
+			existing:  []string{"https://a.example/callback", "https://a.example/"},
+			additions: []string{"https://a.example/"},
+			want:      []string{"https://a.example/callback", "https://a.example/"},
+		},
+		{
+			name:      "skips duplicates within the additions themselves",
+			existing:  []string{},
+			additions: []string{"https://a.example/", "https://a.example/"},
+			want:      []string{"https://a.example/"},
+		},
+		{
+			name:      "no additions returns existing unchanged",
+			existing:  []string{"https://a.example/callback"},
+			additions: []string{},
+			want:      []string{"https://a.example/callback"},
+		},
+		{
+			// Trailing slashes are significant: the logout handler exact-matches
+			// post_logout_redirect_uri against this list.
+			name:      "treats trailing-slash variants as distinct",
+			existing:  []string{"https://a.example"},
+			additions: []string{"https://a.example/"},
+			want:      []string{"https://a.example", "https://a.example/"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AppendUnique(tt.existing, tt.additions)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("AppendUnique(%v, %v) = %v, want %v", tt.existing, tt.additions, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseList(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty string", "", []string{}},
+		{"single value", "a", []string{"a"}},
+		{"trims whitespace and drops empties", " a , , b ", []string{"a", "b"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseList(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseList(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/identity-cli/main.go
+++ b/cmd/identity-cli/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"os"
+
+	"github.com/eswan18/identity/cmd/identity-cli/cmd"
+)
+
+func main() {
+	if err := cmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
Two things, one root cause discovered along the way:

1. **`client update --add-redirect-uris`** — appends URIs to a client's existing list (deduped, exact string comparison — consumers like the OIDC logout handler match exactly). Mutually exclusive with the replace-style `--redirect-uris`, whose help now warns it replaces the full list. Core logic is `internal.AppendUnique`, tested (first tests for this package, ParseList included).

2. **The entire `cmd/identity-cli/` source was never in version control.** The unanchored `identity-cli` gitignore pattern (meant for the compiled binary) also matched the source directory, so the CLI existed only on one machine. The binary patterns are now root-anchored (`/identity`, `/identity-cli`, `/auth-service` — the last escaped the same fate only because it was tracked before the ignore line existed), and this PR adds the full CLI source for the first time.

Verified: gofmt clean, `go vet ./...` clean, `go test ./...` green, `go build ./...` green. The new flag has already been used successfully against both identity DBs (registering the dashboard's post-logout redirect URIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)