### PR TITLE
Fix: reject revoked access tokens at UserInfo endpoint

### DIFF
--- a/pkg/httpserver/oauth.go
+++ b/pkg/httpserver/oauth.go
@@ -479,9 +479,16 @@ func (s *Server) HandleOauthUserInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Check if token has been revoked by looking up the JTI
+	// Check if the token has been revoked by looking up its JTI. Every access
+	// token this server issues (see generateTokens/generateServiceAccountTokens
+	// in credentials.go) gets a corresponding row inserted into oauth_tokens at
+	// issuance time, and GetTokenByAccessToken's query already filters out rows
+	// where revoked_at IS NOT NULL or expires_at has passed. So sql.ErrNoRows
+	// here means the token was revoked (or has expired at the DB level), not
+	// that revocation tracking is unavailable - it must be rejected, mirroring
+	// introspectAccessToken's handling of the same lookup.
 	if claims.ID != "" {
-		token, err := s.datastore.Q.GetTokenByAccessToken(r.Context(), sql.NullString{String: claims.ID, Valid: true})
+		_, err := s.datastore.Q.GetTokenByAccessToken(r.Context(), sql.NullString{String: claims.ID, Valid: true})
 		if err != nil {
 			if !errors.Is(err, sql.ErrNoRows) {
 				// Database error (not "not found") - fail closed for security
@@ -493,9 +500,7 @@ func (s *Server) HandleOauthUserInfo(w http.ResponseWriter, r *http.Request) {
 				})
 				return
 			}
-			// Token not found in DB - that's okay, JWT is still valid
-			// This can happen if revocation tracking is not enabled
-		} else if token.RevokedAt.Valid {
+			// No matching, non-revoked, non-expired row - the token is invalid.
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusUnauthorized)
 			json.NewEncoder(w).Encode(map[string]string{

--- a/pkg/httpserver/oidc_test.go
+++ b/pkg/httpserver/oidc_test.go
@@ -677,6 +677,77 @@ func (s *OAuthFlowSuite) TestUserInfoScopeGating() {
 	s.NotContains(userInfo, "picture", "picture should not be present without profile scope")
 }
 
+// TestUserInfoRejectsRevokedToken verifies that a revoked access token is
+// rejected at the UserInfo endpoint with 401 invalid_token, consistent with
+// the introspection endpoint's handling of revoked tokens. This guards
+// against a regression of the vulnerability where UserInfo treated a
+// missing/revoked JTI row as "revocation tracking not enabled" and let the
+// request through.
+func (s *OAuthFlowSuite) TestUserInfoRejectsRevokedToken() {
+	// Confidential client used to call the revoke endpoint (RFC 7009 requires
+	// client authentication for revocation).
+	clientSecret := s.mustGenerateRandomString(32)
+	revokeClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: clientSecret, Valid: true},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: true,
+		Audience:       "http://localhost:8000",
+	})
+
+	// Complete OAuth flow to get an access token.
+	result := s.mustCompleteOAuthFlow(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: "", Valid: false},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: false,
+		Audience:       "http://localhost:8000",
+	})
+	accessToken := result.TokenResponse.AccessToken
+	s.Require().NotEmpty(accessToken)
+
+	// Sanity check: userinfo works before revocation.
+	req, err := http.NewRequest("GET", "http://localhost:8080/oauth/userinfo", nil)
+	s.Require().NoError(err)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err := s.httpClient.Do(req)
+	s.Require().NoError(err)
+	resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode, "userinfo should succeed before revocation")
+
+	// Revoke the access token.
+	revokeValues := url.Values{
+		"token":           {accessToken},
+		"token_type_hint": {"access_token"},
+		"client_id":       {revokeClient.ClientID},
+		"client_secret":   {clientSecret},
+	}
+	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/revoke", revokeValues)
+	s.Require().NoError(err)
+	resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	// UserInfo must now reject the revoked token.
+	req, err = http.NewRequest("GET", "http://localhost:8080/oauth/userinfo", nil)
+	s.Require().NoError(err)
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	resp, err = s.httpClient.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusUnauthorized, resp.StatusCode, "userinfo should reject a revoked access token")
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	var errResponse map[string]string
+	err = json.Unmarshal(body, &errResponse)
+	s.Require().NoError(err)
+	s.Equal("invalid_token", errResponse["error"])
+}
+
 // TestUserInfoEmailScopeOnly verifies that requesting "openid email" returns
 // email claims but not profile claims.
 func (s *OAuthFlowSuite) TestUserInfoEmailScopeOnly() {


### PR DESCRIPTION
## Vulnerability

`HandleOauthUserInfo` (pkg/httpserver/oauth.go) validated the JWT itself, then looked up the token's JTI via `GetTokenByAccessToken` to check for revocation. `GetTokenByAccessToken`'s query (db/queries/auth.sql) filters `WHERE access_token = $1 AND revoked_at IS NULL AND expires_at > now()`, so a revoked token's lookup returns `sql.ErrNoRows` — it never returns a row with `RevokedAt.Valid == true`.

The handler treated `ErrNoRows` as "token not tracked in DB, JWT is still valid" and let the request through, with a comment claiming "this can happen if revocation tracking is not enabled." That made the `else if token.RevokedAt.Valid` branch unreachable dead code, and meant a revoked access token could still be used to fetch user identity claims from `/oauth/userinfo` until its JWT `exp` passed — defeating revocation entirely for this endpoint.

## The ErrNoRows judgment call

I verified whether every issued access token actually gets a DB row before deciding how to treat `ErrNoRows`:

- `generateTokens` and `generateServiceAccountTokens` (pkg/httpserver/credentials.go) are the only two paths that mint access tokens, and both always generate a JTI (`uuid.New().String()` in `pkg/jwt/jwt.go`) and always call `InsertToken` with it, storing the JTI in `access_token` (not the full JWT) — there's no code path that issues a JWT with a JTI but skips the DB insert.
- `pkg/httpserver/admin_middleware.go`'s `AdminAuthMiddleware` already does the correct thing for the same lookup: it treats `sql.ErrNoRows` as "revoked or invalid" and rejects with 401.
- `introspectAccessToken` (oauth.go) does the same: `ErrNoRows` → `active: false`.

So "revocation tracking not enabled" isn't a real scenario for this codebase — every valid access token has a corresponding row unless it's been revoked or its DB-side expiry has passed. That means `ErrNoRows` at UserInfo should be treated as "invalid token" and rejected, exactly like introspection and the admin middleware already do. Rejecting all `ErrNoRows` cases does not risk breaking any legitimately-untracked valid token, because no such token exists in this system.

## The fix

In `HandleOauthUserInfo`, when `claims.ID != ""`:
- Non-`ErrNoRows` DB errors still fail closed with a 500 `server_error` (unchanged).
- `ErrNoRows` now returns 401 `invalid_token` / "Token has been revoked" instead of silently continuing.
- The dead `else if token.RevokedAt.Valid` branch is removed since the query can never return such a row (it's filtered out in SQL), and the returned token value is no longer needed.

This makes UserInfo's revocation handling consistent with `introspectAccessToken` and `AdminAuthMiddleware`.

## Testing

- Added `TestUserInfoRejectsRevokedToken` in `pkg/httpserver/oidc_test.go` (integration-tagged, uses the existing `OAuthFlowSuite` harness): completes an OAuth flow, confirms `/oauth/userinfo` succeeds, revokes the access token via `/oauth/revoke`, then confirms `/oauth/userinfo` now returns 401 `invalid_token`.
- `go build ./...`, `go vet ./...`, and `go test ./...` all pass.
- `go build -tags integration ./...` and `go vet -tags integration ./...` also pass (integration tests need Postgres, which isn't available in this environment, so they weren't run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE