### PR TITLE
Fix: reset email_verified on email change and revoke sessions/tokens on password change/reset

### DIFF
--- a/db/queries/auth.sql
+++ b/db/queries/auth.sql
@@ -151,6 +151,10 @@ WHERE id = $1
 DELETE FROM auth_sessions
 WHERE id = $1;
 
+-- name: DeleteAllUserSessions :exec
+DELETE FROM auth_sessions
+WHERE user_id = $1;
+
 -- name: UpdateUserPasswordWithTimestamp :exec
 UPDATE auth_users
 SET password_hash = $1, password_changed_at = now(), updated_at = now()
@@ -167,8 +171,11 @@ SET username = $1, updated_at = now()
 WHERE id = $2;
 
 -- name: UpdateUserEmail :exec
+-- Changing the email address invalidates any prior verification: the user
+-- has not proven ownership of the new address, so email_verified must be
+-- reset to false here rather than left at its previous value.
 UPDATE auth_users
-SET email = $1, updated_at = now()
+SET email = $1, email_verified = false, updated_at = now()
 WHERE id = $2;
 
 -- name: UpdateUserProfile :exec

--- a/pkg/db/auth.sql.go
+++ b/pkg/db/auth.sql.go
@@ -230,6 +230,16 @@ func (q *Queries) DeactivateUser(ctx context.Context, id uuid.UUID) error {
 	return err
 }
 
+const deleteAllUserSessions = `-- name: DeleteAllUserSessions :exec
+DELETE FROM auth_sessions
+WHERE user_id = $1
+`
+
+func (q *Queries) DeleteAllUserSessions(ctx context.Context, userID uuid.UUID) error {
+	_, err := q.db.ExecContext(ctx, deleteAllUserSessions, userID)
+	return err
+}
+
 const deleteExpiredEmailTokens = `-- name: DeleteExpiredEmailTokens :exec
 DELETE FROM auth_email_tokens WHERE expires_at <= now()
 `
@@ -1109,7 +1119,7 @@ func (q *Queries) UpdateOAuthClient(ctx context.Context, arg UpdateOAuthClientPa
 
 const updateUserEmail = `-- name: UpdateUserEmail :exec
 UPDATE auth_users
-SET email = $1, updated_at = now()
+SET email = $1, email_verified = false, updated_at = now()
 WHERE id = $2
 `
 
@@ -1118,6 +1128,9 @@ type UpdateUserEmailParams struct {
 	ID    uuid.UUID `json:"id"`
 }
 
+// Changing the email address invalidates any prior verification: the user
+// has not proven ownership of the new address, so email_verified must be
+// reset to false here rather than left at its previous value.
 func (q *Queries) UpdateUserEmail(ctx context.Context, arg UpdateUserEmailParams) error {
 	_, err := q.db.ExecContext(ctx, updateUserEmail, arg.Email, arg.ID)
 	return err

--- a/pkg/httpserver/account.go
+++ b/pkg/httpserver/account.go
@@ -181,7 +181,31 @@ func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request
 	}
 
 	log.Printf("[DEBUG] HandleChangePasswordPost: Password updated successfully for user: %s", user.Username)
-	s.changePasswordTemplate.Execute(w, ChangePasswordPageData{Success: "Password updated successfully"})
+
+	// A password change is a credential change: log the user out everywhere.
+	// Revoke all OAuth tokens and delete all sessions (including the current
+	// one) for this user, same as account deactivation does.
+	userIDNullable := uuid.NullUUID{UUID: user.ID, Valid: true}
+	if err := s.datastore.Q.RevokeAllUserTokens(r.Context(), userIDNullable); err != nil {
+		log.Printf("[ERROR] HandleChangePasswordPost: Failed to revoke tokens: %v", err)
+		// Continue anyway - the password was already changed successfully.
+	}
+	if err := s.datastore.Q.DeleteAllUserSessions(r.Context(), user.ID); err != nil {
+		log.Printf("[ERROR] HandleChangePasswordPost: Failed to delete sessions: %v", err)
+		// Continue anyway - the password was already changed successfully.
+	}
+
+	// Clear the now-invalid session cookie and send the user back to login,
+	// mirroring HandleDeactivateAccountPost's redirect-to-login pattern.
+	http.SetCookie(w, &http.Cookie{
+		Name:     "session_id",
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	http.Redirect(w, r, "/oauth/login?password_changed=true", http.StatusFound)
 }
 
 // HandleChangeUsernameGet godoc
@@ -366,8 +390,17 @@ func (s *Server) HandleChangeEmailPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log.Printf("[DEBUG] HandleChangeEmailPost: Email updated successfully from %s to %s", user.Email, newEmail)
+
+	// The new address hasn't been verified yet (UpdateUserEmail resets
+	// email_verified to false), so send a fresh verification email to it.
+	// Mirror HandleForgotPasswordPost's pattern: a failure to send shouldn't
+	// block the (already-successful) email change, just get logged.
+	if err := s.sendVerificationEmail(r.Context(), user.ID, newEmail, user.Username); err != nil {
+		log.Printf("[ERROR] HandleChangeEmailPost: Failed to send verification email: %v", err)
+	}
+
 	s.changeEmailTemplate.Execute(w, ChangeEmailPageData{
-		Success:      "Email updated successfully",
+		Success:      "Email updated successfully. Please check your new email address for a verification link.",
 		CurrentEmail: newEmail,
 	})
 }

--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -76,6 +76,8 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 		errorMsg = "Email verified successfully! Please sign in."
 	} else if r.URL.Query().Get("password_reset") == "true" {
 		errorMsg = "Password reset successfully! Please sign in with your new password."
+	} else if r.URL.Query().Get("password_changed") == "true" {
+		errorMsg = "Password changed successfully! Please sign in again."
 	} else if r.URL.Query().Get("deactivated") == "true" {
 		errorMsg = "Your account has been deactivated."
 	} else if r.URL.Query().Get("error") == "account_deactivated" {

--- a/pkg/httpserver/oauth_flow_test.go
+++ b/pkg/httpserver/oauth_flow_test.go
@@ -329,11 +329,24 @@ func (s *OAuthFlowSuite) TestPasswordChangeUpdatesPasswordChangedAt() {
 	})
 	s.Require().NoError(err)
 	defer resp.Body.Close()
-	s.Require().Equal(http.StatusOK, resp.StatusCode, "password change should succeed")
+	// A successful password change logs the user out everywhere: it redirects
+	// to the login page rather than rendering the change-password page inline.
+	s.Require().Equal(http.StatusFound, resp.StatusCode, "password change should redirect to login")
+	s.Require().Equal("/oauth/login?password_changed=true", resp.Header.Get("Location"))
 
 	// Verify password_changed_at is now set
 	userAfter, err := s.datastore.Q.GetUserByID(s.T().Context(), user.ID)
 	s.Require().NoError(err)
 	s.True(userAfter.PasswordChangedAt.Valid, "password_changed_at should be set after password change")
 	s.WithinDuration(time.Now(), userAfter.PasswordChangedAt.Time, 5*time.Second, "password_changed_at should be recent")
+
+	// The session used to change the password should have been invalidated,
+	// since a password change revokes all sessions for the user.
+	var sessionCookieValue string
+	for _, c := range jar.Cookies(&url.URL{Scheme: "http", Host: "localhost:8080"}) {
+		if c.Name == "session_id" {
+			sessionCookieValue = c.Value
+		}
+	}
+	s.Empty(sessionCookieValue, "session cookie should be cleared after password change")
 }

--- a/pkg/httpserver/password_reset.go
+++ b/pkg/httpserver/password_reset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/eswan18/identity/pkg/auth"
 	"github.com/eswan18/identity/pkg/db"
 	"github.com/eswan18/identity/pkg/email"
+	"github.com/google/uuid"
 )
 
 const (
@@ -292,6 +293,21 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	}
 
 	log.Printf("[DEBUG] HandleResetPasswordPost: Password reset successfully for user %s", tokenRecord.Username)
+
+	// A password reset is a credential change: log the user out everywhere.
+	// Revoke all OAuth tokens and delete all sessions for this user, same as
+	// HandleChangePasswordPost and account deactivation do. There's no active
+	// session tied to this request (the user isn't logged in during a reset),
+	// so there's no cookie to clear here.
+	userIDNullable := uuid.NullUUID{UUID: tokenRecord.UserID, Valid: true}
+	if err := s.datastore.Q.RevokeAllUserTokens(r.Context(), userIDNullable); err != nil {
+		log.Printf("[ERROR] HandleResetPasswordPost: Failed to revoke tokens: %v", err)
+		// Continue anyway - the password was already reset successfully.
+	}
+	if err := s.datastore.Q.DeleteAllUserSessions(r.Context(), tokenRecord.UserID); err != nil {
+		log.Printf("[ERROR] HandleResetPasswordPost: Failed to delete sessions: %v", err)
+		// Continue anyway - the password was already reset successfully.
+	}
 
 	// Redirect to login with success message
 	http.Redirect(w, r, "/oauth/login?password_reset=true", http.StatusFound)


### PR DESCRIPTION
## Issue 1: Email change didn't reset `email_verified`

`HandleChangeEmailPost` (`pkg/httpserver/account.go`) updated a user's email but left `email_verified` at its previous value, so ID tokens / access tokens (`pkg/httpserver/credentials.go`) kept asserting `email_verified=true` for an address the user never proved ownership of.

**Fix:**
- `UpdateUserEmail` (`db/queries/auth.sql`) now also does `SET email_verified = false`. I modified the shared query directly rather than adding a new one — `UpdateUserEmail` has exactly one call site (`HandleChangeEmailPost`), so there was no risk of surprising other callers.
- `HandleChangeEmailPost` now calls the existing `sendVerificationEmail` helper (already used by `HandleResendVerification`) to send a verification email to the new address after a successful update. No token-generation logic was duplicated.
- Send failures are logged and otherwise ignored, matching the existing pattern in `HandleForgotPasswordPost` ("still show success, but log the error") — the email change itself already succeeded and shouldn't be undone or blocked by a transient email-send failure.
- The success message now tells the user to check their new email for a verification link.

## Issue 2: Password change/reset didn't revoke sessions or tokens

`HandleChangePasswordPost` and `HandleResetPasswordPost` updated the password hash but left all existing sessions and OAuth access/refresh tokens valid — unlike account deactivation, which already calls `RevokeAllUserTokens`.

**Fix:**
- Added a new query `DeleteAllUserSessions` (`db/queries/auth.sql`), mirroring the existing session queries, to delete all `auth_sessions` rows for a user.
- Both handlers now call `RevokeAllUserTokens` and `DeleteAllUserSessions` **after** the password write succeeds (and, in the reset flow, after the reset token has already been atomically marked used — that TOCTOU-safe ordering is unchanged).
- `HandleChangePasswordPost`: since the caller's own session is now among those just deleted, it clears the `session_id` cookie and redirects to `/oauth/login?password_changed=true` (added a matching login-page message, following the same convention as the existing `password_reset=true` message) instead of re-rendering the change-password page — the old inline "success" response would have left the user on a page tied to a session that no longer exists.
- `HandleResetPasswordPost`: no active session is tied to this request, so it keeps its existing `/oauth/login?password_reset=true` redirect unchanged.
- Revoke/delete failures are logged and non-fatal, matching `HandleDeactivateAccountPost`'s existing pattern — the credential change itself already succeeded.

## Regenerating sqlc

`sqlc` was not installed, so I installed it (`go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest`) along with `golang-migrate` to build `db/schema.sql` (it's gitignored and normally produced by `pg_dump` against a live DB per the `Makefile`). I spun up a local Postgres database, ran all migrations from `db/migrations`, dumped the schema, and ran `sqlc generate`. The installed sqlc version (v1.31.1) differed from the one last used to generate this repo's code (v1.30.0), so I reverted the version-comment bumps in the generated files to keep the diff limited to the actual query changes.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- `go build -tags integration ./...` / `go vet -tags integration ./...` also pass, confirming the integration-tagged test files still compile with these changes.
- Per instructions, I did not run the integration test suite itself (requires Postgres/testcontainers).
- I updated the one existing integration test whose expectations the password-change behavior change broke (`TestPasswordChangeUpdatesPasswordChangedAt` in `pkg/httpserver/oauth_flow_test.go`): it now expects a 302 redirect to `/oauth/login?password_changed=true` instead of a 200, and additionally asserts the session cookie is cleared.
- All handler-level tests in this package that exercise `s.datastore.Q` live behind the `integration` build tag and require a real Postgres connection; the non-integration test files only cover pure helper functions (token generation, param parsing, etc.), so I could not add a new DB-free test for the email-change/session-revocation behavior itself. This is a testing gap worth a follow-up integration test if a reviewer wants explicit coverage for `HandleChangeEmailPost`'s new verification-email side effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE