### PR TITLE
Fix: validate redirect_uri before redirecting on login error (open redirect)

### DIFF
--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -35,18 +35,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 
 	// If code_challenge_method is provided, it must be S256 -- meaning a sha256 hash of the code verifier.
 	if codeChallengeMethod != "" && codeChallengeMethod != "S256" {
-		if redirectURI != "" {
-			// OAuth error: redirect back to client with error parameters
-			errorDesc := "Only S256 code challenge method is supported"
-			redirectURL := fmt.Sprintf("%s?error=invalid_request&error_description=%s&state=%s",
-				redirectURI,
-				url.QueryEscape(errorDesc),
-				url.QueryEscape(state))
-			http.Redirect(w, r, redirectURL, http.StatusFound)
-			return
-		}
-		// No redirect_uri: show error page
-		s.renderLoginError(w, http.StatusBadRequest, "Only S256 code challenge method is supported", LoginPageData{
+		oauthParams := LoginPageData{
 			ClientID:            clientID,
 			RedirectURI:         redirectURI,
 			State:               state,
@@ -54,7 +43,28 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 			CodeChallenge:       codeChallenge,
 			CodeChallengeMethod: codeChallengeMethod,
 			Nonce:               nonce,
-		})
+		}
+
+		// Only redirect this OAuth error back to the client if client_id + redirect_uri have
+		// been confirmed valid against the registered client. Blindly redirecting to a raw,
+		// unvalidated redirect_uri is an open redirect (RFC 6749 4.1.2.1 requires validating
+		// client_id/redirect_uri before trusting them for error redirects). This mirrors the
+		// validate-before-redirect pattern used in HandleOauthAuthorize / HandleConsentPost.
+		if clientID != "" && redirectURI != "" {
+			if _, err := s.validateOAuthClientRedirect(r.Context(), clientID, redirectURI); err == nil {
+				// OAuth error: redirect back to client with error parameters
+				errorDesc := "Only S256 code challenge method is supported"
+				redirectURL := fmt.Sprintf("%s?error=invalid_request&error_description=%s&state=%s",
+					redirectURI,
+					url.QueryEscape(errorDesc),
+					url.QueryEscape(state))
+				http.Redirect(w, r, redirectURL, http.StatusFound)
+				return
+			}
+		}
+		// No redirect_uri, or client_id/redirect_uri failed validation: show error page
+		// locally rather than redirecting to an unverified destination.
+		s.renderLoginError(w, http.StatusBadRequest, "Only S256 code challenge method is supported", oauthParams)
 		return
 	}
 

--- a/pkg/httpserver/login_test.go
+++ b/pkg/httpserver/login_test.go
@@ -1,0 +1,109 @@
+package httpserver
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"github.com/eswan18/identity/pkg/config"
+	"github.com/eswan18/identity/pkg/db"
+	"github.com/eswan18/identity/pkg/email"
+	"github.com/eswan18/identity/pkg/storage"
+	"github.com/eswan18/identity/pkg/store"
+)
+
+// testJWTECPrivateKey is a throwaway EC key used only to satisfy Server construction
+// in hermetic (non-integration) tests; it signs nothing meaningful here.
+const testJWTECPrivateKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICQMNHONu2Sud2tu6jgOZs3LIj5yOZr89NBMLYiyqBK/oAoGCCqGSM49
+AwEHoUQDQgAERCHWHrX20emk31HypGNgptwBjdZOyBybV/9BLTbJPj8UsZ/46ri5
+/eFKkRfNApxFU/5lk1RGQJqt8t0GvkkJdw==
+-----END EC PRIVATE KEY-----`
+
+// newHermeticTestServer builds a *Server without a real database connection.
+// sql.Open never dials, so this only fails (fast) the moment a handler actually
+// issues a query against 127.0.0.1 on a closed local port -- e.g. "connection
+// refused" in single-digit milliseconds, never a slow OS-level TCP timeout.
+// That's sufficient to exercise validateOAuthClientRedirect's failure path,
+// which is exactly the "unknown/unregistered client" case this test targets;
+// it does not need to distinguish that from "row not found".
+func newHermeticTestServer(t *testing.T) *Server {
+	t.Helper()
+	sqlDB, err := sql.Open("pgx", "postgres://user:pass@127.0.0.1:1/db?sslmode=disable")
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	t.Cleanup(func() { sqlDB.Close() })
+
+	ds := &store.Store{DB: sqlDB, Q: db.New(sqlDB)}
+	cfg := &config.Config{
+		TemplatesDir:  "../../templates",
+		JWTPrivateKey: testJWTECPrivateKey,
+		JWTIssuer:     "test-issuer",
+	}
+	return New(cfg, ds, email.NewLogSender(), storage.NewLogStorage())
+}
+
+// TestHandleLoginGet_DoesNotOpenRedirectOnUnvalidatedRedirectURI is a regression
+// test for an open redirect: previously, when code_challenge_method was present
+// but not "S256", HandleLoginGet redirected straight to the raw redirect_uri
+// query parameter without ever checking that it belonged to the registered
+// client. An attacker could send
+//
+//	GET /oauth/login?client_id=whatever&redirect_uri=https://evil.example/cb&code_challenge_method=plain
+//
+// and get bounced to redirect_uri with OAuth-looking error params attached.
+// The fix validates client_id + redirect_uri via validateOAuthClientRedirect
+// before ever redirecting there, mirroring HandleOauthAuthorize / HandleConsentPost.
+// Since the client_id here is unregistered (and the backing "database" is
+// unreachable), validation must fail and the handler must render the local
+// error page instead of issuing a 302 to the attacker-controlled host.
+func TestHandleLoginGet_DoesNotOpenRedirectOnUnvalidatedRedirectURI(t *testing.T) {
+	s := newHermeticTestServer(t)
+
+	const evilRedirect = "https://evil.example/cb"
+	req := httptest.NewRequest(http.MethodGet,
+		"/oauth/login?client_id=some-client&redirect_uri="+evilRedirect+
+			"&code_challenge_method=plain&state=xyz", nil)
+	rec := httptest.NewRecorder()
+
+	s.HandleLoginGet(rec, req)
+
+	if rec.Code == http.StatusFound {
+		loc := rec.Header().Get("Location")
+		t.Fatalf("HandleLoginGet must not redirect to an unvalidated redirect_uri; got %d Location=%q", rec.Code, loc)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("expected no Location header on the local error response, got %q", loc)
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (local login error page), got %d", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Only S256 code challenge method is supported") {
+		t.Fatalf("expected error page to include the invalid_request error message, got body: %s", body)
+	}
+}
+
+// TestHandleLoginGet_NoRedirectURIStillRendersLocalError is a sanity check that the
+// pre-existing "no redirect_uri" branch continues to render the local error page
+// (unchanged behavior).
+func TestHandleLoginGet_NoRedirectURIStillRendersLocalError(t *testing.T) {
+	s := newHermeticTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/login?code_challenge_method=plain", nil)
+	rec := httptest.NewRecorder()
+
+	s.HandleLoginGet(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 (local login error page), got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "" {
+		t.Fatalf("expected no Location header, got %q", loc)
+	}
+}


### PR DESCRIPTION
## Vulnerability

`HandleLoginGet` in `pkg/httpserver/login.go` had an open redirect: when
`code_challenge_method` was present but not `S256`, the handler built a
redirect URL directly from the raw `redirect_uri` query parameter and issued
an HTTP 302 to it — without ever checking that `redirect_uri` belongs to the
registered OAuth client.

```
GET /oauth/login?client_id=whatever&redirect_uri=https://evil.com&code_challenge_method=plain
```

would bounce the user straight to `https://evil.com` with OAuth-looking
`error`/`error_description`/`state` params attached, which is useful for
phishing (the URL starts with the legit identity provider's host) and for
leaking `state`/other query values to an attacker-controlled origin.

## Fix

`HandleLoginGet` now validates `client_id` + `redirect_uri` against the
registered client via the existing `validateOAuthClientRedirect` helper
(`pkg/httpserver/credentials.go`) *before* redirecting the
`invalid_request` (unsupported `code_challenge_method`) error back to the
client. This mirrors the "validate before trusting redirect_uri for error
redirects" pattern already used in `HandleOauthAuthorize` and
`HandleConsentPost` (`pkg/httpserver/oauth.go`), which per RFC 6749 §4.1.2.1
must not redirect until client_id/redirect_uri are confirmed valid.

If `client_id`/`redirect_uri` are missing, or validation fails (unknown
client or unregistered redirect_uri), the handler now renders the local
login error page instead of redirecting anywhere.

Scope: this PR only touches the one confirmed open-redirect path in
`HandleLoginGet`. The rest of `HandleLoginGet`/`HandleLoginPost` was
reviewed — the only other redirect in that file (`redirectAfterAuth` /
`buildAuthorizeURL`) always redirects to the local `/oauth/authorize`
endpoint (never to the client-supplied `redirect_uri` directly), and that
endpoint independently re-validates `client_id`/`redirect_uri` on arrival,
so it is not the same bug and is left unchanged.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Added `pkg/httpserver/login_test.go` with a hermetic (non-integration,
  no Postgres/testcontainers) regression test:
  `TestHandleLoginGet_DoesNotOpenRedirectOnUnvalidatedRedirectURI` sends a
  `code_challenge_method=plain` request with an unregistered `client_id`
  and an attacker-controlled `redirect_uri`, and asserts the handler
  returns the local 400 error page (no `Location` header) rather than a
  302 to the attacker's host. A companion test
  (`TestHandleLoginGet_NoRedirectURIStillRendersLocalError`) checks the
  pre-existing "no redirect_uri" branch is unchanged.
  These tests build a `*Server` with a `*sql.DB` pointed at a closed local
  port instead of a real database, so any DB query fails fast
  (connection refused, ~ms) and exercises the same "validation failed"
  path an unknown `client_id` would hit against a real Postgres — no
  integration harness needed. The full integration suite
  (`pkg/httpserver/authorize_consent_test.go`, `oauth_flow_test.go`,
  `integration_common_test.go`, build tag `integration`) was left
  untouched and not run, per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE