### PR TITLE
Fix: require confidential-client auth and enforce token ownership on introspect/revoke

### DIFF
--- a/pkg/httpserver/credentials.go
+++ b/pkg/httpserver/credentials.go
@@ -40,6 +40,11 @@ var (
 	ErrInvalidScope       = errors.New("invalid scope")
 )
 
+// ErrConfidentialClientRequired is returned when an endpoint that requires a fully
+// authenticated confidential client (e.g. introspection, revocation) is called by a
+// public client that only supplied a client_id.
+var ErrConfidentialClientRequired = errors.New("client authentication required")
+
 // authenticateClient extracts client credentials from the request using either
 // client_secret_post (form values) or client_secret_basic (Authorization header),
 // looks up the client, and verifies the secret for confidential clients.
@@ -60,6 +65,38 @@ func (s *Server) authenticateClient(r *http.Request) (db.OauthClient, error) {
 	}
 
 	return client, nil
+}
+
+// requireConfidentialClient is the pure decision logic behind authenticateConfidentialClient:
+// given the result of authenticateClient, it additionally rejects clients that are not
+// confidential. It's split out from authenticateConfidentialClient so it can be unit tested
+// without a database.
+func requireConfidentialClient(client db.OauthClient, err error) (db.OauthClient, error) {
+	if err != nil {
+		return db.OauthClient{}, err
+	}
+	if !client.IsConfidential {
+		return db.OauthClient{}, ErrConfidentialClientRequired
+	}
+	return client, nil
+}
+
+// authenticateConfidentialClient behaves like authenticateClient, but additionally requires
+// that the caller be a confidential client that has presented a valid client_secret.
+//
+// authenticateClient intentionally lets public clients through with just a client_id (no
+// secret) so that the token endpoint can keep supporting the authorization_code + PKCE flow
+// (RFC 7636), where public clients (e.g. SPAs, mobile apps) have no client_secret to present.
+// That's correct for /oauth/token, but it's NOT sufficient for endpoints where RFC 7662 §2.1
+// (introspection) and RFC 7009 §2.1 (revocation) require the caller itself to authenticate:
+// allowing a bare client_id through would let anyone who knows (or guesses) a registered
+// client_id probe token validity or revoke arbitrary tokens.
+//
+// This helper adds that stricter requirement at the call site, without changing
+// authenticateClient's contract or behavior for the token/refresh endpoints.
+func (s *Server) authenticateConfidentialClient(r *http.Request) (db.OauthClient, error) {
+	client, err := s.authenticateClient(r)
+	return requireConfidentialClient(client, err)
 }
 
 // parseClientCredentials extracts client_id and client_secret from the request.

--- a/pkg/httpserver/credentials_test.go
+++ b/pkg/httpserver/credentials_test.go
@@ -1,10 +1,16 @@
 package httpserver
 
 import (
+	"database/sql"
+	"errors"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/eswan18/identity/pkg/db"
+	"github.com/google/uuid"
 )
 
 func TestParseClientCredentials_BasicAuth(t *testing.T) {
@@ -106,5 +112,64 @@ func TestGenerateRandomStringDifferentLengths(t *testing.T) {
 		if len(str) != tt.expectedB64Len {
 			t.Errorf("generateRandomString(%d): expected %d chars, got %d", tt.byteLen, tt.expectedB64Len, len(str))
 		}
+	}
+}
+
+// TestRequireConfidentialClient_RejectsPublicClient covers the core of Issue 1: introspection
+// and revocation (via authenticateConfidentialClient) must reject a caller that only proved
+// it knows a public client's client_id, with no secret. This exercises the pure decision
+// logic behind authenticateConfidentialClient without needing a database, since
+// authenticateClient itself requires a live DB lookup.
+func TestRequireConfidentialClient_RejectsPublicClient(t *testing.T) {
+	publicClient := db.OauthClient{
+		ID:             uuid.New(),
+		ClientID:       "public-client",
+		IsConfidential: false,
+	}
+
+	client, err := requireConfidentialClient(publicClient, nil)
+	if err == nil {
+		t.Fatal("expected an error for a public client, got nil")
+	}
+	if !errors.Is(err, ErrConfidentialClientRequired) {
+		t.Errorf("expected ErrConfidentialClientRequired, got %v", err)
+	}
+	if !reflect.DeepEqual(client, db.OauthClient{}) {
+		t.Errorf("expected zero-value client on rejection, got %+v", client)
+	}
+}
+
+// TestRequireConfidentialClient_AllowsConfidentialClient ensures a client that authenticated
+// as confidential (i.e. authenticateClient already verified its secret) passes through
+// unchanged.
+func TestRequireConfidentialClient_AllowsConfidentialClient(t *testing.T) {
+	confidentialClient := db.OauthClient{
+		ID:             uuid.New(),
+		ClientID:       "confidential-client",
+		ClientSecret:   sql.NullString{String: "shh", Valid: true},
+		IsConfidential: true,
+	}
+
+	client, err := requireConfidentialClient(confidentialClient, nil)
+	if err != nil {
+		t.Fatalf("expected no error for a confidential client, got %v", err)
+	}
+	if !reflect.DeepEqual(client, confidentialClient) {
+		t.Errorf("expected client to be returned unchanged, got %+v", client)
+	}
+}
+
+// TestRequireConfidentialClient_PropagatesUpstreamError ensures that an authentication
+// failure from authenticateClient (e.g. unknown client_id, or wrong secret for a confidential
+// client) is passed through as-is rather than being masked.
+func TestRequireConfidentialClient_PropagatesUpstreamError(t *testing.T) {
+	upstreamErr := errors.New("invalid client credentials")
+
+	client, err := requireConfidentialClient(db.OauthClient{}, upstreamErr)
+	if !errors.Is(err, upstreamErr) {
+		t.Errorf("expected upstream error to propagate, got %v", err)
+	}
+	if !reflect.DeepEqual(client, db.OauthClient{}) {
+		t.Errorf("expected zero-value client on error, got %+v", client)
 	}
 }

--- a/pkg/httpserver/integration_common_test.go
+++ b/pkg/httpserver/integration_common_test.go
@@ -356,6 +356,11 @@ func (s *OAuthFlowSuite) mustCompleteOAuthFlow(clientParams db.CreateOAuthClient
 		"client_id":     {client.ClientID},
 		"code_verifier": {scv.CodeVerifier},
 	}
+	// Confidential clients must also present their client_secret (authenticateClient
+	// verifies it); public clients rely on PKCE alone and have none to present.
+	if clientParams.ClientSecret.Valid {
+		tokenQuery.Set("client_secret", clientParams.ClientSecret.String)
+	}
 	postTokenUrl := fmt.Sprintf("http://%s/oauth/token", host)
 	resp, err = httpClient.PostForm(postTokenUrl, tokenQuery)
 	s.Require().NoError(err)

--- a/pkg/httpserver/introspection_revocation_test.go
+++ b/pkg/httpserver/introspection_revocation_test.go
@@ -258,26 +258,18 @@ func (s *OAuthFlowSuite) TestTokenIntrospectionMissingToken() {
 }
 
 func (s *OAuthFlowSuite) TestTokenRevocationAccessToken() {
-	// Create a confidential client for revocation
+	// Revocation now requires confidential-client authentication (RFC 7009 §2.1), and the
+	// server enforces that a client can only revoke tokens issued to itself. So the client
+	// that obtains the tokens and the client that revokes them must be the same confidential
+	// client (unlike introspection, which doesn't require token ownership).
 	clientSecret := s.mustGenerateRandomString(32)
-	revokeClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
 		ClientID:       s.mustGenerateRandomString(8),
 		ClientSecret:   sql.NullString{String: clientSecret, Valid: true},
 		Name:           s.mustGenerateRandomString(8),
 		RedirectUris:   []string{"http://localhost:8080/callback"},
 		AllowedScopes:  []string{"openid", "profile", "email"},
 		IsConfidential: true,
-		Audience:       "http://localhost:8000",
-	})
-
-	// Create a public client to obtain tokens
-	tokenClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
-		ClientID:       s.mustGenerateRandomString(8),
-		ClientSecret:   sql.NullString{String: "", Valid: false},
-		Name:           s.mustGenerateRandomString(8),
-		RedirectUris:   []string{"http://localhost:8080/callback"},
-		AllowedScopes:  []string{"openid", "profile", "email"},
-		IsConfidential: false,
 		Audience:       "http://localhost:8000",
 	})
 
@@ -289,13 +281,14 @@ func (s *OAuthFlowSuite) TestTokenRevocationAccessToken() {
 	)
 	scv := s.mustCreateStateAndCodeVerifier()
 
-	authCode := s.mustLoginAndConsent(user, tokenClient.ClientID, tokenClient.RedirectUris[0], "openid profile email", scv)
+	authCode := s.mustLoginAndConsent(user, client.ClientID, client.RedirectUris[0], "openid profile email", scv)
 
 	tokenValues := url.Values{
 		"grant_type":    {"authorization_code"},
 		"code":          {authCode},
-		"redirect_uri":  {tokenClient.RedirectUris[0]},
-		"client_id":     {tokenClient.ClientID},
+		"redirect_uri":  {client.RedirectUris[0]},
+		"client_id":     {client.ClientID},
+		"client_secret": {clientSecret},
 		"code_verifier": {scv.CodeVerifier},
 	}
 	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/token", tokenValues)
@@ -313,7 +306,7 @@ func (s *OAuthFlowSuite) TestTokenRevocationAccessToken() {
 	introspectValues := url.Values{
 		"token":           {tokenResponse.AccessToken},
 		"token_type_hint": {"access_token"},
-		"client_id":       {revokeClient.ClientID},
+		"client_id":       {client.ClientID},
 		"client_secret":   {clientSecret},
 	}
 	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/introspect", introspectValues)
@@ -328,11 +321,11 @@ func (s *OAuthFlowSuite) TestTokenRevocationAccessToken() {
 	s.Require().NoError(err)
 	s.True(introspectResponse["active"].(bool), "token should be active before revocation")
 
-	// Revoke the access token
+	// Revoke the access token, using the same client that the token was issued to
 	revokeValues := url.Values{
 		"token":           {tokenResponse.AccessToken},
 		"token_type_hint": {"access_token"},
-		"client_id":       {revokeClient.ClientID},
+		"client_id":       {client.ClientID},
 		"client_secret":   {clientSecret},
 	}
 	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/revoke", revokeValues)
@@ -353,12 +346,16 @@ func (s *OAuthFlowSuite) TestTokenRevocationAccessToken() {
 	s.False(introspectResponse["active"].(bool), "token should be inactive after revocation")
 }
 
-func (s *OAuthFlowSuite) TestTokenRevocationRefreshToken() {
-	// Create a confidential client for revocation
-	clientSecret := s.mustGenerateRandomString(32)
-	revokeClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+// TestTokenRevocationRejectsOtherClient verifies the RFC 7009 §2.1 ownership check: a
+// confidential client cannot revoke a token that was issued to a *different* client, even
+// though it authenticates successfully. The revoke call must still return 200 OK (per RFC
+// 7009, to avoid leaking token validity), but the token must remain active afterward.
+func (s *OAuthFlowSuite) TestTokenRevocationRejectsOtherClient() {
+	// The client that will obtain (and own) the tokens.
+	ownerSecret := s.mustGenerateRandomString(32)
+	ownerClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
 		ClientID:       s.mustGenerateRandomString(8),
-		ClientSecret:   sql.NullString{String: clientSecret, Valid: true},
+		ClientSecret:   sql.NullString{String: ownerSecret, Valid: true},
 		Name:           s.mustGenerateRandomString(8),
 		RedirectUris:   []string{"http://localhost:8080/callback"},
 		AllowedScopes:  []string{"openid", "profile", "email"},
@@ -366,14 +363,93 @@ func (s *OAuthFlowSuite) TestTokenRevocationRefreshToken() {
 		Audience:       "http://localhost:8000",
 	})
 
-	// Create a public client to obtain tokens
-	tokenClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+	// A different, unrelated confidential client that will attempt the revocation.
+	attackerSecret := s.mustGenerateRandomString(32)
+	attackerClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
 		ClientID:       s.mustGenerateRandomString(8),
-		ClientSecret:   sql.NullString{String: "", Valid: false},
+		ClientSecret:   sql.NullString{String: attackerSecret, Valid: true},
 		Name:           s.mustGenerateRandomString(8),
 		RedirectUris:   []string{"http://localhost:8080/callback"},
 		AllowedScopes:  []string{"openid", "profile", "email"},
-		IsConfidential: false,
+		IsConfidential: true,
+		Audience:       "http://localhost:8000",
+	})
+
+	user := s.mustRegisterUser(
+		s.mustGenerateRandomString(8),
+		s.mustGenerateRandomString(8),
+		fmt.Sprintf("%s@example.com", s.mustGenerateRandomString(8)),
+	)
+	scv := s.mustCreateStateAndCodeVerifier()
+
+	authCode := s.mustLoginAndConsent(user, ownerClient.ClientID, ownerClient.RedirectUris[0], "openid profile email", scv)
+
+	tokenValues := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {authCode},
+		"redirect_uri":  {ownerClient.RedirectUris[0]},
+		"client_id":     {ownerClient.ClientID},
+		"client_secret": {ownerSecret},
+		"code_verifier": {scv.CodeVerifier},
+	}
+	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/token", tokenValues)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Require().Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	var tokenResponse TokenResponse
+	err = json.Unmarshal(body, &tokenResponse)
+	s.Require().NoError(err)
+
+	// The attacker client attempts to revoke a token it does not own.
+	revokeValues := url.Values{
+		"token":           {tokenResponse.AccessToken},
+		"token_type_hint": {"access_token"},
+		"client_id":       {attackerClient.ClientID},
+		"client_secret":   {attackerSecret},
+	}
+	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/revoke", revokeValues)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	// RFC 7009 says revocation always returns 200, even when nothing was actually revoked.
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	// The token must still be active — the attacker's client must not have been able to
+	// revoke a token that belongs to a different client.
+	introspectValues := url.Values{
+		"token":           {tokenResponse.AccessToken},
+		"token_type_hint": {"access_token"},
+		"client_id":       {ownerClient.ClientID},
+		"client_secret":   {ownerSecret},
+	}
+	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/introspect", introspectValues)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	body, err = io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	var introspectResponse map[string]interface{}
+	err = json.Unmarshal(body, &introspectResponse)
+	s.Require().NoError(err)
+	s.True(introspectResponse["active"].(bool), "token must remain active after a non-owning client's revoke attempt")
+}
+
+func (s *OAuthFlowSuite) TestTokenRevocationRefreshToken() {
+	// Revocation now requires confidential-client authentication (RFC 7009 §2.1), and the
+	// server enforces that a client can only revoke tokens issued to itself. So the client
+	// that obtains the tokens and the client that revokes them must be the same confidential
+	// client (unlike introspection, which doesn't require token ownership).
+	clientSecret := s.mustGenerateRandomString(32)
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: clientSecret, Valid: true},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: true,
 		Audience:       "http://localhost:8000",
 	})
 
@@ -385,13 +461,14 @@ func (s *OAuthFlowSuite) TestTokenRevocationRefreshToken() {
 	)
 	scv := s.mustCreateStateAndCodeVerifier()
 
-	authCode := s.mustLoginAndConsent(user, tokenClient.ClientID, tokenClient.RedirectUris[0], "openid profile email", scv)
+	authCode := s.mustLoginAndConsent(user, client.ClientID, client.RedirectUris[0], "openid profile email", scv)
 
 	tokenValues := url.Values{
 		"grant_type":    {"authorization_code"},
 		"code":          {authCode},
-		"redirect_uri":  {tokenClient.RedirectUris[0]},
-		"client_id":     {tokenClient.ClientID},
+		"redirect_uri":  {client.RedirectUris[0]},
+		"client_id":     {client.ClientID},
+		"client_secret": {clientSecret},
 		"code_verifier": {scv.CodeVerifier},
 	}
 	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/token", tokenValues)
@@ -409,7 +486,7 @@ func (s *OAuthFlowSuite) TestTokenRevocationRefreshToken() {
 	introspectValues := url.Values{
 		"token":           {tokenResponse.RefreshToken},
 		"token_type_hint": {"refresh_token"},
-		"client_id":       {revokeClient.ClientID},
+		"client_id":       {client.ClientID},
 		"client_secret":   {clientSecret},
 	}
 	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/introspect", introspectValues)
@@ -424,11 +501,11 @@ func (s *OAuthFlowSuite) TestTokenRevocationRefreshToken() {
 	s.Require().NoError(err)
 	s.True(introspectResponse["active"].(bool), "refresh token should be active before revocation")
 
-	// Revoke the refresh token
+	// Revoke the refresh token, using the same client that the token was issued to
 	revokeValues := url.Values{
 		"token":           {tokenResponse.RefreshToken},
 		"token_type_hint": {"refresh_token"},
-		"client_id":       {revokeClient.ClientID},
+		"client_id":       {client.ClientID},
 		"client_secret":   {clientSecret},
 	}
 	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/revoke", revokeValues)

--- a/pkg/httpserver/oauth.go
+++ b/pkg/httpserver/oauth.go
@@ -555,10 +555,14 @@ func (s *Server) HandleIntrospect(w http.ResponseWriter, r *http.Request) {
 	token := r.FormValue("token")
 	tokenTypeHint := r.FormValue("token_type_hint")
 
-	// Authenticate the calling client
-	_, err := s.authenticateClient(r)
+	// Authenticate the calling client. Per RFC 7662 §2.1, the introspection endpoint MUST be
+	// protected against unauthorized callers, so we require a fully authenticated confidential
+	// client (client_id + client_secret) rather than the token endpoint's laxer public-client
+	// allowance.
+	_, err := s.authenticateConfidentialClient(r)
 	if err != nil {
-		s.writeIntrospectError(w, http.StatusUnauthorized, "invalid_client", "Invalid client credentials")
+		w.Header().Set("WWW-Authenticate", `Basic realm="oauth"`)
+		s.writeIntrospectError(w, http.StatusUnauthorized, "invalid_client", "Client authentication required")
 		return
 	}
 
@@ -701,10 +705,14 @@ func (s *Server) HandleOauthRevoke(w http.ResponseWriter, r *http.Request) {
 	token := r.FormValue("token")
 	tokenTypeHint := r.FormValue("token_type_hint")
 
-	// Authenticate the calling client
-	_, err := s.authenticateClient(r)
+	// Authenticate the calling client. Per RFC 7009 §2.1, the revocation endpoint MUST be
+	// protected against unauthorized callers, so we require a fully authenticated confidential
+	// client (client_id + client_secret) rather than the token endpoint's laxer public-client
+	// allowance.
+	client, err := s.authenticateConfidentialClient(r)
 	if err != nil {
-		s.writeRevokeError(w, http.StatusUnauthorized, "invalid_client", "Invalid client credentials")
+		w.Header().Set("WWW-Authenticate", `Basic realm="oauth"`)
+		s.writeRevokeError(w, http.StatusUnauthorized, "invalid_client", "Client authentication required")
 		return
 	}
 
@@ -714,34 +722,69 @@ func (s *Server) HandleOauthRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Per RFC 7009, the revocation endpoint should return 200 OK regardless of
-	// whether the token was found or already revoked. This prevents token enumeration.
-	// We attempt to revoke using both methods based on the hint.
+	// whether the token was found, already revoked, or belongs to another client.
+	// This prevents token enumeration. We attempt to revoke using both methods based on the
+	// hint, but per RFC 7009 §2.1 we only actually revoke a token that was issued to the
+	// authenticated client — this prevents one client from revoking another client's tokens.
 
 	if tokenTypeHint == "refresh_token" {
 		// Try refresh token first, then access token
-		s.datastore.Q.RevokeTokenByRefreshToken(r.Context(), sql.NullString{String: token, Valid: true})
-		s.revokeAccessToken(r.Context(), token)
+		s.revokeRefreshTokenIfOwnedByClient(r.Context(), token, client.ID)
+		s.revokeAccessTokenIfOwnedByClient(r.Context(), token, client.ID)
 	} else {
 		// Try access token first (default), then refresh token
-		s.revokeAccessToken(r.Context(), token)
-		s.datastore.Q.RevokeTokenByRefreshToken(r.Context(), sql.NullString{String: token, Valid: true})
+		s.revokeAccessTokenIfOwnedByClient(r.Context(), token, client.ID)
+		s.revokeRefreshTokenIfOwnedByClient(r.Context(), token, client.ID)
 	}
 
 	// Always return 200 OK per RFC 7009
 	w.WriteHeader(http.StatusOK)
 }
 
-// revokeAccessToken attempts to revoke an access token.
-// For JWTs, the token parameter should be the full JWT. We extract the JTI
-// (which is stored in the database) and revoke by that.
-func (s *Server) revokeAccessToken(ctx context.Context, token string) {
+// revokeAccessTokenIfOwnedByClient attempts to revoke an access token, but only if it was
+// issued to clientID. For JWTs, the token parameter should be the full JWT. We extract the
+// JTI (which is stored in the database) and look up/revoke by that; we also try the raw
+// token value in case it's stored differently. If the token isn't found, or belongs to a
+// different client, this is a silent no-op — the caller still returns 200 OK per RFC 7009.
+func (s *Server) revokeAccessTokenIfOwnedByClient(ctx context.Context, token string, clientID uuid.UUID) {
 	// Try to parse as JWT to extract JTI
-	jti := s.extractJTIFromToken(token)
-	if jti != "" {
-		s.datastore.Q.RevokeTokenByAccessToken(ctx, sql.NullString{String: jti, Valid: true})
+	if jti := s.extractJTIFromToken(token); jti != "" {
+		s.revokeAccessTokenByLookupIfOwned(ctx, jti, clientID)
 	}
 	// Also try revoking by the raw token value in case it's stored differently
-	s.datastore.Q.RevokeTokenByAccessToken(ctx, sql.NullString{String: token, Valid: true})
+	s.revokeAccessTokenByLookupIfOwned(ctx, token, clientID)
+}
+
+// revokeAccessTokenByLookupIfOwned looks up the token record by its stored access_token value
+// (which is the JTI for JWTs) and revokes it only if it belongs to clientID.
+func (s *Server) revokeAccessTokenByLookupIfOwned(ctx context.Context, accessToken string, clientID uuid.UUID) {
+	dbToken, err := s.datastore.Q.GetTokenByAccessToken(ctx, sql.NullString{String: accessToken, Valid: true})
+	if err != nil {
+		// Not found (or already revoked/expired) — nothing to do.
+		return
+	}
+	if dbToken.ClientID != clientID {
+		// Token belongs to a different client — do not reveal this to the caller, and do not
+		// revoke a token this client doesn't own (RFC 7009 §2.1).
+		return
+	}
+	s.datastore.Q.RevokeTokenByAccessToken(ctx, sql.NullString{String: accessToken, Valid: true})
+}
+
+// revokeRefreshTokenIfOwnedByClient looks up the refresh token and revokes it only if it
+// belongs to clientID. If the token isn't found, or belongs to a different client, this is a
+// silent no-op — the caller still returns 200 OK per RFC 7009.
+func (s *Server) revokeRefreshTokenIfOwnedByClient(ctx context.Context, token string, clientID uuid.UUID) {
+	dbToken, err := s.datastore.Q.GetTokenByRefreshToken(ctx, sql.NullString{String: token, Valid: true})
+	if err != nil {
+		// Not found (or already revoked) — nothing to do.
+		return
+	}
+	if dbToken.ClientID != clientID {
+		// Token belongs to a different client — do not revoke it (RFC 7009 §2.1).
+		return
+	}
+	s.datastore.Q.RevokeTokenByRefreshToken(ctx, sql.NullString{String: token, Valid: true})
 }
 
 // extractJTIFromToken extracts the JTI claim from a JWT without validating it.

--- a/pkg/httpserver/oidc_test.go
+++ b/pkg/httpserver/oidc_test.go
@@ -684,27 +684,18 @@ func (s *OAuthFlowSuite) TestUserInfoScopeGating() {
 // missing/revoked JTI row as "revocation tracking not enabled" and let the
 // request through.
 func (s *OAuthFlowSuite) TestUserInfoRejectsRevokedToken() {
-	// Confidential client used to call the revoke endpoint (RFC 7009 requires
-	// client authentication for revocation).
+	// Revocation requires confidential-client authentication (RFC 7009 §2.1), and the server
+	// enforces that a client can only revoke tokens issued to itself (RFC 7009 §2.1
+	// ownership check). So the same confidential client must both obtain and revoke the
+	// token here.
 	clientSecret := s.mustGenerateRandomString(32)
-	revokeClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+	result := s.mustCompleteOAuthFlow(db.CreateOAuthClientParams{
 		ClientID:       s.mustGenerateRandomString(8),
 		ClientSecret:   sql.NullString{String: clientSecret, Valid: true},
 		Name:           s.mustGenerateRandomString(8),
 		RedirectUris:   []string{"http://localhost:8080/callback"},
 		AllowedScopes:  []string{"openid", "profile", "email"},
 		IsConfidential: true,
-		Audience:       "http://localhost:8000",
-	})
-
-	// Complete OAuth flow to get an access token.
-	result := s.mustCompleteOAuthFlow(db.CreateOAuthClientParams{
-		ClientID:       s.mustGenerateRandomString(8),
-		ClientSecret:   sql.NullString{String: "", Valid: false},
-		Name:           s.mustGenerateRandomString(8),
-		RedirectUris:   []string{"http://localhost:8080/callback"},
-		AllowedScopes:  []string{"openid", "profile", "email"},
-		IsConfidential: false,
 		Audience:       "http://localhost:8000",
 	})
 	accessToken := result.TokenResponse.AccessToken
@@ -719,11 +710,11 @@ func (s *OAuthFlowSuite) TestUserInfoRejectsRevokedToken() {
 	resp.Body.Close()
 	s.Equal(http.StatusOK, resp.StatusCode, "userinfo should succeed before revocation")
 
-	// Revoke the access token.
+	// Revoke the access token, using the same client it was issued to.
 	revokeValues := url.Values{
 		"token":           {accessToken},
 		"token_type_hint": {"access_token"},
-		"client_id":       {revokeClient.ClientID},
+		"client_id":       {result.Client.ClientID},
 		"client_secret":   {clientSecret},
 	}
 	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/revoke", revokeValues)


### PR DESCRIPTION
## Issue 1: Introspection and revocation didn't require caller authentication

RFC 7662 §2.1 (introspection) and RFC 7009 §2.1 (revocation) require the calling client to authenticate itself. `authenticateClient` (`pkg/httpserver/credentials.go`) lets a client through with just a `client_id` when that client is registered as public/non-confidential — that's correct behavior for `/oauth/token`, which must keep supporting the authorization_code + PKCE flow for public clients (SPAs, mobile apps) that have no secret to present.

However, `HandleIntrospect` and `HandleOauthRevoke` (`pkg/httpserver/oauth.go`) were reusing `authenticateClient` unmodified, so anyone who knew (or guessed) a registered public `client_id` could call `/oauth/introspect` or `/oauth/revoke` with no secret at all — letting an attacker probe token validity or revoke tokens.

**Fix:** added `authenticateConfidentialClient` in `pkg/httpserver/credentials.go`, which calls `authenticateClient` and then rejects the result unless the client is confidential (i.e. it actually verified a secret). The rejection logic is factored into a small pure function, `requireConfidentialClient(client, err)`, so it can be unit tested without a database. `HandleIntrospect` and `HandleOauthRevoke` now call `authenticateConfidentialClient` instead of `authenticateClient`, and return `401` with a `WWW-Authenticate: Basic realm="oauth"` header on failure (previously only revoke's outer error path returned 401; introspect's was similarly upgraded).

**Why the token endpoint is unaffected:** `authenticateClient` itself, and `HandleOauthToken`/`HandleOauthRefresh`, are untouched — they still call `authenticateClient` directly, so public-client + PKCE flows keep working exactly as before.

## Issue 2: Revocation didn't verify token ownership

RFC 7009 §2.1 says the server SHOULD verify that a token was issued to the client requesting its revocation, to stop one client from revoking another client's tokens. `HandleOauthRevoke` previously revoked purely by token value, with no ownership check at all.

**Fix:** `HandleOauthRevoke` now looks up the token record (via `GetTokenByAccessToken` / `GetTokenByRefreshToken`, both of which return the token's `client_id`) before revoking, and compares it against the authenticated client's ID. If they don't match, revocation is silently skipped — but per RFC 7009 the endpoint still returns `200 OK` either way, to avoid leaking whether a token exists or is valid. See `revokeAccessTokenIfOwnedByClient` / `revokeRefreshTokenIfOwnedByClient` / `revokeAccessTokenByLookupIfOwned` in `pkg/httpserver/oauth.go`.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass (no integration tag).
- Added hermetic unit tests in `pkg/httpserver/credentials_test.go` for `requireConfidentialClient`: rejects a public client, allows a confidential client through unchanged, and propagates an upstream authentication error. These don't need a database, since `authenticateClient`'s DB lookup is out of scope for the pure decision function.
- **Integration tests touched** (all under the `integration` build tag, require Postgres, not run here): `pkg/httpserver/introspection_revocation_test.go` and `pkg/httpserver/oidc_test.go` previously revoked a token obtained by one client (often public, or a differently-named "revokeClient") using a *different* confidential client's credentials. That pattern used to work because there was no ownership check; with this fix it would silently no-op and those tests would start failing since the token would remain active. I updated `TestTokenRevocationAccessToken`, `TestTokenRevocationRefreshToken`, and `TestUserInfoRejectsRevokedToken` so the same confidential client both obtains and revokes the token (adding `client_secret` to the token exchange, and a small tweak to the shared `mustCompleteOAuthFlow` helper in `integration_common_test.go` to send `client_secret` when the client is confidential). I also added a new regression test, `TestTokenRevocationRejectsOtherClient`, which explicitly asserts that a different confidential client cannot revoke another client's token (still gets `200 OK`, but the token stays active).

## Caveats for reviewer

- `WWW-Authenticate: Basic realm="oauth"` is new to this codebase (no prior usage), added to match conventional OAuth2 401 semantics (RFC 6749 §5.2) — happy to adjust the realm string/scheme if there's a house convention.
- Introspection does **not** get an ownership check — only revocation does, per RFC 7009 §2.1's specific requirement; RFC 7662 has no equivalent requirement, and the existing introspection tests intentionally introspect tokens across clients.
- The integration test changes could not be executed locally (they need Postgres); I verified them by compiling with `-tags integration` (`go build`/`go vet` both clean) and by manually tracing the ownership-check logic against each test's client setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE