### PR TITLE
Fix: hash OAuth client secrets at rest

### DIFF
--- a/cmd/identity-cli/cmd/client_create.go
+++ b/cmd/identity-cli/cmd/client_create.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/eswan18/identity/cmd/identity-cli/internal"
+	"github.com/eswan18/identity/pkg/auth"
 	"github.com/eswan18/identity/pkg/db"
 	"github.com/spf13/cobra"
 )
@@ -62,14 +63,18 @@ func runClientCreate(cmd *cobra.Command, args []string) error {
 		log.Fatalf("Failed to generate client_id: %v", err)
 	}
 
-	// Generate client_secret if confidential
+	// Generate client_secret if confidential. The plaintext is shown to the
+	// operator once below, but only a SHA-256 hash of it is persisted so that a
+	// database dump does not disclose usable client credentials.
 	var clientSecret sql.NullString
+	var plaintextSecret string
 	if createIsConfidential {
 		secret, err := internal.GenerateRandomString(32)
 		if err != nil {
 			log.Fatalf("Failed to generate client_secret: %v", err)
 		}
-		clientSecret = sql.NullString{String: secret, Valid: true}
+		plaintextSecret = secret
+		clientSecret = sql.NullString{String: auth.HashClientSecret(secret), Valid: true}
 	}
 
 	// Create the client
@@ -92,8 +97,9 @@ func runClientCreate(cmd *cobra.Command, args []string) error {
 	fmt.Println("\nClient Details:")
 	fmt.Printf("  Name:           %s\n", client.Name)
 	fmt.Printf("  Client ID:      %s\n", client.ClientID)
-	if client.ClientSecret.Valid {
-		fmt.Printf("  Client Secret:  %s\n", client.ClientSecret.String)
+	if plaintextSecret != "" {
+		// Print the plaintext secret (only the hash is stored in the database).
+		fmt.Printf("  Client Secret:  %s\n", plaintextSecret)
 		fmt.Println("\n⚠️  IMPORTANT: Save the client_secret now - it cannot be retrieved later!")
 	} else {
 		fmt.Println("  Client Secret:  (none - public client)")

--- a/db/migrations/000010_hash_client_secrets.down.sql
+++ b/db/migrations/000010_hash_client_secrets.down.sql
@@ -1,0 +1,7 @@
+-- This migration is intentionally irreversible.
+--
+-- The up migration replaced plaintext client secrets with a one-way SHA-256
+-- hash. A hash cannot be reversed to recover the original plaintext secret, so
+-- there is no correct way to restore the previous state. This down migration is
+-- a deliberate no-op; rolling back leaves the hashed secrets in place. Clients
+-- whose plaintext secret is unknown must be rotated (issued a new secret).

--- a/db/migrations/000010_hash_client_secrets.up.sql
+++ b/db/migrations/000010_hash_client_secrets.up.sql
@@ -1,0 +1,15 @@
+-- Hash existing OAuth client secrets at rest.
+--
+-- Client secrets were previously stored as plaintext, so a database dump
+-- disclosed every client's usable credential. Replace each plaintext secret
+-- with its lowercase hex-encoded SHA-256 hash. This matches exactly what the
+-- Go code produces via hex.EncodeToString(sha256.Sum256([]byte(secret))[:]),
+-- so existing clients continue to authenticate with their original secret.
+--
+-- digest() comes from the pgcrypto extension, which is already enabled in
+-- migration 000001; CREATE EXTENSION IF NOT EXISTS is a harmless no-op if so.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+UPDATE oauth_clients
+SET client_secret = encode(digest(client_secret, 'sha256'), 'hex')
+WHERE client_secret IS NOT NULL;

--- a/pkg/auth/client_secret.go
+++ b/pkg/auth/client_secret.go
@@ -1,0 +1,32 @@
+package auth
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+)
+
+// HashClientSecret returns the lowercase hex-encoded SHA-256 hash of an OAuth
+// client secret.
+//
+// Client secrets are high-entropy, randomly generated strings, so a fast
+// cryptographic hash (SHA-256) is appropriate and sufficient here. Unlike
+// low-entropy human passwords (which use argon2/bcrypt via HashPassword), there
+// is no need for a slow, salted KDF: an attacker cannot feasibly brute-force a
+// 32-byte random secret, and a fast hash keeps constant-time verification cheap.
+//
+// The output is lowercase hex with no prefix so that it matches Postgres'
+// `encode(digest(secret, 'sha256'), 'hex')`, which lets the accompanying
+// migration hash existing plaintext secrets in place.
+func HashClientSecret(secret string) string {
+	sum := sha256.Sum256([]byte(secret))
+	return hex.EncodeToString(sum[:])
+}
+
+// ClientSecretMatches reports whether the presented plaintext secret hashes to
+// the stored hash, using a constant-time comparison to avoid leaking timing
+// information about the stored value.
+func ClientSecretMatches(storedHash, presentedSecret string) bool {
+	presentedHash := HashClientSecret(presentedSecret)
+	return subtle.ConstantTimeCompare([]byte(storedHash), []byte(presentedHash)) == 1
+}

--- a/pkg/auth/client_secret_test.go
+++ b/pkg/auth/client_secret_test.go
@@ -1,0 +1,43 @@
+package auth
+
+import "testing"
+
+func TestHashClientSecretKnownVector(t *testing.T) {
+	// Known-answer vector: SHA-256("abc") in lowercase hex. This is exactly what
+	// Postgres produces via encode(digest('abc', 'sha256'), 'hex'), which is how
+	// the 000010 migration hashes existing rows. Keeping this test in sync
+	// guarantees the Go and SQL hashing agree, so migrated clients still
+	// authenticate.
+	const want = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+	if got := HashClientSecret("abc"); got != want {
+		t.Fatalf("HashClientSecret(\"abc\") = %q, want %q", got, want)
+	}
+}
+
+func TestHashClientSecretHexFormat(t *testing.T) {
+	got := HashClientSecret("some-random-high-entropy-secret")
+	if len(got) != 64 {
+		t.Fatalf("expected 64 hex chars, got %d (%q)", len(got), got)
+	}
+	for _, c := range got {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Fatalf("hash contains non-lowercase-hex character %q in %q", c, got)
+		}
+	}
+}
+
+func TestClientSecretMatches(t *testing.T) {
+	secret := "cd9e459ea708a948d5c2f5a6ca8838cf" // arbitrary high-entropy value
+	stored := HashClientSecret(secret)
+
+	if !ClientSecretMatches(stored, secret) {
+		t.Error("ClientSecretMatches returned false for the correct secret")
+	}
+	if ClientSecretMatches(stored, "wrong-secret") {
+		t.Error("ClientSecretMatches returned true for an incorrect secret")
+	}
+	// A presented secret that happens to equal the stored hash must not match.
+	if ClientSecretMatches(stored, stored) {
+		t.Error("ClientSecretMatches returned true when presenting the stored hash itself")
+	}
+}

--- a/pkg/httpserver/avatar_integration_test.go
+++ b/pkg/httpserver/avatar_integration_test.go
@@ -513,8 +513,16 @@ func (s *AvatarFlowSuite) mustGenerateAlphanumericString(length int) string {
 
 // mustRegisterOAuthClient creates an OAuth client for testing
 func (s *AvatarFlowSuite) mustRegisterOAuthClient(params db.CreateOAuthClientParams) db.OauthClient {
+	// The server stores only a hash of the client secret, so hash it before
+	// insert. Preserve the plaintext on the returned struct so callers can
+	// still present it when authenticating.
+	plaintextSecret := params.ClientSecret
+	if params.ClientSecret.Valid {
+		params.ClientSecret = sql.NullString{String: auth.HashClientSecret(params.ClientSecret.String), Valid: true}
+	}
 	client, err := s.datastore.Q.CreateOAuthClient(s.T().Context(), params)
 	s.Require().NoError(err)
+	client.ClientSecret = plaintextSecret
 	return client
 }
 

--- a/pkg/httpserver/credentials.go
+++ b/pkg/httpserver/credentials.go
@@ -3,7 +3,6 @@ package httpserver
 import (
 	"context"
 	"crypto/rand"
-	"crypto/subtle"
 	"database/sql"
 	"encoding/base64"
 	"errors"
@@ -53,7 +52,9 @@ func (s *Server) authenticateClient(r *http.Request) (db.OauthClient, error) {
 	}
 
 	if client.IsConfidential {
-		if !client.ClientSecret.Valid || subtle.ConstantTimeCompare([]byte(client.ClientSecret.String), []byte(clientSecret)) != 1 {
+		// The stored secret is a hex-encoded SHA-256 hash; hash the presented
+		// secret the same way and compare in constant time.
+		if !client.ClientSecret.Valid || !auth.ClientSecretMatches(client.ClientSecret.String, clientSecret) {
 			return db.OauthClient{}, errors.New("invalid client credentials")
 		}
 	}

--- a/pkg/httpserver/integration_common_test.go
+++ b/pkg/httpserver/integration_common_test.go
@@ -211,8 +211,16 @@ func (s *OAuthFlowSuite) mustLoginAndConsent(user UserWithPassword, clientID, re
 }
 
 func (s *OAuthFlowSuite) mustRegisterOAuthClient(params db.CreateOAuthClientParams) db.OauthClient {
+	// The server stores only a hash of the client secret, so hash it before
+	// insert. Preserve the plaintext on the returned struct so callers can
+	// still present it when authenticating.
+	plaintextSecret := params.ClientSecret
+	if params.ClientSecret.Valid {
+		params.ClientSecret = sql.NullString{String: auth.HashClientSecret(params.ClientSecret.String), Valid: true}
+	}
 	client, err := s.datastore.Q.CreateOAuthClient(s.T().Context(), params)
 	s.Require().NoError(err)
+	client.ClientSecret = plaintextSecret
 	s.T().Logf("oauth client created: %s", client.ClientID)
 	return client
 }


### PR DESCRIPTION
## The problem

OAuth client secrets were stored in `oauth_clients.client_secret` as **plaintext**. The CLI `client create` path persisted the raw secret, and `authenticateClient` compared the presented secret against that stored plaintext. A database dump therefore disclosed every confidential client's usable credential.

## The fix: SHA-256 hash at rest

Client secrets are high-entropy random strings (32 bytes from `crypto/rand`, base64-encoded), so a fast cryptographic hash is the right tool. Unlike low-entropy human passwords (which use argon2 via `HashPassword`), there is no brute-force risk that would justify a slow, salted KDF — and SHA-256 keeps constant-time verification cheap.

New helpers in `pkg/auth/client_secret.go`:
- `HashClientSecret(secret) string` — lowercase hex-encoded SHA-256, i.e. `hex.EncodeToString(sha256.Sum256([]byte(secret))[:])`.
- `ClientSecretMatches(storedHash, presented) bool` — hashes the presented secret and compares with `subtle.ConstantTimeCompare` (constant-time preserved).

Changes:
- **Storage** (`cmd/identity-cli/cmd/client_create.go`): the generated secret is hashed before insert; the plaintext is still printed once with the existing "cannot be retrieved later" warning. Secret **generation** (entropy/format) is unchanged. (No server-side admin client-creation path exists — the CLI is the only creator.)
- **Verification** (`pkg/httpserver/credentials.go`): `authenticateClient` now hashes the presented secret and compares hex hashes in constant time. Public clients (no secret, `IsConfidential == false`) are untouched — a NULL/absent stored secret is never hashed and never required.

## Migration (`000010_hash_client_secrets`)

- `.up.sql`: `UPDATE oauth_clients SET client_secret = encode(digest(client_secret, 'sha256'), 'hex') WHERE client_secret IS NOT NULL;`. This uses `digest()` from **pgcrypto**, which is **already enabled** in migration `000001`; a defensive `CREATE EXTENSION IF NOT EXISTS pgcrypto;` is included as a no-op. Postgres `encode(digest(x,'sha256'),'hex')` produces the exact same lowercase-hex string as the Go code, so **existing clients keep authenticating with their original plaintext secret**.
- `.down.sql`: intentional **no-op** — a SHA-256 hash cannot be reversed to recover plaintext. Documented explicitly; clients with unknown secrets must be rotated.

The known-answer unit test asserts `HashClientSecret("abc") == ba7816bf…20015ad`, which is exactly what `encode(digest('abc','sha256'),'hex')` returns — pinning Go/SQL agreement.

## Testing

- `go build ./...`, `go vet ./...`, `go vet -tags=integration ./pkg/httpserver/`: clean.
- `go test ./...` (non-integration): pass, including new hermetic tests in `pkg/auth/client_secret_test.go`.
- The client-auth tests are `//go:build integration` (need Postgres, not run here). Their `mustRegisterOAuthClient` helpers (in `integration_common_test.go` and `avatar_integration_test.go`) were updated to hash the secret on insert while returning the plaintext on the struct, so callers that present either their local plaintext var or `client.ClientSecret.String` still authenticate. Verified these files compile under the integration tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE