### PR TITLE
Fix: keep secrets out of logs, set cookie Secure correctly, add security headers

### DIFF
--- a/pkg/httpserver/account.go
+++ b/pkg/httpserver/account.go
@@ -597,6 +597,7 @@ func (s *Server) HandleDeactivateAccountPost(w http.ResponseWriter, r *http.Requ
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
+		Secure:   s.isSecureContext(),
 		SameSite: http.SameSiteLaxMode,
 	})
 

--- a/pkg/httpserver/logging.go
+++ b/pkg/httpserver/logging.go
@@ -1,0 +1,65 @@
+package httpserver
+
+import (
+	"log"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// sensitiveQueryParams lists query parameter names whose values must never be written
+// to logs. Password-reset and email-verification links carry single-use secret tokens
+// in a "token" query parameter (see password_reset.go's HandleForgotPasswordPost /
+// email_verification.go's sendVerificationEmail), so it is redacted before any request
+// is logged.
+var sensitiveQueryParams = []string{"token"}
+
+// requestLoggingMiddleware is a thin replacement for chi's middleware.Logger. chi's
+// default logger logs the full request URI -- including the raw query string --
+// verbatim, which would write single-use secret tokens straight into access logs (and
+// from there into any log aggregation/shipping downstream). This middleware logs the
+// same operationally useful fields (request ID, method, path, status, response size,
+// duration) but redacts sensitive query parameter values first.
+//
+// It does not change the token-in-URL design itself (that would be a bigger change);
+// it only keeps the token out of logs.
+func requestLoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+		defer func() {
+			reqID := middleware.GetReqID(r.Context())
+			log.Printf("[%s] %s %s -> %d %dB in %s",
+				reqID, r.Method, redactedRequestPath(r.URL), ww.Status(), ww.BytesWritten(), time.Since(start))
+		}()
+
+		next.ServeHTTP(ww, r)
+	})
+}
+
+// redactedRequestPath returns the request path and query string with the value of any
+// sensitive query parameter (see sensitiveQueryParams) replaced by "REDACTED". Requests
+// with no sensitive parameters are returned unmodified (aside from re-serialization via
+// url.Values.Encode, which reorders and re-escapes parameters but keeps the same query
+// keys/values) so the log stays useful for debugging non-sensitive flows.
+func redactedRequestPath(u *url.URL) string {
+	if u.RawQuery == "" {
+		return u.Path
+	}
+
+	q := u.Query()
+	redacted := false
+	for _, key := range sensitiveQueryParams {
+		if q.Has(key) {
+			q.Set(key, "REDACTED")
+			redacted = true
+		}
+	}
+	if !redacted {
+		return u.Path + "?" + u.RawQuery
+	}
+	return u.Path + "?" + q.Encode()
+}

--- a/pkg/httpserver/logging_test.go
+++ b/pkg/httpserver/logging_test.go
@@ -1,0 +1,109 @@
+package httpserver
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// TestRedactedRequestPath_RedactsToken is a regression test for secrets leaking into
+// access logs: password-reset and email-verification links pass their single-use
+// secret token as a "token" query parameter (see password_reset.go,
+// email_verification.go). The raw request logger must never write that value out.
+func TestRedactedRequestPath_RedactsToken(t *testing.T) {
+	const secretToken = "super-secret-single-use-token"
+
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantHas string // substring that must be present (redacted form)
+		wantNot string // substring that must NOT be present (the secret itself)
+	}{
+		{
+			name:    "reset-password token is redacted",
+			rawURL:  "/oauth/reset-password?token=" + secretToken,
+			wantHas: "token=REDACTED",
+			wantNot: secretToken,
+		},
+		{
+			name:    "verify-email token is redacted",
+			rawURL:  "/oauth/verify-email?token=" + secretToken,
+			wantHas: "token=REDACTED",
+			wantNot: secretToken,
+		},
+		{
+			name:    "token redacted alongside other params, which are preserved",
+			rawURL:  "/oauth/reset-password?foo=bar&token=" + secretToken,
+			wantHas: "foo=bar",
+			wantNot: secretToken,
+		},
+		{
+			name:    "no token param is left untouched",
+			rawURL:  "/oauth/login?client_id=abc&state=xyz",
+			wantHas: "client_id=abc",
+			wantNot: "REDACTED",
+		},
+		{
+			name:    "no query string at all",
+			rawURL:  "/health",
+			wantHas: "/health",
+			wantNot: "?",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, err := url.Parse(tt.rawURL)
+			if err != nil {
+				t.Fatalf("url.Parse: %v", err)
+			}
+			got := redactedRequestPath(u)
+			if tt.wantHas != "" && !strings.Contains(got, tt.wantHas) {
+				t.Errorf("redactedRequestPath(%q) = %q, want it to contain %q", tt.rawURL, got, tt.wantHas)
+			}
+			if strings.Contains(got, tt.wantNot) {
+				t.Errorf("redactedRequestPath(%q) = %q, must not contain %q", tt.rawURL, got, tt.wantNot)
+			}
+		})
+	}
+}
+
+// TestRequestLoggingMiddleware_DoesNotLogToken drives an actual request through the
+// middleware and asserts the secret token never appears in the emitted log line, while
+// the operationally useful fields (method, path, status) still do.
+func TestRequestLoggingMiddleware_DoesNotLogToken(t *testing.T) {
+	const secretToken = "super-secret-single-use-token"
+
+	var buf bytes.Buffer
+	oldFlags := log.Flags()
+	oldOutput := log.Writer()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(oldOutput)
+		log.SetFlags(oldFlags)
+	})
+
+	handler := requestLoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/reset-password?token="+secretToken, nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	logged := buf.String()
+	if strings.Contains(logged, secretToken) {
+		t.Fatalf("request log leaked the secret token: %q", logged)
+	}
+	if !strings.Contains(logged, "GET") || !strings.Contains(logged, "/oauth/reset-password") {
+		t.Errorf("request log is missing useful fields (method/path): %q", logged)
+	}
+	if !strings.Contains(logged, "200") {
+		t.Errorf("request log is missing the status code: %q", logged)
+	}
+}

--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -126,8 +126,6 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	codeChallengeMethod := r.FormValue("code_challenge_method")
 	nonce := r.FormValue("nonce")
 
-	log.Printf("[DEBUG] HandleLoginPost: username=%s, clientID=%s, redirectURI=%s", username, clientID, redirectURI)
-
 	// Extract OAuth parameters into a struct for reuse.
 	oauthParams := LoginPageData{
 		ClientID:            clientID,
@@ -140,7 +138,6 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	}
 	// Validate credentials - use the function that includes inactive users
 	// so we can handle deactivated users appropriately based on the login type
-	log.Printf("[DEBUG] HandleLoginPost: Validating credentials for user: %s", username)
 	user, err := s.validateCredentialsIncludingInactive(r.Context(), username, password)
 	if err != nil {
 		log.Printf("[DEBUG] HandleLoginPost: Credential validation failed: %v", err)
@@ -158,14 +155,14 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	// Check if user is deactivated and trying to use OAuth login
 	// Deactivated users can only log in directly (no client_id) to access account settings
 	if !user.IsActive && clientID != "" {
-		log.Printf("[DEBUG] HandleLoginPost: Deactivated user %s attempted OAuth login", username)
+		log.Printf("[DEBUG] HandleLoginPost: Deactivated user (ID: %v) attempted OAuth login", user.ID)
 		s.renderLoginError(w, http.StatusForbidden, ErrAccountDeactivated.Error(), oauthParams)
 		return
 	}
 
 	// Check if MFA is enabled for this user
 	if user.MfaEnabled {
-		log.Printf("[DEBUG] HandleLoginPost: MFA enabled for user %s, creating pending session", username)
+		log.Printf("[DEBUG] HandleLoginPost: MFA enabled for user (ID: %v), creating pending session", user.ID)
 		pendingID, err := s.createMFAPendingSession(r, user.ID, oauthParams)
 		if err != nil {
 			log.Printf("[ERROR] HandleLoginPost: Failed to create MFA pending session: %v", err)
@@ -185,7 +182,11 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 		s.renderLoginError(w, http.StatusInternalServerError, "An error occurred", oauthParams)
 		return
 	}
-	log.Printf("[DEBUG] HandleLoginPost: Session created successfully: %s", session.ID)
+	// Log only the user ID, never the session token itself: session.ID is the bearer
+	// value sent as the session_id cookie, so writing it to logs would let anyone with
+	// log access hijack the session (same class of issue as the reset/verification
+	// tokens -- see the request-logging middleware in logging.go).
+	log.Printf("[DEBUG] HandleLoginPost: Session created successfully for user ID: %v", user.ID)
 
 	// Update last login timestamp
 	if err := s.datastore.Q.UpdateUserLastLogin(r.Context(), user.ID); err != nil {
@@ -233,17 +234,16 @@ func (s *Server) renderLoginError(w http.ResponseWriter, statusCode int, errorMs
 }
 
 // setSessionCookie writes the authenticated session cookie. The Secure attribute is
-// enabled when the configured public address is HTTPS (production) and left off for
-// plain-HTTP local development.
+// enabled when the service is actually reached over HTTPS (production) and left off
+// for plain-HTTP local development; see Server.isSecureContext for how that's decided.
 func (s *Server) setSessionCookie(w http.ResponseWriter, session Session) {
-	isSecure := strings.HasPrefix(s.config.HTTPAddress, "https://") || strings.Contains(s.config.HTTPAddress, ":443")
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session_id",
 		Value:    session.ID,
 		Path:     "/",
 		Expires:  session.ExpiresAt,
 		HttpOnly: true,
-		Secure:   isSecure,
+		Secure:   s.isSecureContext(),
 		SameSite: http.SameSiteLaxMode,
 	})
 }

--- a/pkg/httpserver/login_test.go
+++ b/pkg/httpserver/login_test.go
@@ -107,3 +107,55 @@ func TestHandleLoginGet_NoRedirectURIStillRendersLocalError(t *testing.T) {
 		t.Fatalf("expected no Location header, got %q", loc)
 	}
 }
+
+// TestSetSessionCookie_SecureFlagFollowsIssuerScheme is a regression test: the
+// session cookie's Secure attribute used to be derived from
+// strings.HasPrefix(config.HTTPAddress, "https://"), but HTTPAddress is the local
+// listen address passed to http.Server.Addr (e.g. ":8000") -- never "https://..." --
+// so Secure could never be true even in production behind a TLS-terminating proxy.
+// It's now derived from the scheme of JWTIssuer, the service's public base URL.
+func TestSetSessionCookie_SecureFlagFollowsIssuerScheme(t *testing.T) {
+	tests := []struct {
+		name       string
+		httpAddr   string
+		jwtIssuer  string
+		wantSecure bool
+	}{
+		{
+			name:       "production: TLS-terminated behind proxy, listen addr is plain :port",
+			httpAddr:   ":8000",
+			jwtIssuer:  "https://identity.example.com",
+			wantSecure: true,
+		},
+		{
+			name:       "local dev over plain HTTP",
+			httpAddr:   ":8000",
+			jwtIssuer:  "http://localhost:8000",
+			wantSecure: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Server{config: &config.Config{
+				HTTPAddress: tt.httpAddr,
+				JWTIssuer:   tt.jwtIssuer,
+			}}
+
+			rec := httptest.NewRecorder()
+			s.setSessionCookie(rec, Session{ID: "some-session-id"})
+
+			cookies := rec.Result().Cookies()
+			if len(cookies) != 1 {
+				t.Fatalf("expected exactly one cookie, got %d", len(cookies))
+			}
+			if got := cookies[0].Secure; got != tt.wantSecure {
+				t.Errorf("session_id cookie Secure = %v, want %v (HTTPAddress=%q JWTIssuer=%q)",
+					got, tt.wantSecure, tt.httpAddr, tt.jwtIssuer)
+			}
+			if !cookies[0].HttpOnly {
+				t.Error("session_id cookie must remain HttpOnly")
+			}
+		})
+	}
+}

--- a/pkg/httpserver/routes.go
+++ b/pkg/httpserver/routes.go
@@ -206,6 +206,7 @@ func (s *Server) HandleLogout(w http.ResponseWriter, r *http.Request) {
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
+		Secure:   s.isSecureContext(),
 		SameSite: http.SameSiteLaxMode,
 	})
 

--- a/pkg/httpserver/security_headers.go
+++ b/pkg/httpserver/security_headers.go
@@ -1,0 +1,56 @@
+package httpserver
+
+import "net/http"
+
+// securityHeadersMiddleware sets baseline security headers on every response. This
+// matters most for the login and consent pages: an IdP's consent screen is the
+// classic clickjacking target (an attacker frames it in an invisible iframe and
+// tricks an already-authenticated user into approving a malicious client's consent
+// request), so framing is disabled outright.
+//
+// secure gates Strict-Transport-Security: it must only be sent when the service is
+// actually reached over HTTPS (see isSecureContext in server.go), because HSTS tells
+// the browser to refuse plain-HTTP connections to this host for the given duration --
+// sending it during local HTTP development would lock developers out of
+// http://localhost.
+func securityHeadersMiddleware(secure bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			h := w.Header()
+
+			// Belt-and-suspenders against clickjacking: X-Frame-Options for older
+			// browsers that don't understand CSP, frame-ancestors (the modern
+			// replacement) for the rest.
+			h.Set("X-Frame-Options", "DENY")
+
+			// frame-ancestors 'none' is the only directive in this CSP. The
+			// server-rendered templates include inline <script> blocks and inline
+			// event handlers (see templates/change-avatar.html,
+			// templates/register.html) with no nonce/hash scheme in place, so adding
+			// a script-src/style-src restriction today would either break those
+			// pages or require 'unsafe-inline' -- which provides little real
+			// protection anyway. Tightening the CSP further (nonces on the inline
+			// scripts, then a strict script-src) is a good follow-up, not bundled
+			// into this change.
+			h.Set("Content-Security-Policy", "frame-ancestors 'none'")
+
+			// Prevents browsers from MIME-sniffing responses away from the
+			// declared Content-Type (e.g. treating an upload as executable HTML/JS).
+			h.Set("X-Content-Type-Options", "nosniff")
+
+			// no-referrer avoids leaking this origin's URLs -- including
+			// password-reset and email-verification links that carry single-use
+			// tokens in the query string -- via the Referer header when a page
+			// links out to a third party.
+			h.Set("Referrer-Policy", "no-referrer")
+
+			if secure {
+				// 2 years, apply to subdomains. Only sent over HTTPS/behind TLS;
+				// see the `secure` parameter doc above.
+				h.Set("Strict-Transport-Security", "max-age=63072000; includeSubDomains")
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/httpserver/security_headers_test.go
+++ b/pkg/httpserver/security_headers_test.go
@@ -1,0 +1,95 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eswan18/identity/pkg/config"
+)
+
+// TestSecurityHeadersMiddleware_SetsBaselineHeaders verifies that every response gets
+// the clickjacking/MIME-sniffing/referrer protections regardless of the secure-context
+// signal, since these don't depend on TLS.
+func TestSecurityHeadersMiddleware_SetsBaselineHeaders(t *testing.T) {
+	handler := securityHeadersMiddleware(false)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/consent", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{"X-Frame-Options", "DENY"},
+		{"Content-Security-Policy", "frame-ancestors 'none'"},
+		{"X-Content-Type-Options", "nosniff"},
+		{"Referrer-Policy", "no-referrer"},
+	}
+	for _, tt := range tests {
+		if got := rec.Header().Get(tt.header); got != tt.want {
+			t.Errorf("header %s = %q, want %q", tt.header, got, tt.want)
+		}
+	}
+}
+
+// TestSecurityHeadersMiddleware_HSTSGatedOnSecureContext verifies that
+// Strict-Transport-Security is only sent when the caller says the service is being
+// served over HTTPS. Sending it unconditionally would be actively harmful in local
+// HTTP development: browsers would refuse plain-HTTP connections to that host for the
+// max-age duration.
+func TestSecurityHeadersMiddleware_HSTSGatedOnSecureContext(t *testing.T) {
+	newHandler := func(secure bool) http.Handler {
+		return securityHeadersMiddleware(secure)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	}
+
+	t.Run("insecure context omits HSTS", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		newHandler(false).ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("Strict-Transport-Security"); got != "" {
+			t.Errorf("Strict-Transport-Security = %q, want empty when not in a secure context", got)
+		}
+	})
+
+	t.Run("secure context sends HSTS", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		newHandler(true).ServeHTTP(rec, req)
+
+		if got := rec.Header().Get("Strict-Transport-Security"); got == "" {
+			t.Error("Strict-Transport-Security header missing when serving over HTTPS")
+		}
+	})
+}
+
+// TestIsSecureContext verifies the signal that gates both the session cookie's Secure
+// attribute and HSTS: it must be derived from the service's public issuer URL, never
+// from config.HTTPAddress (which is just the local listen address, e.g. ":8000", and
+// so would always look "insecure" even in production behind TLS -- that was the bug).
+func TestIsSecureContext(t *testing.T) {
+	tests := []struct {
+		name   string
+		issuer string
+		want   bool
+	}{
+		{"https issuer is secure", "https://identity.example.com", true},
+		{"http issuer is not secure", "http://localhost:8000", false},
+		{"issuer without scheme is not secure", "identity.example.com", false},
+		{"empty issuer is not secure", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{JWTIssuer: tt.issuer}
+			if got := isSecureContext(cfg); got != tt.want {
+				t.Errorf("isSecureContext(issuer=%q) = %v, want %v", tt.issuer, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/httpserver/server.go
+++ b/pkg/httpserver/server.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/eswan18/identity/pkg/avatar"
@@ -74,7 +75,17 @@ func New(config *config.Config, datastore *store.Store, emailSender email.Sender
 	// derived from the CF-Connecting-IP header in getClientIP, which
 	// Cloudflare guarantees to overwrite (unlike XFF/X-Real-IP, which anyone
 	// can set).
-	r.Use(middleware.Logger)
+	// Security headers apply to every response; HSTS within them is gated on
+	// isSecureContext so it is only ever sent when the service is actually reached
+	// over HTTPS (see isSecureContext for why config.HTTPAddress can't be used here).
+	r.Use(securityHeadersMiddleware(isSecureContext(config)))
+	// requestLoggingMiddleware replaces chi's middleware.Logger, which logs the raw
+	// RequestURI (including query string) verbatim. Password-reset and
+	// email-verification links carry single-use secret tokens in a "token" query
+	// parameter (see password_reset.go, email_verification.go); logging them verbatim
+	// would put those secrets in access logs. requestLoggingMiddleware logs the same
+	// method/path/status/duration fields but redacts sensitive query parameter values.
+	r.Use(requestLoggingMiddleware)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(60 * time.Second))
 
@@ -122,6 +133,25 @@ func New(config *config.Config, datastore *store.Store, emailSender email.Sender
 	return s
 }
 
+// isSecureContext reports whether the service is actually reached by clients over
+// HTTPS (e.g. behind a TLS-terminating reverse proxy in production). It is used to
+// gate anything that must never be sent/applied over plain HTTP: the session cookie's
+// Secure attribute and the Strict-Transport-Security header.
+//
+// config.HTTPAddress cannot be used for this: it is just the local listen address
+// passed to http.Server.Addr (e.g. ":8000"), so a prefix check like
+// strings.HasPrefix(cfg.HTTPAddress, "https://") is always false, even in production
+// behind TLS -- which is exactly the bug this fixes.
+//
+// config.JWTIssuer is the service's public base URL and is validated at startup to be
+// a well-formed http(s) URL (see config.validateIssuerURL), so its scheme reliably
+// reflects how the service is actually reached: "https://identity.example.com" in
+// production, "http://localhost:8000" in local dev. That makes it a reliable,
+// zero-new-config signal for "am I being served over HTTPS".
+func isSecureContext(cfg *config.Config) bool {
+	return strings.HasPrefix(cfg.JWTIssuer, "https://")
+}
+
 // IsListening checks if the server is listening on the configured address.
 func (s *Server) IsListening() bool {
 	if s.httpServer == nil {
@@ -156,6 +186,12 @@ func (s *Server) Close() error {
 		s.rateLimitStore.Stop()
 	}
 	return err
+}
+
+// isSecureContext reports whether this server instance is being served over HTTPS.
+// See the package-level isSecureContext function for the reasoning behind the signal.
+func (s *Server) isSecureContext() bool {
+	return isSecureContext(s.config)
 }
 
 // ResetRateLimits clears all rate limiters (useful for testing)


### PR DESCRIPTION
## Summary

Three hardening fixes, kept as separate concerns but bundled since they touch the same request pipeline:

### 1. Secrets ending up in access logs
- `middleware.Logger` (chi) logged the full request URI **including the query string**. Password-reset (`/oauth/reset-password?token=...`) and email-verification (`/oauth/verify-email?token=...`) links carry single-use secret tokens in that query string, so they were being written straight into logs.
- `login.go` separately logged the raw session ID via `log.Printf("... Session created successfully: %s", session.ID)` — the session cookie's bearer value, in plaintext, in logs.
- **Fix:** replaced `middleware.Logger` with a small custom `requestLoggingMiddleware` (`pkg/httpserver/logging.go`) that logs the same operationally useful fields (request ID, method, path, status, response size, duration) but redacts the `token` query parameter's value before it's ever written out. Request-ID logging is preserved (`middleware.GetReqID`). Removed the session-ID log line and the `[DEBUG]` lines in `login.go` that printed raw usernames, replacing them with non-sensitive user-ID logging. Did **not** change the token-in-URL design itself — just kept it out of logs.

### 2. Session cookie `Secure` flag could never be true in production
- `setSessionCookie` derived `Secure` from `strings.HasPrefix(config.HTTPAddress, "https://")`. `HTTPAddress` is just the local listen address passed to `http.Server.Addr` (e.g. `:8000`) — never `"https://..."` — so `Secure` was **always false**, even in production behind a TLS-terminating proxy (Cloudflare Tunnel, per the comments already in `server.go`).
- **Fix:** introduced `isSecureContext(cfg *config.Config) bool` in `server.go`, which checks whether `config.JWTIssuer` (the service's public base URL, already required and validated as a well-formed `http(s)` URL at startup — see `config.validateIssuerURL`) starts with `https://`. No new config flag needed: `JWT_ISSUER=https://identity.example.com` in production naturally yields `Secure: true`; `JWT_ISSUER=http://localhost:8000` in local dev naturally yields `Secure: false`. Applied consistently to all three `session_id` cookie sites: `login.go` (`setSessionCookie`), logout (`routes.go`), and deactivate-account (`account.go`) — the latter two were clearing the cookie without a `Secure` attribute at all.

### 3. No security headers
- Added `securityHeadersMiddleware` (`pkg/httpserver/security_headers.go`), applied to every response:
  - `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'` — defends the login/consent pages against clickjacking (the classic attack against an IdP's consent screen).
  - `X-Content-Type-Options: nosniff`
  - `Referrer-Policy: no-referrer` — also keeps token-bearing URLs out of the `Referer` header.
  - `Strict-Transport-Security: max-age=63072000; includeSubDomains` — gated on the same `isSecureContext` signal as the cookie fix, so it's never sent in local HTTP dev (sending HSTS over plain HTTP would lock developers out of `http://localhost`).
- **CSP scope:** deliberately limited to `frame-ancestors 'none'` only. `templates/change-avatar.html` and `templates/register.html` use inline `<script>` blocks and an inline `onchange` handler, with no nonce/hash scheme in place — a `script-src`/`style-src` restriction would break those pages today (or require `'unsafe-inline'`, which provides little real protection). Tightening the CSP further (adding nonces to the inline scripts, then a strict `script-src`) is a good follow-up, not bundled into this change.

## Testing
- `go build ./...`, `go vet ./...` — clean.
- `go test ./...` — all passing (integration tests, which need Postgres, were not run — they're gated behind `//go:build integration` and are skipped by the default `go test ./...`).
- Added hermetic tests:
  - `pkg/httpserver/security_headers_test.go` — asserts the baseline headers are set and that HSTS is gated on the secure-context signal, plus `isSecureContext` scheme-detection cases.
  - `pkg/httpserver/logging_test.go` — asserts a secret token in the query string never appears in the emitted log line (both at the redaction-function level and end-to-end through the middleware), while method/path/status are still logged.
  - `pkg/httpserver/login_test.go` — new `TestSetSessionCookie_SecureFlagFollowsIssuerScheme` regression test covering the exact production-vs-dev scenario that motivated the fix.

## Caveats for reviewer
- No new environment variable was introduced; the `Secure`/HSTS signal reuses `JWT_ISSUER`, which is already required in all environments. If there's ever a deployment where the public URL is HTTPS but `JWT_ISSUER` is intentionally set to something else, this signal would need revisiting — didn't find such a case in this codebase.
- CSP is intentionally conservative (see above) to avoid breaking `change-avatar.html`/`register.html`; a stricter `script-src` is a follow-up, not included here.
- Diff is scoped to these three issues only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE