### PR TITLE
Fix: key rate limiter on real peer IP to prevent header spoofing

### DIFF
--- a/pkg/httpserver/ratelimit.go
+++ b/pkg/httpserver/ratelimit.go
@@ -86,24 +86,24 @@ func (r *rateLimitStore) getLimiter(ip string, requestsPerMinute int) *rate.Limi
 	return entry.limiter
 }
 
-// getClientIP extracts the client IP address from the request
+// getClientIP extracts the client IP address from the request.
+//
+// SECURITY: This intentionally ignores client-supplied headers such as
+// X-Forwarded-For and X-Real-IP. Those headers are fully controlled by the
+// client and, if trusted, let an attacker get a fresh rate-limit bucket on
+// every request simply by sending a different (fabricated) value each time
+// - defeating the rate limiter entirely. Instead we key on r.RemoteAddr,
+// which is the actual TCP peer address and cannot be spoofed by the client.
+//
+// Tradeoff: if this service sits behind a reverse proxy/load balancer that
+// doesn't preserve the original client IP, RemoteAddr will be the proxy's
+// address and all proxied traffic will share a single rate-limit bucket.
+// That's an availability/precision tradeoff, not a security one - it's
+// strictly safer than trusting spoofable headers. If a trusted proxy is
+// introduced in front of this service, this function (and the removed
+// middleware.RealIP in server.go) should be revisited to derive the real
+// client IP from a header that the trusted proxy guarantees to set/sanitize.
 func getClientIP(r *http.Request) string {
-	// Check X-Forwarded-For header (set by proxies/load balancers)
-	// Take the first IP if there are multiple (comma-separated)
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		// X-Forwarded-For can contain multiple IPs, take the first one
-		for i, char := range xff {
-			if char == ',' {
-				return xff[:i]
-			}
-		}
-		return xff
-	}
-	// Check X-Real-IP header
-	if xri := r.Header.Get("X-Real-IP"); xri != "" {
-		return xri
-	}
-	// Fall back to RemoteAddr
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return r.RemoteAddr

--- a/pkg/httpserver/ratelimit.go
+++ b/pkg/httpserver/ratelimit.go
@@ -88,22 +88,34 @@ func (r *rateLimitStore) getLimiter(ip string, requestsPerMinute int) *rate.Limi
 
 // getClientIP extracts the client IP address from the request.
 //
-// SECURITY: This intentionally ignores client-supplied headers such as
-// X-Forwarded-For and X-Real-IP. Those headers are fully controlled by the
-// client and, if trusted, let an attacker get a fresh rate-limit bucket on
-// every request simply by sending a different (fabricated) value each time
-// - defeating the rate limiter entirely. Instead we key on r.RemoteAddr,
-// which is the actual TCP peer address and cannot be spoofed by the client.
+// SECURITY: The only header this trusts is CF-Connecting-IP, and only
+// because of how this service is deployed: the k8s Service is ClusterIP
+// (not directly reachable from the internet) and production traffic arrives
+// exclusively via a Cloudflare Tunnel (see k8s/README.md). Cloudflare sets
+// CF-Connecting-IP to the real client IP and OVERWRITES any value the
+// client supplies, so an external attacker cannot forge it as long as the
+// origin is reachable only through Cloudflare. If that assumption ever
+// changes - e.g. the service is exposed via a LoadBalancer/NodePort, a
+// non-Cloudflare ingress, or any other path that bypasses the tunnel - this
+// header becomes client-controlled and MUST stop being trusted here.
 //
-// Tradeoff: if this service sits behind a reverse proxy/load balancer that
-// doesn't preserve the original client IP, RemoteAddr will be the proxy's
-// address and all proxied traffic will share a single rate-limit bucket.
-// That's an availability/precision tradeoff, not a security one - it's
-// strictly safer than trusting spoofable headers. If a trusted proxy is
-// introduced in front of this service, this function (and the removed
-// middleware.RealIP in server.go) should be revisited to derive the real
-// client IP from a header that the trusted proxy guarantees to set/sanitize.
+// X-Forwarded-For and X-Real-IP are deliberately NOT trusted: on any direct
+// connection they are fully client-controlled, and trusting them lets an
+// attacker mint a fresh rate-limit bucket per request by sending a
+// different fabricated value each time, defeating the limiter entirely.
+// (For the same reason, chi's middleware.RealIP is not installed in
+// server.go.)
+//
+// When CF-Connecting-IP is absent or not a valid IP (local dev, staging via
+// the Tailscale ingress, in-cluster requests), we fall back to the host
+// portion of r.RemoteAddr - the actual TCP peer address, which cannot be
+// spoofed.
 func getClientIP(r *http.Request) string {
+	if cfIP := r.Header.Get("CF-Connecting-IP"); cfIP != "" {
+		if parsed := net.ParseIP(cfIP); parsed != nil {
+			return parsed.String()
+		}
+	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		return r.RemoteAddr

--- a/pkg/httpserver/ratelimit_test.go
+++ b/pkg/httpserver/ratelimit_test.go
@@ -1,0 +1,114 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGetClientIP_IgnoresSpoofableHeaders verifies that getClientIP keys
+// exclusively on the real transport peer address (RemoteAddr) and does not
+// trust client-supplied X-Forwarded-For / X-Real-IP headers. If it did trust
+// them, an attacker could send a different fabricated value on every request
+// and get a brand new rate-limit bucket each time, defeating rate limiting.
+func TestGetClientIP_IgnoresSpoofableHeaders(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		headers    map[string]string
+		want       string
+	}{
+		{
+			name:       "no headers, uses RemoteAddr host",
+			remoteAddr: "203.0.113.10:54321",
+			want:       "203.0.113.10",
+		},
+		{
+			name:       "spoofed X-Forwarded-For is ignored",
+			remoteAddr: "203.0.113.10:54321",
+			headers:    map[string]string{"X-Forwarded-For": "1.2.3.4"},
+			want:       "203.0.113.10",
+		},
+		{
+			name:       "spoofed X-Forwarded-For with multiple values is ignored",
+			remoteAddr: "203.0.113.10:54321",
+			headers:    map[string]string{"X-Forwarded-For": "9.9.9.9, 8.8.8.8"},
+			want:       "203.0.113.10",
+		},
+		{
+			name:       "spoofed X-Real-IP is ignored",
+			remoteAddr: "203.0.113.10:54321",
+			headers:    map[string]string{"X-Real-IP": "6.6.6.6"},
+			want:       "203.0.113.10",
+		},
+		{
+			name:       "RemoteAddr without a port is returned as-is",
+			remoteAddr: "203.0.113.10",
+			want:       "203.0.113.10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			for k, v := range tt.headers {
+				req.Header.Set(k, v)
+			}
+
+			got := getClientIP(req)
+			if got != tt.want {
+				t.Errorf("getClientIP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRateLimitMiddleware_SpoofedHeadersShareLimiter verifies the end-to-end
+// behavior of rateLimitMiddleware: two requests from the same transport peer
+// (same RemoteAddr) but with different, attacker-controlled X-Forwarded-For
+// values must share the same rate limiter bucket rather than each getting a
+// fresh one. This is the regression test for the IP-spoofing rate-limit
+// bypass.
+func TestRateLimitMiddleware_SpoofedHeadersShareLimiter(t *testing.T) {
+	store := newRateLimitStore()
+	defer store.Stop()
+
+	// Only allow 1 request per minute so the second request from the same
+	// peer is guaranteed to be blocked if (and only if) spoofed headers are
+	// correctly ignored.
+	handler := rateLimitMiddleware(store, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	makeRequest := func(spoofedXFF string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		req.RemoteAddr = "203.0.113.10:11111"
+		req.Header.Set("X-Forwarded-For", spoofedXFF)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec
+	}
+
+	first := makeRequest("1.1.1.1")
+	if first.Code != http.StatusOK {
+		t.Fatalf("first request: got status %d, want %d", first.Code, http.StatusOK)
+	}
+
+	// Same RemoteAddr, but a completely different spoofed X-Forwarded-For.
+	// Prior to the fix, this would have been treated as a brand new client
+	// and allowed through with a fresh limiter.
+	second := makeRequest("9.9.9.9")
+	if second.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request (spoofed XFF, same RemoteAddr): got status %d, want %d (rate limit should apply)", second.Code, http.StatusTooManyRequests)
+	}
+
+	// Sanity check: only one limiter bucket should have been created, keyed
+	// on RemoteAddr rather than the spoofed header.
+	store.mu.RLock()
+	numLimiters := len(store.limiters)
+	store.mu.RUnlock()
+	if numLimiters != 1 {
+		t.Errorf("expected exactly 1 rate limiter bucket, got %d", numLimiters)
+	}
+}

--- a/pkg/httpserver/ratelimit_test.go
+++ b/pkg/httpserver/ratelimit_test.go
@@ -6,12 +6,16 @@ import (
 	"testing"
 )
 
-// TestGetClientIP_IgnoresSpoofableHeaders verifies that getClientIP keys
-// exclusively on the real transport peer address (RemoteAddr) and does not
-// trust client-supplied X-Forwarded-For / X-Real-IP headers. If it did trust
-// them, an attacker could send a different fabricated value on every request
-// and get a brand new rate-limit bucket each time, defeating rate limiting.
-func TestGetClientIP_IgnoresSpoofableHeaders(t *testing.T) {
+// TestGetClientIP verifies the trust model of getClientIP:
+//   - CF-Connecting-IP is trusted when present and valid, because the origin
+//     is only reachable through the Cloudflare Tunnel and Cloudflare
+//     overwrites any client-supplied value.
+//   - X-Forwarded-For and X-Real-IP are never trusted; they are fully
+//     client-controlled. If they were trusted, an attacker could send a
+//     different fabricated value on every request and get a brand new
+//     rate-limit bucket each time, defeating rate limiting.
+//   - Absent/invalid CF-Connecting-IP falls back to the RemoteAddr host.
+func TestGetClientIP(t *testing.T) {
 	tests := []struct {
 		name       string
 		remoteAddr string
@@ -21,6 +25,24 @@ func TestGetClientIP_IgnoresSpoofableHeaders(t *testing.T) {
 		{
 			name:       "no headers, uses RemoteAddr host",
 			remoteAddr: "203.0.113.10:54321",
+			want:       "203.0.113.10",
+		},
+		{
+			name:       "valid CF-Connecting-IP is trusted",
+			remoteAddr: "10.0.0.5:54321", // e.g. the cloudflared connector pod
+			headers:    map[string]string{"CF-Connecting-IP": "198.51.100.7"},
+			want:       "198.51.100.7",
+		},
+		{
+			name:       "valid IPv6 CF-Connecting-IP is trusted",
+			remoteAddr: "10.0.0.5:54321",
+			headers:    map[string]string{"CF-Connecting-IP": "2001:db8::1"},
+			want:       "2001:db8::1",
+		},
+		{
+			name:       "invalid CF-Connecting-IP falls back to RemoteAddr",
+			remoteAddr: "203.0.113.10:54321",
+			headers:    map[string]string{"CF-Connecting-IP": "not-an-ip"},
 			want:       "203.0.113.10",
 		},
 		{
@@ -40,6 +62,16 @@ func TestGetClientIP_IgnoresSpoofableHeaders(t *testing.T) {
 			remoteAddr: "203.0.113.10:54321",
 			headers:    map[string]string{"X-Real-IP": "6.6.6.6"},
 			want:       "203.0.113.10",
+		},
+		{
+			name:       "CF-Connecting-IP wins over spoofed XFF and X-Real-IP",
+			remoteAddr: "10.0.0.5:54321",
+			headers: map[string]string{
+				"CF-Connecting-IP": "198.51.100.7",
+				"X-Forwarded-For":  "1.2.3.4",
+				"X-Real-IP":        "6.6.6.6",
+			},
+			want: "198.51.100.7",
 		},
 		{
 			name:       "RemoteAddr without a port is returned as-is",
@@ -64,51 +96,83 @@ func TestGetClientIP_IgnoresSpoofableHeaders(t *testing.T) {
 	}
 }
 
-// TestRateLimitMiddleware_SpoofedHeadersShareLimiter verifies the end-to-end
-// behavior of rateLimitMiddleware: two requests from the same transport peer
-// (same RemoteAddr) but with different, attacker-controlled X-Forwarded-For
-// values must share the same rate limiter bucket rather than each getting a
-// fresh one. This is the regression test for the IP-spoofing rate-limit
-// bypass.
-func TestRateLimitMiddleware_SpoofedHeadersShareLimiter(t *testing.T) {
+// rateLimitTestHandler builds a rateLimitMiddleware-wrapped handler that
+// allows only 1 request per minute, so a second request sharing the same
+// limiter bucket is guaranteed to be rejected.
+func rateLimitTestHandler(t *testing.T) (http.Handler, *rateLimitStore) {
+	t.Helper()
 	store := newRateLimitStore()
-	defer store.Stop()
-
-	// Only allow 1 request per minute so the second request from the same
-	// peer is guaranteed to be blocked if (and only if) spoofed headers are
-	// correctly ignored.
+	t.Cleanup(store.Stop)
 	handler := rateLimitMiddleware(store, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
+	return handler, store
+}
 
-	makeRequest := func(spoofedXFF string) *httptest.ResponseRecorder {
-		req := httptest.NewRequest(http.MethodGet, "/", nil)
-		req.RemoteAddr = "203.0.113.10:11111"
-		req.Header.Set("X-Forwarded-For", spoofedXFF)
-		rec := httptest.NewRecorder()
-		handler.ServeHTTP(rec, req)
-		return rec
+func doRateLimitedRequest(handler http.Handler, remoteAddr string, headers map[string]string) int {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.RemoteAddr = remoteAddr
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec.Code
+}
+
+// TestRateLimitMiddleware_SpoofedXFFSharesLimiter is the regression test for
+// the IP-spoofing rate-limit bypass: two requests from the same transport
+// peer (same RemoteAddr) with different, attacker-controlled X-Forwarded-For
+// values must share one limiter bucket rather than each getting a fresh one.
+func TestRateLimitMiddleware_SpoofedXFFSharesLimiter(t *testing.T) {
+	handler, store := rateLimitTestHandler(t)
+
+	if code := doRateLimitedRequest(handler, "203.0.113.10:11111", map[string]string{"X-Forwarded-For": "1.1.1.1"}); code != http.StatusOK {
+		t.Fatalf("first request: got status %d, want %d", code, http.StatusOK)
 	}
 
-	first := makeRequest("1.1.1.1")
-	if first.Code != http.StatusOK {
-		t.Fatalf("first request: got status %d, want %d", first.Code, http.StatusOK)
+	// Same RemoteAddr, completely different spoofed X-Forwarded-For. Prior
+	// to the fix this was treated as a brand new client with a fresh bucket.
+	if code := doRateLimitedRequest(handler, "203.0.113.10:11111", map[string]string{"X-Forwarded-For": "9.9.9.9"}); code != http.StatusTooManyRequests {
+		t.Fatalf("second request (spoofed XFF, same RemoteAddr): got status %d, want %d", code, http.StatusTooManyRequests)
 	}
 
-	// Same RemoteAddr, but a completely different spoofed X-Forwarded-For.
-	// Prior to the fix, this would have been treated as a brand new client
-	// and allowed through with a fresh limiter.
-	second := makeRequest("9.9.9.9")
-	if second.Code != http.StatusTooManyRequests {
-		t.Fatalf("second request (spoofed XFF, same RemoteAddr): got status %d, want %d (rate limit should apply)", second.Code, http.StatusTooManyRequests)
-	}
-
-	// Sanity check: only one limiter bucket should have been created, keyed
-	// on RemoteAddr rather than the spoofed header.
 	store.mu.RLock()
 	numLimiters := len(store.limiters)
 	store.mu.RUnlock()
 	if numLimiters != 1 {
 		t.Errorf("expected exactly 1 rate limiter bucket, got %d", numLimiters)
+	}
+}
+
+// TestRateLimitMiddleware_CFConnectingIPIsTheKey verifies that behind the
+// Cloudflare Tunnel (where all requests share the cloudflared connector's
+// RemoteAddr) the limiter is keyed on CF-Connecting-IP: requests with the
+// SAME CF-Connecting-IP share a bucket even across different RemoteAddrs,
+// and requests with DIFFERENT CF-Connecting-IP values get separate buckets.
+func TestRateLimitMiddleware_CFConnectingIPIsTheKey(t *testing.T) {
+	handler, store := rateLimitTestHandler(t)
+
+	// Same CF-Connecting-IP, different RemoteAddr (e.g. two cloudflared
+	// replicas): must share one bucket, so the second request is limited.
+	if code := doRateLimitedRequest(handler, "10.0.0.5:11111", map[string]string{"CF-Connecting-IP": "198.51.100.7"}); code != http.StatusOK {
+		t.Fatalf("first request from client A: got status %d, want %d", code, http.StatusOK)
+	}
+	if code := doRateLimitedRequest(handler, "10.0.0.6:22222", map[string]string{"CF-Connecting-IP": "198.51.100.7"}); code != http.StatusTooManyRequests {
+		t.Fatalf("second request from client A via different RemoteAddr: got status %d, want %d", code, http.StatusTooManyRequests)
+	}
+
+	// A different CF-Connecting-IP (a different real client), even from the
+	// same RemoteAddr, must get its own bucket and NOT be throttled by
+	// client A's traffic.
+	if code := doRateLimitedRequest(handler, "10.0.0.5:11111", map[string]string{"CF-Connecting-IP": "198.51.100.8"}); code != http.StatusOK {
+		t.Fatalf("first request from client B: got status %d, want %d", code, http.StatusOK)
+	}
+
+	store.mu.RLock()
+	numLimiters := len(store.limiters)
+	store.mu.RUnlock()
+	if numLimiters != 2 {
+		t.Errorf("expected exactly 2 rate limiter buckets (one per CF-Connecting-IP), got %d", numLimiters)
 	}
 }

--- a/pkg/httpserver/server.go
+++ b/pkg/httpserver/server.go
@@ -69,13 +69,11 @@ func New(config *config.Config, datastore *store.Store, emailSender email.Sender
 	// unconditionally trusts the client-supplied X-Forwarded-For/X-Real-IP
 	// headers and rewrites r.RemoteAddr from them, which lets any client
 	// spoof its apparent IP (e.g. to bypass rate limiting keyed on IP - see
-	// getClientIP in ratelimit.go). There is currently no trusted-proxy
-	// configuration in this service to safely scope RealIP's trust, so we
-	// leave r.RemoteAddr as the actual TCP peer address. If this service is
-	// deployed behind a reverse proxy that must be trusted to set these
-	// headers, reintroduce IP-restricted RealIP handling (e.g. chi's
-	// middleware.RealIP combined with TrustedProxies) rather than trusting
-	// them unconditionally.
+	// getClientIP in ratelimit.go). We leave r.RemoteAddr as the actual TCP
+	// peer address; the real client IP behind the Cloudflare Tunnel is
+	// derived from the CF-Connecting-IP header in getClientIP, which
+	// Cloudflare guarantees to overwrite (unlike XFF/X-Real-IP, which anyone
+	// can set).
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(60 * time.Second))

--- a/pkg/httpserver/server.go
+++ b/pkg/httpserver/server.go
@@ -65,7 +65,17 @@ func New(config *config.Config, datastore *store.Store, emailSender email.Sender
 	consentTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/consent.html"))
 
 	r.Use(middleware.RequestID)
-	r.Use(middleware.RealIP)
+	// NOTE: chi's middleware.RealIP is intentionally NOT used here. It
+	// unconditionally trusts the client-supplied X-Forwarded-For/X-Real-IP
+	// headers and rewrites r.RemoteAddr from them, which lets any client
+	// spoof its apparent IP (e.g. to bypass rate limiting keyed on IP - see
+	// getClientIP in ratelimit.go). There is currently no trusted-proxy
+	// configuration in this service to safely scope RealIP's trust, so we
+	// leave r.RemoteAddr as the actual TCP peer address. If this service is
+	// deployed behind a reverse proxy that must be trusted to set these
+	// headers, reintroduce IP-restricted RealIP handling (e.g. chi's
+	// middleware.RealIP combined with TrustedProxies) rather than trusting
+	// them unconditionally.
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(60 * time.Second))


### PR DESCRIPTION
## The vulnerability

`getClientIP` in `pkg/httpserver/ratelimit.go` trusted client-supplied
`X-Forwarded-For` (first entry) and `X-Real-IP` headers before falling back
to `RemoteAddr`. Both headers are fully controlled by the client. An
attacker could send a different, fabricated value on every request and get
a brand-new per-IP token-bucket limiter each time in `rateLimitMiddleware`,
making the rate limiter (20 req/min per "IP", intended as basic DDoS
protection) provide essentially no protection at all.

This was compounded by `server.go`'s middleware stack installing chi's
`middleware.RealIP`, which *also* unconditionally trusts the same
XFF/X-Real-IP headers and rewrites `r.RemoteAddr` from them — reintroducing
the exact same spoofing surface even with `getClientIP` fixed.

## The fix

Per `k8s/README.md`, production traffic flows:

```
Internet → Cloudflare Edge (SSL) → Cloudflare Tunnel (cloudflared pod) → ClusterIP Service → Pods
```

The k8s Service is ClusterIP-only — the origin is not reachable from the
internet except through the Cloudflare Tunnel. That makes exactly one
header trustworthy: **`CF-Connecting-IP`**, which Cloudflare sets to the
real client IP and **overwrites** if a client supplies it. A naive
RemoteAddr-only fix was rejected because it would collapse all tunneled
traffic into the cloudflared connector's IP, throttling every real user to
a single shared 20 req/min bucket.

- `pkg/httpserver/ratelimit.go` — `getClientIP` now:
  1. Uses `CF-Connecting-IP` as the limiter key when present and valid
     (validated with `net.ParseIP`; the parsed/canonicalized form is used).
  2. Otherwise falls back to the host portion of `r.RemoteAddr` (the actual
     TCP peer, unspoofable) — covers local dev, the staging Tailscale
     ingress, and in-cluster traffic.
  3. Never trusts `X-Forwarded-For` or `X-Real-IP` — those remain fully
     client-controlled on any direct connection.
  A comment documents the trust model and the assumption it rests on.
- `pkg/httpserver/server.go` — `middleware.RealIP` removed from the
  middleware stack (it trusts XFF/X-Real-IP indiscriminately and rewrites
  `RemoteAddr`), with a comment explaining why.
- `pkg/httpserver/ratelimit_test.go` (new) —
  - `TestGetClientIP`: table test covering CF-Connecting-IP trusted
    (IPv4/IPv6), invalid CF-Connecting-IP falling back to RemoteAddr,
    spoofed XFF/X-Real-IP ignored, CF-Connecting-IP winning over spoofed
    XFF/X-Real-IP, and RemoteAddr host extraction.
  - `TestRateLimitMiddleware_SpoofedXFFSharesLimiter`: regression test —
    two requests with the same RemoteAddr but different spoofed
    `X-Forwarded-For` share one bucket; the second gets 429. Verified this
    fails against the pre-fix code.
  - `TestRateLimitMiddleware_CFConnectingIPIsTheKey`: same
    `CF-Connecting-IP` across different RemoteAddrs shares one bucket
    (second request 429); a different `CF-Connecting-IP` gets its own
    bucket and is not throttled; exactly one bucket per client IP.

## Security assumption (important for reviewers)

Trusting `CF-Connecting-IP` is safe **only while the origin is reachable
exclusively through the Cloudflare Tunnel**. If this service is ever
exposed via a LoadBalancer/NodePort, a non-Cloudflare ingress, or any other
path that bypasses the tunnel, `CF-Connecting-IP` becomes client-forgeable
on that path and must stop being trusted. This is called out in the code
comments in both files. Note also that requests arriving via the staging
Tailscale ingress or in-cluster (which don't carry the header) fall back to
RemoteAddr keying, which is the safe default.

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- `go test ./...` — passes (integration tests, which require Postgres and
  are behind the `integration` build tag, were not run)

Diff is scoped to `pkg/httpserver/ratelimit.go`,
`pkg/httpserver/server.go`, and the new `pkg/httpserver/ratelimit_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE
