### PR TITLE
Fix: enforce authorize-time validation in consent endpoint

### DIFF
--- a/pkg/httpserver/authorize_params_test.go
+++ b/pkg/httpserver/authorize_params_test.go
@@ -1,0 +1,93 @@
+package httpserver
+
+import (
+	"testing"
+
+	"github.com/eswan18/identity/pkg/db"
+)
+
+// TestValidateAuthorizeParams exercises the shared validation used by both the
+// authorize and consent endpoints. The consent endpoint previously skipped these
+// checks, allowing a direct POST to /oauth/consent to obtain a PKCE-less
+// authorization code with arbitrary scopes. These cases assert that consent and
+// authorize now enforce identical rules.
+func TestValidateAuthorizeParams(t *testing.T) {
+	allowed := []string{"openid", "profile", "email"}
+
+	tests := []struct {
+		name                string
+		responseType        string
+		codeChallenge       string
+		codeChallengeMethod string
+		scope               []string
+		wantErrCode         string // "" means expect no error
+	}{
+		{
+			name:                "valid request",
+			responseType:        "code",
+			codeChallenge:       "abc123",
+			codeChallengeMethod: "S256",
+			scope:               []string{"openid", "profile"},
+			wantErrCode:         "",
+		},
+		{
+			name:                "unsupported response type",
+			responseType:        "token",
+			codeChallenge:       "abc123",
+			codeChallengeMethod: "S256",
+			scope:               []string{"openid"},
+			wantErrCode:         "unsupported_response_type",
+		},
+		{
+			name:                "missing code challenge (PKCE required)",
+			responseType:        "code",
+			codeChallenge:       "",
+			codeChallengeMethod: "",
+			scope:               []string{"openid"},
+			wantErrCode:         "invalid_request",
+		},
+		{
+			name:                "missing code challenge method",
+			responseType:        "code",
+			codeChallenge:       "abc123",
+			codeChallengeMethod: "",
+			scope:               []string{"openid"},
+			wantErrCode:         "invalid_request",
+		},
+		{
+			name:                "non-S256 challenge method rejected",
+			responseType:        "code",
+			codeChallenge:       "abc123",
+			codeChallengeMethod: "plain",
+			scope:               []string{"openid"},
+			wantErrCode:         "invalid_request",
+		},
+		{
+			name:                "scope not allowed for client",
+			responseType:        "code",
+			codeChallenge:       "abc123",
+			codeChallengeMethod: "S256",
+			scope:               []string{"openid", "admin"},
+			wantErrCode:         "invalid_scope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := db.OauthClient{AllowedScopes: allowed}
+			got := validateAuthorizeParams(client, tt.responseType, tt.codeChallenge, tt.codeChallengeMethod, tt.scope)
+			if tt.wantErrCode == "" {
+				if got != nil {
+					t.Fatalf("expected no error, got %q (%s)", got.Code, got.Description)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected error %q, got nil", tt.wantErrCode)
+			}
+			if got.Code != tt.wantErrCode {
+				t.Errorf("expected error code %q, got %q (%s)", tt.wantErrCode, got.Code, got.Description)
+			}
+		})
+	}
+}

--- a/pkg/httpserver/oauth.go
+++ b/pkg/httpserver/oauth.go
@@ -88,22 +88,10 @@ func (s *Server) HandleOauthAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Phase 2: Validate remaining parameters. These errors are redirected to the client.
-	if responseType != "code" {
-		redirectError("unsupported_response_type", "Only 'code' response type is supported")
-		return
-	}
-	if codeChallenge == "" || codeChallengeMethod == "" {
-		redirectError("invalid_request", "Code challenge and code challenge method are required")
-		return
-	}
-	if codeChallengeMethod != "S256" {
-		redirectError("invalid_request", "Code challenge method must be S256")
-		return
-	}
-
-	// Validate scopes against client's allowed scopes
-	if scopesAllowed, invalidScopes := containsAll(client.AllowedScopes, scope); !scopesAllowed {
-		redirectError("invalid_scope", fmt.Sprintf("Scopes %v not allowed for this client", invalidScopes))
+	// The consent endpoint (HandleConsentPost) applies the exact same checks via
+	// validateAuthorizeParams so the two code-minting paths cannot drift.
+	if authErr := validateAuthorizeParams(client, responseType, codeChallenge, codeChallengeMethod, scope); authErr != nil {
+		redirectError(authErr.Code, authErr.Description)
 		return
 	}
 
@@ -843,6 +831,37 @@ func (s *Server) HandleOIDCDiscovery(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(discovery)
 }
 
+// oauthAuthorizeError describes an OAuth error that should be redirected back to
+// the client's redirect_uri per RFC 6749 4.1.2.1.
+type oauthAuthorizeError struct {
+	Code        string
+	Description string
+}
+
+// validateAuthorizeParams performs the parameter validation shared by the
+// authorize (HandleOauthAuthorize) and consent (HandleConsentPost) endpoints.
+// Both endpoints can mint an authorization code, so they must enforce the same
+// rules to prevent a validation bypass: response_type must be "code", PKCE
+// (code_challenge + S256) is mandatory, and requested scopes must be a subset of
+// the client's allowed scopes. Callers must have already validated client_id and
+// redirect_uri (so that returned errors can be safely redirected to the client).
+// Returns nil when the parameters are valid, otherwise the first failure.
+func validateAuthorizeParams(client db.OauthClient, responseType, codeChallenge, codeChallengeMethod string, scope []string) *oauthAuthorizeError {
+	if responseType != "code" {
+		return &oauthAuthorizeError{"unsupported_response_type", "Only 'code' response type is supported"}
+	}
+	if codeChallenge == "" || codeChallengeMethod == "" {
+		return &oauthAuthorizeError{"invalid_request", "Code challenge and code challenge method are required"}
+	}
+	if codeChallengeMethod != "S256" {
+		return &oauthAuthorizeError{"invalid_request", "Code challenge method must be S256"}
+	}
+	if scopesAllowed, invalidScopes := containsAll(client.AllowedScopes, scope); !scopesAllowed {
+		return &oauthAuthorizeError{"invalid_scope", fmt.Sprintf("Scopes %v not allowed for this client", invalidScopes)}
+	}
+	return nil
+}
+
 // scopesCovered returns true if all requested scopes are present in the stored scopes.
 func scopesCovered(storedScopes, requestedScopes []string) bool {
 	for _, s := range requestedScopes {
@@ -954,6 +973,16 @@ func (s *Server) HandleConsentPost(w http.ResponseWriter, r *http.Request) {
 		q.Set("state", state)
 		redirectURL.RawQuery = q.Encode()
 		http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+	}
+
+	// Enforce the same parameter validation as the authorize endpoint before we
+	// store consent or mint an authorization code. Without this, a user could POST
+	// directly to /oauth/consent to obtain a PKCE-less code with arbitrary scopes,
+	// bypassing the checks in HandleOauthAuthorize (validation-bypass vulnerability).
+	responseType := r.FormValue("response_type")
+	if authErr := validateAuthorizeParams(client, responseType, codeChallenge, codeChallengeMethod, scope); authErr != nil {
+		redirectError(authErr.Code, authErr.Description)
+		return
 	}
 
 	if decision == "deny" {


### PR DESCRIPTION
## Vulnerability

`HandleConsentPost` in `pkg/httpserver/oauth.go` minted an OAuth authorization code directly from POSTed form values **without** re-running the parameter validation that `HandleOauthAuthorize` performs. Specifically it did not:

- validate that requested `scope` values are a subset of the client's `AllowedScopes`
- require a `code_challenge` with method `S256` (PKCE)
- validate `response_type`

Because the token endpoint only enforces PKCE conditionally (`if authCode.CodeChallenge.Valid`), a user could POST directly to `/oauth/consent` and obtain a **PKCE-less authorization code with arbitrary scopes**, bypassing every check in the authorize endpoint. This is a real, exploitable validation bypass.

## Fix

The parameter validation shared by the authorize and consent endpoints is extracted into a single helper, `validateAuthorizeParams(client, responseType, codeChallenge, codeChallengeMethod, scope)`, which enforces:

1. `response_type` must be `code` → `unsupported_response_type`
2. `code_challenge` and `code_challenge_method` must both be present → `invalid_request`
3. `code_challenge_method` must be `S256` → `invalid_request`
4. requested scopes must be a subset of `client.AllowedScopes` → `invalid_scope`

Both `HandleOauthAuthorize` and `HandleConsentPost` now call this helper after validating `client_id`/`redirect_uri`, so the two code-minting paths **cannot drift again**. The helper returns the first failure as an OAuth error code + description; the consent handler redirects it back to the validated `redirect_uri` with `error`/`error_description`/`state`, exactly matching the authorize endpoint's existing error style. The checks mirror authorize precisely (PKCE with S256 is mandatory) — no stricter, no looser.

The consent HTML form already submits `response_type`, `code_challenge`, `code_challenge_method`, `scope`, and `nonce` as hidden fields, so legitimate consent flows (which reach consent via the authorize redirect that already passed validation) continue to work unchanged.

## Testing

- Added `pkg/httpserver/authorize_params_test.go` — a non-integration, DB-free table test for `validateAuthorizeParams` covering the valid case plus the response_type, missing-PKCE, non-S256, and disallowed-scope rejections.
- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` (non-integration) — passes

Integration tests (which require Postgres, `//go:build integration`) were not run per the constraints of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE