### PR TITLE
Add CSRF protection to browser forms and fix cookie Secure flag

### DIFF
--- a/pkg/httpserver/account.go
+++ b/pkg/httpserver/account.go
@@ -77,7 +77,7 @@ func (s *Server) HandleAccountSettingsGet(w http.ResponseWriter, r *http.Request
 	}
 	displayName := strings.Join(nameParts, " ")
 
-	s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+	s.renderAccountSettings(w, r, AccountSettingsPageData{
 		Username:      user.Username,
 		Email:         user.Email,
 		Name:          displayName,
@@ -104,7 +104,7 @@ func (s *Server) HandleChangePasswordGet(w http.ResponseWriter, r *http.Request)
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
-	s.changePasswordTemplate.Execute(w, ChangePasswordPageData{})
+	s.changePasswordTemplate.Execute(w, ChangePasswordPageData{CSRFToken: s.ensureCSRFToken(w, r)})
 }
 
 // HandleChangePasswordPost godoc
@@ -133,19 +133,19 @@ func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request
 
 	// Validate that all fields are provided
 	if currentPassword == "" || newPassword == "" || confirmPassword == "" {
-		s.renderChangePasswordError(w, http.StatusBadRequest, "All password fields are required")
+		s.renderChangePasswordError(w, r, http.StatusBadRequest, "All password fields are required")
 		return
 	}
 
 	// Validate that new password and confirm password match
 	if newPassword != confirmPassword {
-		s.renderChangePasswordError(w, http.StatusBadRequest, "New passwords do not match")
+		s.renderChangePasswordError(w, r, http.StatusBadRequest, "New passwords do not match")
 		return
 	}
 
 	// Validate new password requirements
 	if err := auth.ValidatePassword(newPassword, user.Username); err != nil {
-		s.renderChangePasswordError(w, http.StatusBadRequest, err.Error())
+		s.renderChangePasswordError(w, r, http.StatusBadRequest, err.Error())
 		return
 	}
 
@@ -153,11 +153,11 @@ func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request
 	valid, err := auth.VerifyPassword(currentPassword, user.PasswordHash)
 	if err != nil {
 		log.Printf("[ERROR] HandleChangePasswordPost: Failed to verify password: %v", err)
-		s.renderChangePasswordError(w, http.StatusInternalServerError, "An error occurred")
+		s.renderChangePasswordError(w, r, http.StatusInternalServerError, "An error occurred")
 		return
 	}
 	if !valid {
-		s.renderChangePasswordError(w, http.StatusUnauthorized, "Current password is incorrect")
+		s.renderChangePasswordError(w, r, http.StatusUnauthorized, "Current password is incorrect")
 		return
 	}
 
@@ -165,7 +165,7 @@ func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request
 	newPasswordHash, err := auth.HashPassword(newPassword)
 	if err != nil {
 		log.Printf("[ERROR] HandleChangePasswordPost: Failed to hash new password: %v", err)
-		s.renderChangePasswordError(w, http.StatusInternalServerError, "An error occurred")
+		s.renderChangePasswordError(w, r, http.StatusInternalServerError, "An error occurred")
 		return
 	}
 
@@ -176,7 +176,7 @@ func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request
 	})
 	if err != nil {
 		log.Printf("[ERROR] HandleChangePasswordPost: Failed to update password: %v", err)
-		s.renderChangePasswordError(w, http.StatusInternalServerError, "An error occurred")
+		s.renderChangePasswordError(w, r, http.StatusInternalServerError, "An error occurred")
 		return
 	}
 
@@ -197,12 +197,16 @@ func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request
 
 	// Clear the now-invalid session cookie and send the user back to login,
 	// mirroring HandleDeactivateAccountPost's redirect-to-login pattern.
+	// Secure mirrors isSecureContext, consistent with setSessionCookie and the
+	// other session-clearing cookies (logout, deactivate) so the flag is never
+	// dropped when the service is served over HTTPS.
 	http.SetCookie(w, &http.Cookie{
 		Name:     "session_id",
 		Value:    "",
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
+		Secure:   s.isSecureContext(),
 		SameSite: http.SameSiteLaxMode,
 	})
 	http.Redirect(w, r, "/oauth/login?password_changed=true", http.StatusFound)
@@ -222,7 +226,7 @@ func (s *Server) HandleChangeUsernameGet(w http.ResponseWriter, r *http.Request)
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
-	s.changeUsernameTemplate.Execute(w, ChangeUsernamePageData{CurrentUsername: user.Username})
+	s.changeUsernameTemplate.Execute(w, ChangeUsernamePageData{CurrentUsername: user.Username, CSRFToken: s.ensureCSRFToken(w, r)})
 }
 
 // HandleChangeUsernamePost godoc
@@ -247,7 +251,7 @@ func (s *Server) HandleChangeUsernamePost(w http.ResponseWriter, r *http.Request
 	newUsername := r.FormValue("new_username")
 	password := r.FormValue("password")
 
-	pageData := ChangeUsernamePageData{CurrentUsername: user.Username}
+	pageData := ChangeUsernamePageData{CurrentUsername: user.Username, CSRFToken: s.ensureCSRFToken(w, r)}
 
 	// Validate that all fields are provided
 	if newUsername == "" || password == "" {
@@ -299,6 +303,7 @@ func (s *Server) HandleChangeUsernamePost(w http.ResponseWriter, r *http.Request
 	s.changeUsernameTemplate.Execute(w, ChangeUsernamePageData{
 		Success:         "Username updated successfully",
 		CurrentUsername: newUsername,
+		CSRFToken:       s.ensureCSRFToken(w, r),
 	})
 }
 
@@ -316,7 +321,7 @@ func (s *Server) HandleChangeEmailGet(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
-	s.changeEmailTemplate.Execute(w, ChangeEmailPageData{CurrentEmail: user.Email})
+	s.changeEmailTemplate.Execute(w, ChangeEmailPageData{CurrentEmail: user.Email, CSRFToken: s.ensureCSRFToken(w, r)})
 }
 
 // HandleChangeEmailPost godoc
@@ -341,7 +346,7 @@ func (s *Server) HandleChangeEmailPost(w http.ResponseWriter, r *http.Request) {
 	newEmail := r.FormValue("new_email")
 	password := r.FormValue("password")
 
-	pageData := ChangeEmailPageData{CurrentEmail: user.Email}
+	pageData := ChangeEmailPageData{CurrentEmail: user.Email, CSRFToken: s.ensureCSRFToken(w, r)}
 
 	// Validate that all fields are provided
 	if newEmail == "" || password == "" {
@@ -402,6 +407,7 @@ func (s *Server) HandleChangeEmailPost(w http.ResponseWriter, r *http.Request) {
 	s.changeEmailTemplate.Execute(w, ChangeEmailPageData{
 		Success:      "Email updated successfully. Please check your new email address for a verification link.",
 		CurrentEmail: newEmail,
+		CSRFToken:    s.ensureCSRFToken(w, r),
 	})
 }
 
@@ -422,6 +428,7 @@ func (s *Server) HandleEditProfileGet(w http.ResponseWriter, r *http.Request) {
 	s.editProfileTemplate.Execute(w, EditProfilePageData{
 		GivenName:  user.GivenName.String,
 		FamilyName: user.FamilyName.String,
+		CSRFToken:  s.ensureCSRFToken(w, r),
 	})
 }
 
@@ -458,6 +465,7 @@ func (s *Server) HandleEditProfilePost(w http.ResponseWriter, r *http.Request) {
 			Error:      "An error occurred",
 			GivenName:  givenName,
 			FamilyName: familyName,
+			CSRFToken:  s.ensureCSRFToken(w, r),
 		})
 		return
 	}
@@ -467,6 +475,7 @@ func (s *Server) HandleEditProfilePost(w http.ResponseWriter, r *http.Request) {
 		Success:    "Profile updated successfully",
 		GivenName:  givenName,
 		FamilyName: familyName,
+		CSRFToken:  s.ensureCSRFToken(w, r),
 	})
 }
 
@@ -479,9 +488,30 @@ func toNullString(s string) sql.NullString {
 }
 
 // renderChangePasswordError renders the change password page with an error message
-func (s *Server) renderChangePasswordError(w http.ResponseWriter, statusCode int, errorMsg string) {
+func (s *Server) renderChangePasswordError(w http.ResponseWriter, r *http.Request, statusCode int, errorMsg string) {
+	csrfToken := s.ensureCSRFToken(w, r)
 	w.WriteHeader(statusCode)
-	s.changePasswordTemplate.Execute(w, ChangePasswordPageData{Error: errorMsg})
+	s.changePasswordTemplate.Execute(w, ChangePasswordPageData{Error: errorMsg, CSRFToken: csrfToken})
+}
+
+// renderAccountSettings renders the account settings page, injecting the CSRF token
+// into the page data so every form on it (deactivate/reactivate/logout/mfa-disable/
+// resend-verification) submits a valid token. Centralizing this keeps the token
+// consistent across the many render sites in the account handlers.
+func (s *Server) renderAccountSettings(w http.ResponseWriter, r *http.Request, data AccountSettingsPageData) {
+	data.CSRFToken = s.ensureCSRFToken(w, r)
+	if err := s.accountSettingsTemplate.Execute(w, data); err != nil {
+		log.Printf("[ERROR] renderAccountSettings: Failed to render account settings page: %v", err)
+	}
+}
+
+// renderChangeAvatar renders the change avatar page, injecting the CSRF token so the
+// upload and delete-avatar forms both submit a valid token.
+func (s *Server) renderChangeAvatar(w http.ResponseWriter, r *http.Request, data ChangeAvatarPageData) {
+	data.CSRFToken = s.ensureCSRFToken(w, r)
+	if err := s.changeAvatarTemplate.Execute(w, data); err != nil {
+		log.Printf("[ERROR] renderChangeAvatar: Failed to render change avatar page: %v", err)
+	}
 }
 
 // getUserFromSession retrieves the authenticated user from the session cookie.
@@ -535,7 +565,7 @@ func (s *Server) HandleDeactivateAccountPost(w http.ResponseWriter, r *http.Requ
 
 	// Validate that password is provided
 	if password == "" {
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username: user.Username,
 			Email:    user.Email,
 			Error:    "Password is required to deactivate your account",
@@ -547,7 +577,7 @@ func (s *Server) HandleDeactivateAccountPost(w http.ResponseWriter, r *http.Requ
 	valid, err := auth.VerifyPassword(password, user.PasswordHash)
 	if err != nil {
 		log.Printf("[ERROR] HandleDeactivateAccountPost: Failed to verify password: %v", err)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username: user.Username,
 			Email:    user.Email,
 			Error:    "An error occurred",
@@ -556,7 +586,7 @@ func (s *Server) HandleDeactivateAccountPost(w http.ResponseWriter, r *http.Requ
 	}
 	if !valid {
 		w.WriteHeader(http.StatusUnauthorized)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username: user.Username,
 			Email:    user.Email,
 			Error:    "Password is incorrect",
@@ -568,7 +598,7 @@ func (s *Server) HandleDeactivateAccountPost(w http.ResponseWriter, r *http.Requ
 	err = s.datastore.Q.DeactivateUser(r.Context(), user.ID)
 	if err != nil {
 		log.Printf("[ERROR] HandleDeactivateAccountPost: Failed to deactivate user: %v", err)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username: user.Username,
 			Email:    user.Email,
 			Error:    "An error occurred while deactivating your account",
@@ -627,7 +657,7 @@ func (s *Server) HandleReactivateAccountPost(w http.ResponseWriter, r *http.Requ
 
 	// Validate that password is provided
 	if password == "" {
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			IsInactive: !user.IsActive,
@@ -640,7 +670,7 @@ func (s *Server) HandleReactivateAccountPost(w http.ResponseWriter, r *http.Requ
 	valid, err := auth.VerifyPassword(password, user.PasswordHash)
 	if err != nil {
 		log.Printf("[ERROR] HandleReactivateAccountPost: Failed to verify password: %v", err)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			IsInactive: !user.IsActive,
@@ -650,7 +680,7 @@ func (s *Server) HandleReactivateAccountPost(w http.ResponseWriter, r *http.Requ
 	}
 	if !valid {
 		w.WriteHeader(http.StatusUnauthorized)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			IsInactive: !user.IsActive,
@@ -663,7 +693,7 @@ func (s *Server) HandleReactivateAccountPost(w http.ResponseWriter, r *http.Requ
 	err = s.datastore.Q.ReactivateUser(r.Context(), user.ID)
 	if err != nil {
 		log.Printf("[ERROR] HandleReactivateAccountPost: Failed to reactivate user: %v", err)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			IsInactive: !user.IsActive,
@@ -698,7 +728,7 @@ func (s *Server) HandleChangeAvatarGet(w http.ResponseWriter, r *http.Request) {
 		success = "Avatar removed successfully."
 	}
 
-	s.changeAvatarTemplate.Execute(w, ChangeAvatarPageData{
+	s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 		Success:   success,
 		AvatarURL: user.Picture.String,
 	})
@@ -724,7 +754,7 @@ func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) 
 
 	// Parse multipart form with max file size
 	if err := r.ParseMultipartForm(avatar.MaxAvatarSize); err != nil {
-		s.changeAvatarTemplate.Execute(w, ChangeAvatarPageData{
+		s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 			Error:     "File too large. Maximum size is 5MB.",
 			AvatarURL: user.Picture.String,
 		})
@@ -733,7 +763,7 @@ func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) 
 
 	file, header, err := r.FormFile("avatar")
 	if err != nil {
-		s.changeAvatarTemplate.Execute(w, ChangeAvatarPageData{
+		s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 			Error:     "Please select a file to upload.",
 			AvatarURL: user.Picture.String,
 		})
@@ -752,14 +782,14 @@ func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		// Check if it's a validation error
 		if validationErr, ok := err.(*avatar.ValidationError); ok {
-			s.changeAvatarTemplate.Execute(w, ChangeAvatarPageData{
+			s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 				Error:     validationErr.Message,
 				AvatarURL: user.Picture.String,
 			})
 			return
 		}
 		log.Printf("[ERROR] HandleChangeAvatarPost: Failed to upload avatar: %v", err)
-		s.changeAvatarTemplate.Execute(w, ChangeAvatarPageData{
+		s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 			Error:     "Failed to upload avatar. Please try again.",
 			AvatarURL: user.Picture.String,
 		})
@@ -779,7 +809,7 @@ func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) 
 		if deleteErr := s.avatarService.Delete(r.Context(), avatarURL); deleteErr != nil {
 			log.Printf("[WARN] HandleChangeAvatarPost: Failed to rollback uploaded avatar: %v", deleteErr)
 		}
-		s.changeAvatarTemplate.Execute(w, ChangeAvatarPageData{
+		s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 			Error:     "Failed to save avatar. Please try again.",
 			AvatarURL: user.Picture.String,
 		})
@@ -787,7 +817,7 @@ func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) 
 	}
 
 	log.Printf("[DEBUG] HandleChangeAvatarPost: Avatar updated for user %s", user.Username)
-	s.changeAvatarTemplate.Execute(w, ChangeAvatarPageData{
+	s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 		Success:   "Avatar updated successfully.",
 		AvatarURL: avatarURL,
 	})
@@ -823,7 +853,7 @@ func (s *Server) HandleDeleteAvatarPost(w http.ResponseWriter, r *http.Request) 
 		ID:      user.ID,
 	}); err != nil {
 		log.Printf("[ERROR] HandleDeleteAvatarPost: Failed to clear user picture: %v", err)
-		s.changeAvatarTemplate.Execute(w, ChangeAvatarPageData{
+		s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 			Error:     "Failed to remove avatar. Please try again.",
 			AvatarURL: user.Picture.String,
 		})

--- a/pkg/httpserver/admin_test.go
+++ b/pkg/httpserver/admin_test.go
@@ -94,7 +94,7 @@ func (s *OAuthFlowSuite) TestAdminCreateUser_WithClientCredentials() {
 		"code_challenge":        {scv.CodeChallenge},
 		"code_challenge_method": {scv.CodeChallengeMethod},
 	}
-	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/login", loginValues)
+	resp, err = csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/login", loginValues)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 	s.Equal(http.StatusFound, resp.StatusCode, "user should be able to login with created credentials")

--- a/pkg/httpserver/authorize_consent_test.go
+++ b/pkg/httpserver/authorize_consent_test.go
@@ -49,7 +49,7 @@ func (s *OAuthFlowSuite) TestSuccessPageRendersWhenAuthenticated() {
 	}
 
 	// Login to establish a session
-	resp, err := httpClient.PostForm("http://localhost:8080/oauth/login", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/login", url.Values{
 		"username": {username},
 		"password": {password},
 	})
@@ -270,7 +270,7 @@ func (s *OAuthFlowSuite) TestConsentApproveGeneratesCode() {
 	scv := s.mustCreateStateAndCodeVerifier()
 
 	// POST consent approval
-	resp, err := httpClient.PostForm("http://localhost:8080/oauth/consent", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/consent", url.Values{
 		"decision":              {"allow"},
 		"client_id":             {client.ClientID},
 		"redirect_uri":          {"http://localhost:8080/callback"},
@@ -304,7 +304,7 @@ func (s *OAuthFlowSuite) TestConsentDenyRedirectsWithError() {
 	scv := s.mustCreateStateAndCodeVerifier()
 
 	// POST consent denial
-	resp, err := httpClient.PostForm("http://localhost:8080/oauth/consent", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/consent", url.Values{
 		"decision":              {"deny"},
 		"client_id":             {client.ClientID},
 		"redirect_uri":          {"http://localhost:8080/callback"},
@@ -338,7 +338,7 @@ func (s *OAuthFlowSuite) TestConsentRemembered() {
 	scv := s.mustCreateStateAndCodeVerifier()
 
 	// First: approve consent
-	resp, err := httpClient.PostForm("http://localhost:8080/oauth/consent", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/consent", url.Values{
 		"decision":              {"allow"},
 		"client_id":             {client.ClientID},
 		"redirect_uri":          {"http://localhost:8080/callback"},
@@ -387,7 +387,7 @@ func (s *OAuthFlowSuite) TestConsentRePromptedForNewScopes() {
 	scv := s.mustCreateStateAndCodeVerifier()
 
 	// First: approve consent for openid only
-	resp, err := httpClient.PostForm("http://localhost:8080/oauth/consent", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/consent", url.Values{
 		"decision":              {"allow"},
 		"client_id":             {client.ClientID},
 		"redirect_uri":          {"http://localhost:8080/callback"},
@@ -424,7 +424,7 @@ func (s *OAuthFlowSuite) TestConsentRePromptedForNewScopes() {
 }
 
 func (s *OAuthFlowSuite) TestLogoutRedirectsToLoginByDefault() {
-	resp, err := s.httpClient.Post("http://localhost:8080/oauth/logout", "", nil)
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/logout", nil)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 
@@ -444,9 +444,9 @@ func (s *OAuthFlowSuite) TestLogoutWithValidPostLogoutRedirectURI() {
 	})
 
 	// Logout with a valid post_logout_redirect_uri and client_id
-	resp, err := s.httpClient.Post(
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, 
 		"http://localhost:8080/oauth/logout?post_logout_redirect_uri=http://example.com/callback&client_id="+client.ClientID,
-		"", nil,
+		nil,
 	)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
@@ -467,9 +467,9 @@ func (s *OAuthFlowSuite) TestLogoutRejectsUnregisteredPostLogoutRedirectURI() {
 	})
 
 	// Logout with a redirect URI that is NOT in the client's registered URIs
-	resp, err := s.httpClient.Post(
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, 
 		"http://localhost:8080/oauth/logout?post_logout_redirect_uri=https://evil.com/phishing&client_id=logout-reject-client",
-		"", nil,
+		nil,
 	)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
@@ -481,9 +481,9 @@ func (s *OAuthFlowSuite) TestLogoutRejectsUnregisteredPostLogoutRedirectURI() {
 
 func (s *OAuthFlowSuite) TestLogoutRejectsPostLogoutRedirectURIWithUnknownClientID() {
 	// Providing a client_id that doesn't exist should fall back to login
-	resp, err := s.httpClient.Post(
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, 
 		"http://localhost:8080/oauth/logout?post_logout_redirect_uri=http://example.com/callback&client_id=nonexistent-client",
-		"", nil,
+		nil,
 	)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
@@ -494,9 +494,9 @@ func (s *OAuthFlowSuite) TestLogoutRejectsPostLogoutRedirectURIWithUnknownClient
 
 func (s *OAuthFlowSuite) TestLogoutRejectsPostLogoutRedirectURIWithoutClientID() {
 	// Providing post_logout_redirect_uri without client_id should fall back to login
-	resp, err := s.httpClient.Post(
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, 
 		"http://localhost:8080/oauth/logout?post_logout_redirect_uri=http://example.com/callback",
-		"", nil,
+		nil,
 	)
 	s.Require().NoError(err)
 	defer resp.Body.Close()

--- a/pkg/httpserver/avatar_integration_test.go
+++ b/pkg/httpserver/avatar_integration_test.go
@@ -159,11 +159,18 @@ func (s *AvatarFlowSuite) loginAndGetClient(user db.AuthUser, password string) *
 		},
 	}
 
-	// Post to login form
+	// Seed the CSRF token/cookie from the login page (double-submit). The cookie has
+	// Path=/ and stays in the jar, so every later request from this client (including
+	// the multipart avatar uploads and the delete-avatar POST) carries it; those
+	// requests only need to add the matching csrf_token form field.
 	loginURL := "http://localhost:8081/oauth/login"
+	csrfToken, _ := fetchCSRFToken(s.T(), client, loginURL)
+
+	// Post to login form
 	form := url.Values{}
 	form.Set("username", user.Username)
 	form.Set("password", password)
+	form.Set("csrf_token", csrfToken)
 	resp, err := client.PostForm(loginURL, form)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
@@ -172,6 +179,21 @@ func (s *AvatarFlowSuite) loginAndGetClient(user db.AuthUser, password string) *
 	s.Require().Equal(http.StatusFound, resp.StatusCode)
 
 	return client
+}
+
+// csrfTokenFromJar returns the csrf_token cookie value currently held in the client's
+// cookie jar (seeded by loginAndGetClient). Used to populate the csrf_token field on
+// multipart avatar uploads, where the cookie itself is sent automatically by the jar.
+func (s *AvatarFlowSuite) csrfTokenFromJar(client *http.Client) string {
+	u, err := url.Parse("http://localhost:8081/")
+	s.Require().NoError(err)
+	for _, c := range client.Jar.Cookies(u) {
+		if c.Name == csrfCookieName {
+			return c.Value
+		}
+	}
+	s.Require().FailNow("no csrf_token cookie present in jar")
+	return ""
 }
 
 func (s *AvatarFlowSuite) TestAvatarUpload() {
@@ -192,6 +214,7 @@ func (s *AvatarFlowSuite) TestAvatarUpload() {
 	s.Require().NoError(err)
 	_, err = io.Copy(part, bytes.NewReader(imgData))
 	s.Require().NoError(err)
+	s.Require().NoError(writer.WriteField("csrf_token", s.csrfTokenFromJar(client)))
 	s.Require().NoError(writer.Close())
 
 	// POST to change-avatar
@@ -231,6 +254,7 @@ func (s *AvatarFlowSuite) TestAvatarUploadOversizedFile() {
 	s.Require().NoError(err)
 	_, err = io.Copy(part, bytes.NewReader(largeData))
 	s.Require().NoError(err)
+	s.Require().NoError(writer.WriteField("csrf_token", s.csrfTokenFromJar(client)))
 	s.Require().NoError(writer.Close())
 
 	// POST to change-avatar
@@ -267,6 +291,7 @@ func (s *AvatarFlowSuite) TestAvatarUploadInvalidFileType() {
 	s.Require().NoError(err)
 	_, err = io.Copy(part, bytes.NewReader(textData))
 	s.Require().NoError(err)
+	s.Require().NoError(writer.WriteField("csrf_token", s.csrfTokenFromJar(client)))
 	s.Require().NoError(writer.Close())
 
 	// POST to change-avatar
@@ -306,6 +331,7 @@ func (s *AvatarFlowSuite) TestAvatarUpdate() {
 	s.Require().NoError(err)
 	_, err = io.Copy(part, bytes.NewReader(imgData1))
 	s.Require().NoError(err)
+	s.Require().NoError(writer.WriteField("csrf_token", s.csrfTokenFromJar(client)))
 	s.Require().NoError(writer.Close())
 
 	req, err := http.NewRequest("POST", "http://localhost:8081/oauth/change-avatar", body)
@@ -332,6 +358,7 @@ func (s *AvatarFlowSuite) TestAvatarUpdate() {
 	s.Require().NoError(err)
 	_, err = io.Copy(part, bytes.NewReader(imgData2))
 	s.Require().NoError(err)
+	s.Require().NoError(writer.WriteField("csrf_token", s.csrfTokenFromJar(client)))
 	s.Require().NoError(writer.Close())
 
 	req, err = http.NewRequest("POST", "http://localhost:8081/oauth/change-avatar", body)
@@ -375,6 +402,7 @@ func (s *AvatarFlowSuite) TestAvatarDelete() {
 	s.Require().NoError(err)
 	_, err = io.Copy(part, bytes.NewReader(imgData))
 	s.Require().NoError(err)
+	s.Require().NoError(writer.WriteField("csrf_token", s.csrfTokenFromJar(client)))
 	s.Require().NoError(writer.Close())
 
 	req, err := http.NewRequest("POST", "http://localhost:8081/oauth/change-avatar", body)
@@ -390,8 +418,10 @@ func (s *AvatarFlowSuite) TestAvatarDelete() {
 	s.Require().NoError(err)
 	s.Require().True(updatedUser.Picture.Valid)
 
-	// Now delete the avatar
-	resp, err = client.PostForm("http://localhost:8081/oauth/delete-avatar", url.Values{})
+	// Now delete the avatar (CSRF-aware: cookie from the jar, token in the form)
+	resp, err = client.PostForm("http://localhost:8081/oauth/delete-avatar", url.Values{
+		"csrf_token": {s.csrfTokenFromJar(client)},
+	})
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 
@@ -432,6 +462,7 @@ func (s *AvatarFlowSuite) TestUserInfoReturnsPicture() {
 	s.Require().NoError(err)
 	_, err = io.Copy(part, bytes.NewReader(imgData))
 	s.Require().NoError(err)
+	s.Require().NoError(writer.WriteField("csrf_token", s.csrfTokenFromJar(httpClient)))
 	s.Require().NoError(writer.Close())
 
 	req, err := http.NewRequest("POST", "http://localhost:8081/oauth/change-avatar", body)
@@ -604,6 +635,7 @@ func (s *AvatarFlowSuite) mustCompleteAuthorizationFlow(
 		form := url.Values{}
 		form.Set("username", user.Username)
 		form.Set("password", password)
+		form.Set("csrf_token", s.csrfTokenFromJar(client))
 		resp, err = client.PostForm(loginURL, form)
 		s.Require().NoError(err)
 		s.Require().Equal(http.StatusFound, resp.StatusCode)
@@ -641,6 +673,7 @@ func (s *AvatarFlowSuite) mustCompleteAuthorizationFlow(
 		"code_challenge":        {consentURL.Query().Get("code_challenge")},
 		"code_challenge_method": {consentURL.Query().Get("code_challenge_method")},
 		"nonce":                 {consentURL.Query().Get("nonce")},
+		"csrf_token":            {s.csrfTokenFromJar(client)},
 	}
 	resp, err = client.PostForm("http://localhost:8081/oauth/consent", consentForm)
 	s.Require().NoError(err)

--- a/pkg/httpserver/csrf.go
+++ b/pkg/httpserver/csrf.go
@@ -1,0 +1,104 @@
+package httpserver
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
+	"net/http"
+)
+
+// csrfCookieName is the name of the double-submit CSRF cookie and the matching
+// hidden form field.
+const csrfCookieName = "csrf_token"
+
+// csrfFormField is the form field (and hidden <input> name) that carries the CSRF
+// token back on state-changing submits. It intentionally matches the cookie name.
+const csrfFormField = "csrf_token"
+
+// csrfTokenBytes is the number of random bytes in a CSRF token before encoding.
+const csrfTokenBytes = 32
+
+// generateCSRFToken returns a cryptographically random, URL-safe token string.
+func generateCSRFToken() (string, error) {
+	b := make([]byte, csrfTokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// setCSRFCookie writes the csrf_token cookie. It mirrors the session cookie's flags:
+// HttpOnly (the server renders the hidden field, so JS never needs to read it),
+// SameSite=Lax, and Secure gated on isSecureContext (see server.go) so it is only
+// marked Secure when the service is actually reached over HTTPS. It is a session
+// cookie (no Max-Age/Expires) so the same token persists across the multi-step
+// browser flows (e.g. login -> mfa) for the life of the browser session.
+func (s *Server) setCSRFCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     csrfCookieName,
+		Value:    token,
+		Path:     "/",
+		HttpOnly: true,
+		Secure:   s.isSecureContext(),
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// ensureCSRFToken returns the CSRF token for this request, creating and setting the
+// csrf_token cookie if the request does not already carry a valid one. GET handlers
+// that render a protected form call this and embed the returned value as a hidden
+// field so the double-submit check can succeed on the subsequent POST.
+//
+// Because the cookie has Path=/ and is a session cookie, a token minted while
+// rendering one form page (e.g. /oauth/login) remains valid for a later form on a
+// different page in the same session (e.g. /oauth/mfa, /oauth/account-settings).
+func (s *Server) ensureCSRFToken(w http.ResponseWriter, r *http.Request) string {
+	if cookie, err := r.Cookie(csrfCookieName); err == nil && cookie.Value != "" {
+		return cookie.Value
+	}
+	token, err := generateCSRFToken()
+	if err != nil {
+		// Extremely unlikely (crypto/rand failure). Return empty; the form will then
+		// carry no token and the middleware will reject the eventual POST with 403,
+		// which is the safe failure mode.
+		return ""
+	}
+	s.setCSRFCookie(w, token)
+	return token
+}
+
+// csrfMiddleware enforces the double-submit-cookie CSRF check on state-changing
+// requests to the browser, session-cookie form routes it wraps. Safe methods
+// (GET/HEAD/OPTIONS) are never checked. For every other method the request must
+// carry a csrf_token cookie and a csrf_token form value that are both present and
+// equal (compared in constant time). Failure is a 403.
+//
+// This middleware is applied ONLY to the browser form route group. The OAuth2/OIDC
+// machine endpoints (/oauth/token, /oauth/refresh, /oauth/introspect, /oauth/revoke)
+// and the admin API authenticate with Authorization headers / client credentials and
+// have no browser form, so they are deliberately outside this group and never see it.
+func (s *Server) csrfMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		cookie, err := r.Cookie(csrfCookieName)
+		if err != nil || cookie.Value == "" {
+			s.renderError(w, http.StatusForbidden, "Invalid Request",
+				"Your session could not be verified (missing CSRF token). Please reload the page and try again.", "")
+			return
+		}
+
+		formToken := r.FormValue(csrfFormField)
+		if formToken == "" || subtle.ConstantTimeCompare([]byte(cookie.Value), []byte(formToken)) != 1 {
+			s.renderError(w, http.StatusForbidden, "Invalid Request",
+				"Your session could not be verified (CSRF token mismatch). Please reload the page and try again.", "")
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/httpserver/csrf_test.go
+++ b/pkg/httpserver/csrf_test.go
@@ -1,0 +1,167 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// okHandler is a trivial next-handler that records it was reached and writes 200.
+func okHandler(reached *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*reached = true
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// newCSRFFormPost builds a urlencoded POST carrying the given cookie/form token
+// values. Empty string means "omit".
+func newCSRFFormPost(cookieToken, formToken string) *http.Request {
+	body := ""
+	if formToken != "" {
+		body = "csrf_token=" + formToken + "&foo=bar"
+	} else {
+		body = "foo=bar"
+	}
+	req := httptest.NewRequest(http.MethodPost, "/oauth/change-password", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if cookieToken != "" {
+		req.AddCookie(&http.Cookie{Name: csrfCookieName, Value: cookieToken})
+	}
+	return req
+}
+
+func TestCSRFMiddleware_MissingToken403(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	h := s.csrfMiddleware(okHandler(&reached))
+
+	// No cookie, no form field.
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newCSRFFormPost("", ""))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("missing token: expected 403, got %d", rec.Code)
+	}
+	if reached {
+		t.Fatal("missing token: next handler must not be reached")
+	}
+}
+
+func TestCSRFMiddleware_CookiePresentFormMissing403(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	h := s.csrfMiddleware(okHandler(&reached))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newCSRFFormPost("tok-abc", ""))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("form missing: expected 403, got %d", rec.Code)
+	}
+	if reached {
+		t.Fatal("form missing: next handler must not be reached")
+	}
+}
+
+func TestCSRFMiddleware_Mismatch403(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	h := s.csrfMiddleware(okHandler(&reached))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newCSRFFormPost("cookie-token", "different-form-token"))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("mismatch: expected 403, got %d", rec.Code)
+	}
+	if reached {
+		t.Fatal("mismatch: next handler must not be reached")
+	}
+}
+
+func TestCSRFMiddleware_MatchPasses(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	h := s.csrfMiddleware(okHandler(&reached))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, newCSRFFormPost("matching-token", "matching-token"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("match: expected 200, got %d", rec.Code)
+	}
+	if !reached {
+		t.Fatal("match: next handler must be reached")
+	}
+}
+
+func TestCSRFMiddleware_SafeMethodsNeverChecked(t *testing.T) {
+	s := newHermeticTestServer(t)
+	for _, method := range []string{http.MethodGet, http.MethodHead, http.MethodOptions} {
+		reached := false
+		h := s.csrfMiddleware(okHandler(&reached))
+		// No cookie, no form token whatsoever.
+		req := httptest.NewRequest(method, "/oauth/change-password", nil)
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		if !reached {
+			t.Fatalf("%s: safe method must pass through without a CSRF token", method)
+		}
+		if rec.Code == http.StatusForbidden {
+			t.Fatalf("%s: safe method must not be rejected with 403", method)
+		}
+	}
+}
+
+// TestCSRFMiddleware_ExemptRouteNotBlocked verifies that the machine OAuth endpoint
+// /oauth/token, which is deliberately outside the CSRF-protected route group, is not
+// rejected for lacking a CSRF token. It is routed through the full server router so
+// the actual middleware wiring in registerRoutes is exercised. The hermetic server
+// has no reachable DB, so the token handler may fail for other reasons — the only
+// thing asserted here is that the failure is NOT the CSRF 403.
+func TestCSRFMiddleware_ExemptRouteNotBlocked(t *testing.T) {
+	s := newHermeticTestServer(t)
+
+	body := "grant_type=client_credentials&client_id=x&client_secret=y"
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rec := httptest.NewRecorder()
+
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusForbidden && strings.Contains(rec.Body.String(), "CSRF") {
+		t.Fatalf("/oauth/token must be exempt from CSRF, but got a CSRF 403: %s", rec.Body.String())
+	}
+}
+
+// TestEnsureCSRFToken_SetsCookieWhenAbsent verifies the read-or-create helper mints a
+// token and sets the cookie when the request carries none, and reuses the existing
+// cookie value (without resetting it) when one is present.
+func TestEnsureCSRFToken_SetsCookieWhenAbsent(t *testing.T) {
+	s := newHermeticTestServer(t)
+
+	// Absent -> mint + set.
+	req := httptest.NewRequest(http.MethodGet, "/oauth/login", nil)
+	rec := httptest.NewRecorder()
+	tok := s.ensureCSRFToken(rec, req)
+	if tok == "" {
+		t.Fatal("expected a non-empty token when none present")
+	}
+	cookies := rec.Result().Cookies()
+	if len(cookies) != 1 || cookies[0].Name != csrfCookieName || cookies[0].Value != tok {
+		t.Fatalf("expected csrf_token cookie set to %q, got %+v", tok, cookies)
+	}
+	if !cookies[0].HttpOnly {
+		t.Error("csrf_token cookie must be HttpOnly")
+	}
+
+	// Present -> reuse, no new Set-Cookie.
+	req2 := httptest.NewRequest(http.MethodGet, "/oauth/login", nil)
+	req2.AddCookie(&http.Cookie{Name: csrfCookieName, Value: "existing-token"})
+	rec2 := httptest.NewRecorder()
+	tok2 := s.ensureCSRFToken(rec2, req2)
+	if tok2 != "existing-token" {
+		t.Fatalf("expected existing token to be reused, got %q", tok2)
+	}
+	if len(rec2.Result().Cookies()) != 0 {
+		t.Fatalf("expected no Set-Cookie when a valid token cookie is already present")
+	}
+}

--- a/pkg/httpserver/email_verification_flow_test.go
+++ b/pkg/httpserver/email_verification_flow_test.go
@@ -32,7 +32,7 @@ func (s *OAuthFlowSuite) TestEmailVerificationFlow() {
 	emailAddr := username + "@example.com"
 	password := "securepassword123"
 
-	regResp, err := s.httpClient.PostForm("http://localhost:8080/oauth/register", url.Values{
+	regResp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/register", url.Values{
 		"username":              {username},
 		"email":                 {emailAddr},
 		"password":              {password},
@@ -110,8 +110,9 @@ func (s *OAuthFlowSuite) TestVerifyEmailWithMissingToken() {
 }
 
 func (s *OAuthFlowSuite) TestResendVerificationRequiresAuth() {
-	// Try to resend verification without being logged in
-	resp, err := s.httpClient.Post("http://localhost:8080/oauth/resend-verification", "application/x-www-form-urlencoded", nil)
+	// Try to resend verification without being logged in (CSRF-aware POST). With a
+	// valid CSRF token but no session, the handler still redirects to login.
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/resend-verification", nil)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 

--- a/pkg/httpserver/integration_common_test.go
+++ b/pkg/httpserver/integration_common_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/eswan18/identity/pkg/store"
 	"github.com/pquerna/otp/totp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 
@@ -156,6 +157,10 @@ func (s *OAuthFlowSuite) mustLoginAndConsent(user UserWithPassword, clientID, re
 		},
 	}
 
+	// Obtain a CSRF token/cookie (double-submit) by fetching the login form first;
+	// the same token is valid for the later consent POST since the cookie is Path=/.
+	csrfToken, _ := fetchCSRFToken(s.T(), httpClient, "http://localhost:8080/oauth/login")
+
 	// Step 1: Login
 	formValues := url.Values{
 		"username":              {user.Username},
@@ -166,6 +171,7 @@ func (s *OAuthFlowSuite) mustLoginAndConsent(user UserWithPassword, clientID, re
 		"scope":                 {scope},
 		"code_challenge":        {scv.CodeChallenge},
 		"code_challenge_method": {scv.CodeChallengeMethod},
+		"csrf_token":            {csrfToken},
 	}
 	resp, err := httpClient.PostForm("http://localhost:8080/oauth/login", formValues)
 	s.Require().NoError(err)
@@ -196,6 +202,7 @@ func (s *OAuthFlowSuite) mustLoginAndConsent(user UserWithPassword, clientID, re
 		"code_challenge":        {consentURL.Query().Get("code_challenge")},
 		"code_challenge_method": {consentURL.Query().Get("code_challenge_method")},
 		"nonce":                 {consentURL.Query().Get("nonce")},
+		"csrf_token":            {csrfToken},
 	}
 	resp, err = httpClient.PostForm("http://localhost:8080/oauth/consent", consentForm)
 	s.Require().NoError(err)
@@ -294,6 +301,9 @@ func (s *OAuthFlowSuite) mustCompleteOAuthFlow(clientParams db.CreateOAuthClient
 		},
 	}
 
+	// Obtain a CSRF token/cookie for the browser-form POSTs (login + consent).
+	csrfToken, _ := fetchCSRFToken(s.T(), httpClient, fmt.Sprintf("http://%s/oauth/login", host))
+
 	// Step 1: Login (establishes session, redirects to /oauth/authorize)
 	formValues := url.Values{
 		"username":              {user.Username},
@@ -304,6 +314,7 @@ func (s *OAuthFlowSuite) mustCompleteOAuthFlow(clientParams db.CreateOAuthClient
 		"scope":                 {scope},
 		"code_challenge":        {scv.CodeChallenge},
 		"code_challenge_method": {scv.CodeChallengeMethod},
+		"csrf_token":            {csrfToken},
 	}
 	postLoginUrl := fmt.Sprintf("http://%s/oauth/login", host)
 	resp, err := httpClient.PostForm(postLoginUrl, formValues)
@@ -335,6 +346,7 @@ func (s *OAuthFlowSuite) mustCompleteOAuthFlow(clientParams db.CreateOAuthClient
 		"code_challenge":        {consentURL.Query().Get("code_challenge")},
 		"code_challenge_method": {consentURL.Query().Get("code_challenge_method")},
 		"nonce":                 {consentURL.Query().Get("nonce")},
+		"csrf_token":            {csrfToken},
 	}
 	postConsentUrl := fmt.Sprintf("http://%s/oauth/consent", host)
 	resp, err = httpClient.PostForm(postConsentUrl, consentFormValues)
@@ -451,10 +463,12 @@ func (s *OAuthFlowSuite) mustLoginAndGetAuthorizeClient(clientParams db.CreateOA
 		},
 	}
 
-	// Login to establish a session
+	// Login to establish a session (CSRF-aware: seed the token from the login page).
+	csrfToken, _ := fetchCSRFToken(s.T(), httpClient, "http://localhost:8080/oauth/login")
 	resp, err := httpClient.PostForm("http://localhost:8080/oauth/login", url.Values{
-		"username": {username},
-		"password": {password},
+		"username":   {username},
+		"password":   {password},
+		"csrf_token": {csrfToken},
 	})
 	s.Require().NoError(err)
 	defer resp.Body.Close()
@@ -522,4 +536,63 @@ func TestOAuthFlowSuite(t *testing.T) {
 func generateCodeChallenge(codeVerifier string) string {
 	hash := sha256.Sum256([]byte(codeVerifier))
 	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// fetchCSRFToken issues a GET to getURL to obtain a csrf_token cookie and returns the
+// token value plus the cookie itself. Browser-form routes set the csrf_token cookie
+// (Path=/) when their GET handler renders, so this performs the "GET the form page
+// first" half of the double-submit handshake. When the client already holds the
+// cookie in its jar, the server does not resend it, so we fall back to the jar.
+func fetchCSRFToken(t *testing.T, client *http.Client, getURL string) (string, *http.Cookie) {
+	t.Helper()
+	resp, err := client.Get(getURL)
+	require.NoError(t, err)
+	resp.Body.Close()
+	for _, c := range resp.Cookies() {
+		if c.Name == csrfCookieName {
+			return c.Value, c
+		}
+	}
+	if client.Jar != nil {
+		if u, err := url.Parse(getURL); err == nil {
+			for _, c := range client.Jar.Cookies(u) {
+				if c.Name == csrfCookieName {
+					return c.Value, c
+				}
+			}
+		}
+	}
+	require.FailNowf(t, "csrf token missing", "no %s cookie returned from %s", csrfCookieName, getURL)
+	return "", nil
+}
+
+// csrfPostForm performs a CSRF-aware urlencoded form POST to a browser-form route. It
+// GETs getURL to obtain a csrf_token, injects the token into both the form field and
+// the request cookies (so it works for jarless clients too), then POSTs to postURL.
+func csrfPostForm(t *testing.T, client *http.Client, getURL, postURL string, form url.Values) (*http.Response, error) {
+	t.Helper()
+	token, cookie := fetchCSRFToken(t, client, getURL)
+	if form == nil {
+		form = url.Values{}
+	}
+	form.Set("csrf_token", token)
+	req, err := http.NewRequest(http.MethodPost, postURL, strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	return client.Do(req)
+}
+
+// csrfPostFormLogin is a convenience wrapper over csrfPostForm that sources the
+// csrf_token from the login page on the same host as postURL. The login page is a
+// reliable, always-available GET that seeds the csrf_token cookie, and because the
+// double-submit check only compares the cookie and form value on the POST itself,
+// the token's origin page is irrelevant. This lets every browser-form POST become a
+// one-line, CSRF-aware call regardless of whether the client carries a cookie jar.
+func csrfPostFormLogin(t *testing.T, client *http.Client, postURL string, form url.Values) (*http.Response, error) {
+	t.Helper()
+	u, err := url.Parse(postURL)
+	require.NoError(t, err)
+	getURL := fmt.Sprintf("%s://%s/oauth/login", u.Scheme, u.Host)
+	return csrfPostForm(t, client, getURL, postURL, form)
 }

--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -64,7 +64,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 		}
 		// No redirect_uri, or client_id/redirect_uri failed validation: show error page
 		// locally rather than redirecting to an unverified destination.
-		s.renderLoginError(w, http.StatusBadRequest, "Only S256 code challenge method is supported", oauthParams)
+		s.renderLoginError(w, r, http.StatusBadRequest, "Only S256 code challenge method is supported", oauthParams)
 		return
 	}
 
@@ -93,6 +93,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 		CodeChallenge:       codeChallenge,
 		CodeChallengeMethod: codeChallengeMethod,
 		Nonce:               nonce,
+		CSRFToken:           s.ensureCSRFToken(w, r),
 	})
 }
 
@@ -147,7 +148,7 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 		} else if errors.Is(err, ErrInvalidCredentials) {
 			status = http.StatusUnauthorized
 		}
-		s.renderLoginError(w, status, err.Error(), oauthParams)
+		s.renderLoginError(w, r, status, err.Error(), oauthParams)
 		return
 	}
 	log.Printf("[DEBUG] HandleLoginPost: Credentials validated successfully for user ID: %v", user.ID)
@@ -156,7 +157,7 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	// Deactivated users can only log in directly (no client_id) to access account settings
 	if !user.IsActive && clientID != "" {
 		log.Printf("[DEBUG] HandleLoginPost: Deactivated user (ID: %v) attempted OAuth login", user.ID)
-		s.renderLoginError(w, http.StatusForbidden, ErrAccountDeactivated.Error(), oauthParams)
+		s.renderLoginError(w, r, http.StatusForbidden, ErrAccountDeactivated.Error(), oauthParams)
 		return
 	}
 
@@ -166,7 +167,7 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 		pendingID, err := s.createMFAPendingSession(r, user.ID, oauthParams)
 		if err != nil {
 			log.Printf("[ERROR] HandleLoginPost: Failed to create MFA pending session: %v", err)
-			s.renderLoginError(w, http.StatusInternalServerError, "An error occurred", oauthParams)
+			s.renderLoginError(w, r, http.StatusInternalServerError, "An error occurred", oauthParams)
 			return
 		}
 		// Redirect to MFA verification page
@@ -179,7 +180,7 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	session, err := s.createSession(r.Context(), user.ID)
 	if err != nil {
 		log.Printf("[ERROR] HandleLoginPost: Failed to create session: %v", err)
-		s.renderLoginError(w, http.StatusInternalServerError, "An error occurred", oauthParams)
+		s.renderLoginError(w, r, http.StatusInternalServerError, "An error occurred", oauthParams)
 		return
 	}
 	// Log only the user ID, never the session token itself: session.ID is the bearer
@@ -205,7 +206,10 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 
 // renderLoginError renders the login page with an error message, preserving OAuth parameters.
 // It handles template execution errors gracefully by falling back to the error template.
-func (s *Server) renderLoginError(w http.ResponseWriter, statusCode int, errorMsg string, oauthParams LoginPageData) {
+func (s *Server) renderLoginError(w http.ResponseWriter, r *http.Request, statusCode int, errorMsg string, oauthParams LoginPageData) {
+	// Ensure the CSRF token/cookie before writing the status line, so the re-rendered
+	// login form carries a token the eventual POST can echo back.
+	csrfToken := s.ensureCSRFToken(w, r)
 	w.WriteHeader(statusCode)
 	err := s.loginTemplate.Execute(w, LoginPageData{
 		Error:               errorMsg,
@@ -216,6 +220,7 @@ func (s *Server) renderLoginError(w http.ResponseWriter, statusCode int, errorMs
 		CodeChallenge:       oauthParams.CodeChallenge,
 		CodeChallengeMethod: oauthParams.CodeChallengeMethod,
 		Nonce:               oauthParams.Nonce,
+		CSRFToken:           csrfToken,
 	})
 	if err != nil {
 		// Fallback to error template if login template fails

--- a/pkg/httpserver/mfa.go
+++ b/pkg/httpserver/mfa.go
@@ -32,6 +32,7 @@ type MFAPageData struct {
 	CodeChallenge       string
 	CodeChallengeMethod string
 	Nonce               string
+	CSRFToken           string
 }
 
 // oauthParamsFromPending lifts the OAuth authorization parameters stored on a pending
@@ -50,7 +51,7 @@ func oauthParamsFromPending(p db.AuthMfaPending) LoginPageData {
 
 // mfaPageData assembles the MFA template data from the pending ID, the OAuth context,
 // and an optional error message.
-func mfaPageData(pendingID string, p LoginPageData, errMsg string) MFAPageData {
+func mfaPageData(pendingID string, p LoginPageData, errMsg, csrfToken string) MFAPageData {
 	return MFAPageData{
 		Error:               errMsg,
 		PendingID:           pendingID,
@@ -61,6 +62,7 @@ func mfaPageData(pendingID string, p LoginPageData, errMsg string) MFAPageData {
 		CodeChallenge:       p.CodeChallenge,
 		CodeChallengeMethod: p.CodeChallengeMethod,
 		Nonce:               p.Nonce,
+		CSRFToken:           csrfToken,
 	}
 }
 
@@ -81,7 +83,7 @@ func (s *Server) HandleMFAGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.mfaTemplate.Execute(w, mfaPageData(pendingID, oauthParamsFromPending(pending), ""))
+	s.mfaTemplate.Execute(w, mfaPageData(pendingID, oauthParamsFromPending(pending), "", s.ensureCSRFToken(w, r)))
 }
 
 // HandleMFAPost validates the MFA code and completes the login flow.
@@ -128,7 +130,7 @@ func (s *Server) HandleMFAPost(w http.ResponseWriter, r *http.Request) {
 	mfaStatus, err := s.datastore.Q.GetUserMFAStatus(r.Context(), pending.UserID)
 	if err != nil {
 		log.Printf("[ERROR] HandleMFAPost: Failed to get MFA status: %v", err)
-		s.renderMFAError(w, http.StatusInternalServerError, "An error occurred", pendingID, pendingParams)
+		s.renderMFAError(w, r, http.StatusInternalServerError, "An error occurred", pendingID, pendingParams)
 		return
 	}
 
@@ -142,7 +144,7 @@ func (s *Server) HandleMFAPost(w http.ResponseWriter, r *http.Request) {
 	// retry within the validity window.
 	if !mfa.ValidateCode(mfaStatus.MfaSecret.String, code) {
 		log.Printf("[DEBUG] HandleMFAPost: Invalid MFA code for user: %v", pending.UserID)
-		s.renderMFAError(w, http.StatusUnauthorized, "Invalid verification code", pendingID, pendingParams)
+		s.renderMFAError(w, r, http.StatusUnauthorized, "Invalid verification code", pendingID, pendingParams)
 		return
 	}
 
@@ -155,7 +157,7 @@ func (s *Server) HandleMFAPost(w http.ResponseWriter, r *http.Request) {
 	session, err := s.createSession(r.Context(), pending.UserID)
 	if err != nil {
 		log.Printf("[ERROR] HandleMFAPost: Failed to create session: %v", err)
-		s.renderMFAError(w, http.StatusInternalServerError, "An error occurred", pendingID, pendingParams)
+		s.renderMFAError(w, r, http.StatusInternalServerError, "An error occurred", pendingID, pendingParams)
 		return
 	}
 
@@ -222,7 +224,8 @@ func (s *Server) createMFAPendingSession(r *http.Request, userID uuid.UUID, oaut
 
 // renderMFAError renders the MFA page with an error message, preserving the OAuth
 // context so a retry keeps the originating authorization request intact.
-func (s *Server) renderMFAError(w http.ResponseWriter, statusCode int, errorMsg string, pendingID string, p LoginPageData) {
+func (s *Server) renderMFAError(w http.ResponseWriter, r *http.Request, statusCode int, errorMsg string, pendingID string, p LoginPageData) {
+	csrfToken := s.ensureCSRFToken(w, r)
 	w.WriteHeader(statusCode)
-	s.mfaTemplate.Execute(w, mfaPageData(pendingID, p, errorMsg))
+	s.mfaTemplate.Execute(w, mfaPageData(pendingID, p, errorMsg, csrfToken))
 }

--- a/pkg/httpserver/mfa_setup.go
+++ b/pkg/httpserver/mfa_setup.go
@@ -13,19 +13,20 @@ import (
 
 // MFASetupPageData holds the data needed to render the MFA setup page template.
 type MFASetupPageData struct {
-	Error          string
-	Success        string
-	QRCode         string // Base64-encoded PNG
-	Secret         string // For manual entry
+	Error           string
+	Success         string
+	QRCode          string // Base64-encoded PNG
+	Secret          string // For manual entry
 	ProvisioningURI string
+	CSRFToken       string
 }
 
 // mfaEnrollmentExpiresIn is how long a pending enrollment secret remains valid.
 const mfaEnrollmentExpiresIn = 10 * time.Minute
 
 // renderMFASetupError renders the setup page with only an error message (no QR).
-func (s *Server) renderMFASetupError(w http.ResponseWriter, msg string) {
-	if err := s.mfaSetupTemplate.Execute(w, MFASetupPageData{Error: msg}); err != nil {
+func (s *Server) renderMFASetupError(w http.ResponseWriter, r *http.Request, msg string) {
+	if err := s.mfaSetupTemplate.Execute(w, MFASetupPageData{Error: msg, CSRFToken: s.ensureCSRFToken(w, r)}); err != nil {
 		log.Printf("[ERROR] renderMFASetupError: Failed to render MFA setup page: %v", err)
 	}
 }
@@ -33,18 +34,18 @@ func (s *Server) renderMFASetupError(w http.ResponseWriter, msg string) {
 // renderMFASetupPage renders the setup page for a given server-stored secret,
 // reconstructing the QR code and provisioning URI from that exact secret so the
 // displayed QR always matches the secret that will be validated.
-func (s *Server) renderMFASetupPage(w http.ResponseWriter, username, secret, errMsg string) {
+func (s *Server) renderMFASetupPage(w http.ResponseWriter, r *http.Request, username, secret, errMsg string) {
 	key, err := mfa.KeyFromSecret(username, secret)
 	if err != nil {
 		log.Printf("[ERROR] renderMFASetupPage: Failed to rebuild TOTP key: %v", err)
-		s.renderMFASetupError(w, "Failed to generate MFA setup. Please try again.")
+		s.renderMFASetupError(w, r, "Failed to generate MFA setup. Please try again.")
 		return
 	}
 
 	qrCode, err := mfa.GenerateQRCode(key)
 	if err != nil {
 		log.Printf("[ERROR] renderMFASetupPage: Failed to generate QR code: %v", err)
-		s.renderMFASetupError(w, "Failed to generate QR code. Please try again.")
+		s.renderMFASetupError(w, r, "Failed to generate QR code. Please try again.")
 		return
 	}
 
@@ -53,6 +54,7 @@ func (s *Server) renderMFASetupPage(w http.ResponseWriter, username, secret, err
 		QRCode:          qrCode,
 		Secret:          secret,
 		ProvisioningURI: mfa.GetProvisioningURI(key),
+		CSRFToken:       s.ensureCSRFToken(w, r),
 	}); err != nil {
 		log.Printf("[ERROR] renderMFASetupPage: Failed to render MFA setup page: %v", err)
 	}
@@ -76,7 +78,7 @@ func (s *Server) HandleMFASetupGet(w http.ResponseWriter, r *http.Request) {
 	key, err := mfa.GenerateSecret(user.Username)
 	if err != nil {
 		log.Printf("[ERROR] HandleMFASetupGet: Failed to generate TOTP secret: %v", err)
-		s.renderMFASetupError(w, "Failed to generate MFA secret. Please try again.")
+		s.renderMFASetupError(w, r, "Failed to generate MFA secret. Please try again.")
 		return
 	}
 	secret := mfa.GetSecret(key)
@@ -90,11 +92,11 @@ func (s *Server) HandleMFASetupGet(w http.ResponseWriter, r *http.Request) {
 		ExpiresAt: time.Now().Add(mfaEnrollmentExpiresIn),
 	}); err != nil {
 		log.Printf("[ERROR] HandleMFASetupGet: Failed to store pending MFA secret: %v", err)
-		s.renderMFASetupError(w, "Failed to start MFA setup. Please try again.")
+		s.renderMFASetupError(w, r, "Failed to start MFA setup. Please try again.")
 		return
 	}
 
-	s.renderMFASetupPage(w, user.Username, secret, "")
+	s.renderMFASetupPage(w, r, user.Username, secret, "")
 }
 
 // HandleMFASetupPost verifies the TOTP code and enables MFA.
@@ -126,7 +128,7 @@ func (s *Server) HandleMFASetupPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if code == "" {
-		s.renderMFASetupPage(w, user.Username, pending.Secret, "Please enter the verification code from your authenticator app.")
+		s.renderMFASetupPage(w, r, user.Username, pending.Secret, "Please enter the verification code from your authenticator app.")
 		return
 	}
 
@@ -134,7 +136,7 @@ func (s *Server) HandleMFASetupPost(w http.ResponseWriter, r *http.Request) {
 	if !mfa.ValidateCode(pending.Secret, code) {
 		// Re-render using the SAME server-stored secret so the displayed QR and the
 		// secret being validated stay consistent across retries.
-		s.renderMFASetupPage(w, user.Username, pending.Secret, "Invalid verification code. Please try again.")
+		s.renderMFASetupPage(w, r, user.Username, pending.Secret, "Invalid verification code. Please try again.")
 		return
 	}
 
@@ -144,7 +146,7 @@ func (s *Server) HandleMFASetupPost(w http.ResponseWriter, r *http.Request) {
 		MfaSecret: sql.NullString{String: pending.Secret, Valid: true},
 	}); err != nil {
 		log.Printf("[ERROR] HandleMFASetupPost: Failed to enable MFA: %v", err)
-		s.renderMFASetupPage(w, user.Username, pending.Secret, "Failed to enable MFA. Please try again.")
+		s.renderMFASetupPage(w, r, user.Username, pending.Secret, "Failed to enable MFA. Please try again.")
 		return
 	}
 
@@ -178,7 +180,7 @@ func (s *Server) HandleMFADisablePost(w http.ResponseWriter, r *http.Request) {
 
 	// Validate password
 	if password == "" {
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			MfaEnabled: user.MfaEnabled,
@@ -190,7 +192,7 @@ func (s *Server) HandleMFADisablePost(w http.ResponseWriter, r *http.Request) {
 	valid, err := auth.VerifyPassword(password, user.PasswordHash)
 	if err != nil {
 		log.Printf("[ERROR] HandleMFADisablePost: Failed to verify password: %v", err)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			MfaEnabled: user.MfaEnabled,
@@ -200,7 +202,7 @@ func (s *Server) HandleMFADisablePost(w http.ResponseWriter, r *http.Request) {
 	}
 	if !valid {
 		w.WriteHeader(http.StatusUnauthorized)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			MfaEnabled: user.MfaEnabled,
@@ -211,7 +213,7 @@ func (s *Server) HandleMFADisablePost(w http.ResponseWriter, r *http.Request) {
 
 	// Validate MFA code
 	if code == "" || !user.MfaSecret.Valid {
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			MfaEnabled: user.MfaEnabled,
@@ -222,7 +224,7 @@ func (s *Server) HandleMFADisablePost(w http.ResponseWriter, r *http.Request) {
 
 	if !mfa.ValidateCode(user.MfaSecret.String, code) {
 		w.WriteHeader(http.StatusUnauthorized)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			MfaEnabled: user.MfaEnabled,
@@ -235,7 +237,7 @@ func (s *Server) HandleMFADisablePost(w http.ResponseWriter, r *http.Request) {
 	err = s.datastore.Q.DisableMFA(r.Context(), user.ID)
 	if err != nil {
 		log.Printf("[ERROR] HandleMFADisablePost: Failed to disable MFA: %v", err)
-		s.accountSettingsTemplate.Execute(w, AccountSettingsPageData{
+		s.renderAccountSettings(w, r, AccountSettingsPageData{
 			Username:   user.Username,
 			Email:      user.Email,
 			MfaEnabled: user.MfaEnabled,

--- a/pkg/httpserver/mfa_test.go
+++ b/pkg/httpserver/mfa_test.go
@@ -66,7 +66,7 @@ func (s *OAuthFlowSuite) TestOAuthFlowWithMFA() {
 		"code_challenge":        {scv.CodeChallenge},
 		"code_challenge_method": {scv.CodeChallengeMethod},
 	}
-	resp, err := httpClient.PostForm(fmt.Sprintf("http://%s/oauth/login", host), formValues)
+	resp, err := csrfPostFormLogin(s.T(), httpClient, fmt.Sprintf("http://%s/oauth/login", host), formValues)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 	s.Require().Equal(http.StatusFound, resp.StatusCode, "login should redirect")
@@ -83,7 +83,7 @@ func (s *OAuthFlowSuite) TestOAuthFlowWithMFA() {
 	validCode, err := generateTOTPCode(totpSecret)
 	s.Require().NoError(err)
 
-	resp, err = httpClient.PostForm(fmt.Sprintf("http://%s/oauth/mfa", host), url.Values{
+	resp, err = csrfPostFormLogin(s.T(), httpClient, fmt.Sprintf("http://%s/oauth/mfa", host), url.Values{
 		"pending_id": {pendingID},
 		"code":       {validCode},
 	})
@@ -105,7 +105,7 @@ func (s *OAuthFlowSuite) TestOAuthFlowWithMFA() {
 	consentLocation := resp.Header.Get("Location")
 	consentURL, err := url.Parse(consentLocation)
 	s.Require().NoError(err)
-	resp, err = httpClient.PostForm(fmt.Sprintf("http://%s/oauth/consent", host), url.Values{
+	resp, err = csrfPostFormLogin(s.T(), httpClient, fmt.Sprintf("http://%s/oauth/consent", host), url.Values{
 		"decision":              {"allow"},
 		"client_id":             {consentURL.Query().Get("client_id")},
 		"redirect_uri":          {consentURL.Query().Get("redirect_uri")},
@@ -185,7 +185,7 @@ func (s *OAuthFlowSuite) TestMFAWithInvalidCode() {
 		"code_challenge_method": {scv.CodeChallengeMethod},
 	}
 	postLoginUrl := fmt.Sprintf("http://%s/oauth/login", host)
-	resp, err := s.httpClient.PostForm(postLoginUrl, formValues)
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, postLoginUrl, formValues)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 	s.Require().Equal(http.StatusFound, resp.StatusCode)
@@ -201,7 +201,7 @@ func (s *OAuthFlowSuite) TestMFAWithInvalidCode() {
 		"code":       {"000000"}, // Invalid code
 	}
 	postMfaUrl := fmt.Sprintf("http://%s/oauth/mfa", host)
-	resp, err = s.httpClient.PostForm(postMfaUrl, mfaFormValues)
+	resp, err = csrfPostFormLogin(s.T(), s.httpClient, postMfaUrl, mfaFormValues)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 
@@ -240,7 +240,7 @@ func (s *OAuthFlowSuite) TestMFAPageRendersOAuthContext() {
 	host := "localhost:8080"
 
 	// Login to reach the MFA page.
-	resp, err := s.httpClient.PostForm(fmt.Sprintf("http://%s/oauth/login", host), url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, fmt.Sprintf("http://%s/oauth/login", host), url.Values{
 		"username":              {user.Username},
 		"password":              {user.Password},
 		"client_id":             {client.ClientID},
@@ -305,7 +305,7 @@ func (s *OAuthFlowSuite) TestMFAPostWithExpiredPendingPreservesContext() {
 	nonce := s.mustGenerateRandomString(16)
 	host := "localhost:8080"
 
-	resp, err := s.httpClient.PostForm(fmt.Sprintf("http://%s/oauth/login", host), url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, fmt.Sprintf("http://%s/oauth/login", host), url.Values{
 		"username":              {user.Username},
 		"password":              {user.Password},
 		"client_id":             {client.ClientID},
@@ -332,7 +332,7 @@ func (s *OAuthFlowSuite) TestMFAPostWithExpiredPendingPreservesContext() {
 	s.Require().NoError(err)
 
 	// Submit the code together with the OAuth context the rendered page would carry.
-	resp, err = s.httpClient.PostForm(fmt.Sprintf("http://%s/oauth/mfa", host), url.Values{
+	resp, err = csrfPostFormLogin(s.T(), s.httpClient, fmt.Sprintf("http://%s/oauth/mfa", host), url.Values{
 		"pending_id":            {pendingID},
 		"code":                  {validCode},
 		"client_id":             {client.ClientID},
@@ -394,7 +394,7 @@ func (s *OAuthFlowSuite) TestMFADoubleSubmitPreservesContext() {
 		},
 	}
 
-	resp, err := httpClient.PostForm(fmt.Sprintf("http://%s/oauth/login", host), url.Values{
+	resp, err := csrfPostFormLogin(s.T(), httpClient, fmt.Sprintf("http://%s/oauth/login", host), url.Values{
 		"username":              {user.Username},
 		"password":              {user.Password},
 		"client_id":             {client.ClientID},
@@ -429,7 +429,7 @@ func (s *OAuthFlowSuite) TestMFADoubleSubmitPreservesContext() {
 	}
 
 	// First submit: succeeds, consumes the pending row, and sets the session cookie.
-	resp, err = httpClient.PostForm(fmt.Sprintf("http://%s/oauth/mfa", host), mfaForm)
+	resp, err = csrfPostFormLogin(s.T(), httpClient, fmt.Sprintf("http://%s/oauth/mfa", host), mfaForm)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 	s.Require().Equal(http.StatusFound, resp.StatusCode)
@@ -447,7 +447,7 @@ func (s *OAuthFlowSuite) TestMFADoubleSubmitPreservesContext() {
 
 	// Second submit (replay): the pending row is already gone. The flow must still be
 	// preserved — resume authorize, not bounce to account settings.
-	resp, err = httpClient.PostForm(fmt.Sprintf("http://%s/oauth/mfa", host), mfaForm)
+	resp, err = csrfPostFormLogin(s.T(), httpClient, fmt.Sprintf("http://%s/oauth/mfa", host), mfaForm)
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 	s.Require().Equal(http.StatusFound, resp.StatusCode)
@@ -489,7 +489,7 @@ func (s *OAuthFlowSuite) TestMFALoginSetsLastLoginAt() {
 	scv := s.mustCreateStateAndCodeVerifier()
 
 	// Step 1: Login (should redirect to MFA)
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/login", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/login", url.Values{
 		"username":              {username},
 		"password":              {password},
 		"client_id":             {client.ClientID},
@@ -520,7 +520,7 @@ func (s *OAuthFlowSuite) TestMFALoginSetsLastLoginAt() {
 	totpCode, err := generateTOTPCode(totpSecret)
 	s.Require().NoError(err)
 
-	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/mfa", url.Values{
+	resp, err = csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/mfa", url.Values{
 		"pending_id": {pendingID},
 		"code":       {totpCode},
 	})

--- a/pkg/httpserver/oauth.go
+++ b/pkg/httpserver/oauth.go
@@ -975,6 +975,7 @@ func (s *Server) HandleConsentGet(w http.ResponseWriter, r *http.Request) {
 		CodeChallengeMethod: r.URL.Query().Get("code_challenge_method"),
 		Nonce:               r.URL.Query().Get("nonce"),
 		ResponseType:        r.URL.Query().Get("response_type"),
+		CSRFToken:           s.ensureCSRFToken(w, r),
 	}
 
 	if err := s.consentTemplate.Execute(w, data); err != nil {

--- a/pkg/httpserver/oauth_flow_test.go
+++ b/pkg/httpserver/oauth_flow_test.go
@@ -86,6 +86,7 @@ func (s *OAuthFlowSuite) TestFullOAuthFlow() {
 			"code_verifier": {scv.CodeVerifier},
 		}
 		postTokenUrl := fmt.Sprintf("http://%s%s", host, route)
+		// /oauth/token is a machine endpoint, exempt from CSRF.
 		resp, err := s.httpClient.PostForm(postTokenUrl, tokenQuery)
 		s.Require().NoError(err)
 		defer resp.Body.Close()
@@ -118,6 +119,7 @@ func (s *OAuthFlowSuite) TestFullOAuthFlow() {
 			"client_id":     {client.ClientID},
 		}
 		postRefreshUrl := fmt.Sprintf("http://%s%s", host, route)
+		// /oauth/refresh is a machine endpoint, exempt from CSRF.
 		resp, err := s.httpClient.PostForm(postRefreshUrl, refreshQuery)
 		s.Require().NoError(err)
 		defer resp.Body.Close()
@@ -208,7 +210,7 @@ func (s *OAuthFlowSuite) TestLoginFailedPreservesAllScopes() {
 	scv := s.mustCreateStateAndCodeVerifier()
 
 	// POST to login with WRONG password and multiple scopes
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/login", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/login", url.Values{
 		"username":              {username},
 		"password":              {"wrong-password"},
 		"client_id":             {client.ClientID},
@@ -267,7 +269,7 @@ func (s *OAuthFlowSuite) TestLoginSetsLastLoginAt() {
 	scv := s.mustCreateStateAndCodeVerifier()
 
 	// Login
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/login", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/login", url.Values{
 		"username":              {username},
 		"password":              {password},
 		"client_id":             {client.ClientID},
@@ -312,7 +314,7 @@ func (s *OAuthFlowSuite) TestPasswordChangeUpdatesPasswordChangedAt() {
 	}
 
 	// Do a direct login (no client_id) to get a session
-	resp, err := httpClientWithCookies.PostForm("http://localhost:8080/oauth/login", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), httpClientWithCookies, "http://localhost:8080/oauth/login", url.Values{
 		"username": {username},
 		"password": {password},
 	})
@@ -322,7 +324,7 @@ func (s *OAuthFlowSuite) TestPasswordChangeUpdatesPasswordChangedAt() {
 
 	// Change password
 	newPassword := s.mustGenerateRandomString(16)
-	resp, err = httpClientWithCookies.PostForm("http://localhost:8080/oauth/change-password", url.Values{
+	resp, err = csrfPostFormLogin(s.T(), httpClientWithCookies, "http://localhost:8080/oauth/change-password", url.Values{
 		"current_password": {password},
 		"new_password":     {newPassword},
 		"confirm_password": {newPassword},

--- a/pkg/httpserver/oidc_test.go
+++ b/pkg/httpserver/oidc_test.go
@@ -99,7 +99,7 @@ func (s *OAuthFlowSuite) TestIDTokenIncludesNonce() {
 	}
 
 	// Login (with nonce) → authorize → consent → approve → callback with code
-	resp, err := httpClient.PostForm("http://localhost:8080/oauth/login", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/login", url.Values{
 		"username":              {username},
 		"password":              {password},
 		"client_id":             {client.ClientID},
@@ -128,7 +128,7 @@ func (s *OAuthFlowSuite) TestIDTokenIncludesNonce() {
 	consentLocation := resp.Header.Get("Location")
 	consentURL, err := url.Parse(consentLocation)
 	s.Require().NoError(err)
-	resp, err = httpClient.PostForm("http://localhost:8080/oauth/consent", url.Values{
+	resp, err = csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/consent", url.Values{
 		"decision":              {"allow"},
 		"client_id":             {consentURL.Query().Get("client_id")},
 		"redirect_uri":          {consentURL.Query().Get("redirect_uri")},
@@ -316,7 +316,7 @@ func (s *OAuthFlowSuite) TestIDTokenIncludesNonceThroughBrowserFlow() {
 		"code_challenge_method": {loginURL.Query().Get("code_challenge_method")},
 		"nonce":                 {loginURL.Query().Get("nonce")},
 	}
-	resp, err = httpClient.PostForm("http://localhost:8080/oauth/login", loginForm)
+	resp, err = csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/login", loginForm)
 	s.Require().NoError(err)
 	s.Require().NoError(resp.Body.Close())
 	s.Require().Equal(http.StatusFound, resp.StatusCode)
@@ -346,7 +346,7 @@ func (s *OAuthFlowSuite) TestIDTokenIncludesNonceThroughBrowserFlow() {
 		"code_challenge_method": {consentURL.Query().Get("code_challenge_method")},
 		"nonce":                 {consentURL.Query().Get("nonce")},
 	}
-	resp, err = httpClient.PostForm("http://localhost:8080/oauth/consent", consentForm)
+	resp, err = csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/consent", consentForm)
 	s.Require().NoError(err)
 	s.Require().NoError(resp.Body.Close())
 	s.Require().Equal(http.StatusFound, resp.StatusCode)

--- a/pkg/httpserver/password_reset.go
+++ b/pkg/httpserver/password_reset.go
@@ -32,6 +32,24 @@ func generateResetToken() (rawToken, tokenHash string, err error) {
 	return rawToken, tokenHash, nil
 }
 
+// renderForgotPassword renders the forgot-password page, injecting the CSRF token.
+func (s *Server) renderForgotPassword(w http.ResponseWriter, r *http.Request, data ForgotPasswordPageData) {
+	data.CSRFToken = s.ensureCSRFToken(w, r)
+	s.forgotPasswordTemplate.Execute(w, data)
+}
+
+// renderForgotUsername renders the forgot-username page, injecting the CSRF token.
+func (s *Server) renderForgotUsername(w http.ResponseWriter, r *http.Request, data ForgotPasswordPageData) {
+	data.CSRFToken = s.ensureCSRFToken(w, r)
+	s.forgotUsernameTemplate.Execute(w, data)
+}
+
+// renderResetPassword renders the reset-password page, injecting the CSRF token.
+func (s *Server) renderResetPassword(w http.ResponseWriter, r *http.Request, data ResetPasswordPageData) {
+	data.CSRFToken = s.ensureCSRFToken(w, r)
+	s.resetPasswordTemplate.Execute(w, data)
+}
+
 // HandleForgotPasswordGet godoc
 // @Summary      Show forgot password page
 // @Description  Displays the forgot password form
@@ -40,7 +58,7 @@ func generateResetToken() (rawToken, tokenHash string, err error) {
 // @Success      200 {string} string "HTML forgot password page"
 // @Router       /forgot-password [get]
 func (s *Server) HandleForgotPasswordGet(w http.ResponseWriter, r *http.Request) {
-	s.forgotPasswordTemplate.Execute(w, ForgotPasswordPageData{})
+	s.renderForgotPassword(w, r, ForgotPasswordPageData{})
 }
 
 // HandleForgotPasswordPost godoc
@@ -57,7 +75,7 @@ func (s *Server) HandleForgotPasswordPost(w http.ResponseWriter, r *http.Request
 
 	if emailAddr == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		s.forgotPasswordTemplate.Execute(w, ForgotPasswordPageData{
+		s.renderForgotPassword(w, r, ForgotPasswordPageData{
 			Error: "Email address is required",
 		})
 		return
@@ -71,7 +89,7 @@ func (s *Server) HandleForgotPasswordPost(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		// User not found - still show success message (no email enumeration)
 		log.Printf("[DEBUG] HandleForgotPasswordPost: No user found for email %s", emailAddr)
-		s.forgotPasswordTemplate.Execute(w, ForgotPasswordPageData{
+		s.renderForgotPassword(w, r, ForgotPasswordPageData{
 			Success: successMsg,
 		})
 		return
@@ -81,7 +99,7 @@ func (s *Server) HandleForgotPasswordPost(w http.ResponseWriter, r *http.Request
 	rawToken, tokenHash, err := generateResetToken()
 	if err != nil {
 		log.Printf("[ERROR] HandleForgotPasswordPost: Failed to generate token: %v", err)
-		s.forgotPasswordTemplate.Execute(w, ForgotPasswordPageData{
+		s.renderForgotPassword(w, r, ForgotPasswordPageData{
 			Error: "An error occurred. Please try again.",
 		})
 		return
@@ -96,7 +114,7 @@ func (s *Server) HandleForgotPasswordPost(w http.ResponseWriter, r *http.Request
 	})
 	if err != nil {
 		log.Printf("[ERROR] HandleForgotPasswordPost: Failed to store token: %v", err)
-		s.forgotPasswordTemplate.Execute(w, ForgotPasswordPageData{
+		s.renderForgotPassword(w, r, ForgotPasswordPageData{
 			Error: "An error occurred. Please try again.",
 		})
 		return
@@ -132,7 +150,7 @@ If you didn't request this, you can safely ignore this email.
 	}
 
 	log.Printf("[DEBUG] HandleForgotPasswordPost: Password reset email sent to %s", emailAddr)
-	s.forgotPasswordTemplate.Execute(w, ForgotPasswordPageData{
+	s.renderForgotPassword(w, r, ForgotPasswordPageData{
 		Success: successMsg,
 	})
 }
@@ -151,7 +169,7 @@ func (s *Server) HandleResetPasswordGet(w http.ResponseWriter, r *http.Request) 
 
 	if token == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "Invalid password reset link.",
 		})
 		return
@@ -163,13 +181,13 @@ func (s *Server) HandleResetPasswordGet(w http.ResponseWriter, r *http.Request) 
 	if err != nil {
 		log.Printf("[DEBUG] HandleResetPasswordGet: Invalid or expired token")
 		w.WriteHeader(http.StatusBadRequest)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "This password reset link is invalid or has expired. Please request a new one.",
 		})
 		return
 	}
 
-	s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+	s.renderResetPassword(w, r, ResetPasswordPageData{
 		Token: token,
 	})
 }
@@ -194,7 +212,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	// Validate required fields
 	if token == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "Invalid password reset link.",
 		})
 		return
@@ -202,7 +220,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 
 	if newPassword == "" || confirmPassword == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "All fields are required.",
 			Token: token,
 		})
@@ -211,7 +229,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 
 	if newPassword != confirmPassword {
 		w.WriteHeader(http.StatusBadRequest)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "Passwords do not match.",
 			Token: token,
 		})
@@ -224,7 +242,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		log.Printf("[DEBUG] HandleResetPasswordPost: Invalid or expired token")
 		w.WriteHeader(http.StatusBadRequest)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "This password reset link is invalid or has expired. Please request a new one.",
 		})
 		return
@@ -233,7 +251,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	// Validate password requirements
 	if err := auth.ValidatePassword(newPassword, tokenRecord.Username); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: err.Error(),
 			Token: token,
 		})
@@ -245,7 +263,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		log.Printf("[ERROR] HandleResetPasswordPost: Failed to hash password: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "An error occurred. Please try again.",
 			Token: token,
 		})
@@ -263,7 +281,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		log.Printf("[ERROR] HandleResetPasswordPost: Failed to mark token as used: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "An error occurred. Please try again.",
 			Token: token,
 		})
@@ -271,7 +289,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	}
 	if rowsAffected == 0 {
 		w.WriteHeader(http.StatusBadRequest)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "This password reset link is invalid or has expired. Please request a new one.",
 		})
 		return
@@ -285,7 +303,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	if err != nil {
 		log.Printf("[ERROR] HandleResetPasswordPost: Failed to update password: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
-		s.resetPasswordTemplate.Execute(w, ResetPasswordPageData{
+		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "An error occurred. Please try again.",
 			Token: token,
 		})
@@ -321,7 +339,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 // @Success      200 {string} string "HTML forgot username page"
 // @Router       /forgot-username [get]
 func (s *Server) HandleForgotUsernameGet(w http.ResponseWriter, r *http.Request) {
-	s.forgotUsernameTemplate.Execute(w, ForgotPasswordPageData{})
+	s.renderForgotUsername(w, r, ForgotPasswordPageData{})
 }
 
 // HandleForgotUsernamePost godoc
@@ -338,7 +356,7 @@ func (s *Server) HandleForgotUsernamePost(w http.ResponseWriter, r *http.Request
 
 	if emailAddr == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		s.forgotUsernameTemplate.Execute(w, ForgotPasswordPageData{
+		s.renderForgotUsername(w, r, ForgotPasswordPageData{
 			Error: "Email address is required",
 		})
 		return
@@ -352,7 +370,7 @@ func (s *Server) HandleForgotUsernamePost(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		// User not found - still show success message (no email enumeration)
 		log.Printf("[DEBUG] HandleForgotUsernamePost: No user found for email %s", emailAddr)
-		s.forgotUsernameTemplate.Execute(w, ForgotPasswordPageData{
+		s.renderForgotUsername(w, r, ForgotPasswordPageData{
 			Success: successMsg,
 		})
 		return
@@ -384,7 +402,7 @@ If you didn't request this, you can safely ignore this email.
 	}
 
 	log.Printf("[DEBUG] HandleForgotUsernamePost: Username reminder email sent to %s", emailAddr)
-	s.forgotUsernameTemplate.Execute(w, ForgotPasswordPageData{
+	s.renderForgotUsername(w, r, ForgotPasswordPageData{
 		Success: successMsg,
 	})
 }

--- a/pkg/httpserver/password_reset_flow_test.go
+++ b/pkg/httpserver/password_reset_flow_test.go
@@ -36,7 +36,7 @@ func (s *OAuthFlowSuite) TestPasswordResetTokenCannotBeReused() {
 	newPassword := "NewS3cure-" + s.mustGenerateRandomString(16)
 
 	// First reset: succeeds and redirects to login.
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/reset-password", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/reset-password", url.Values{
 		"token":            {rawToken},
 		"new_password":     {newPassword},
 		"confirm_password": {newPassword},
@@ -47,7 +47,7 @@ func (s *OAuthFlowSuite) TestPasswordResetTokenCannotBeReused() {
 
 	// Second reset with same token: must be rejected.
 	secondPassword := "Another-" + s.mustGenerateRandomString(16)
-	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/reset-password", url.Values{
+	resp, err = csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/reset-password", url.Values{
 		"token":            {rawToken},
 		"new_password":     {secondPassword},
 		"confirm_password": {secondPassword},
@@ -86,7 +86,7 @@ func (s *OAuthFlowSuite) TestPasswordResetFlow() {
 	s.Require().NoError(err)
 
 	// Request password reset
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/forgot-password", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/forgot-password", url.Values{
 		"email": {emailAddr},
 	})
 	s.Require().NoError(err)
@@ -123,7 +123,7 @@ func (s *OAuthFlowSuite) TestPasswordResetFlow() {
 	s.Equal(http.StatusOK, resp.StatusCode)
 
 	// Submit new password
-	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/reset-password", url.Values{
+	resp, err = csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/reset-password", url.Values{
 		"token":            {rawToken},
 		"new_password":     {newPassword},
 		"confirm_password": {newPassword},
@@ -147,7 +147,7 @@ func (s *OAuthFlowSuite) TestPasswordResetFlow() {
 	scv := s.mustCreateStateAndCodeVerifier()
 
 	// Try login with old password (should fail)
-	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/login", url.Values{
+	resp, err = csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/login", url.Values{
 		"username":              {username},
 		"password":              {originalPassword},
 		"client_id":             {client.ClientID},
@@ -162,7 +162,7 @@ func (s *OAuthFlowSuite) TestPasswordResetFlow() {
 	s.Equal(http.StatusUnauthorized, resp.StatusCode)
 
 	// Try login with new password (should succeed — redirects to authorize)
-	resp, err = s.httpClient.PostForm("http://localhost:8080/oauth/login", url.Values{
+	resp, err = csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/login", url.Values{
 		"username":              {username},
 		"password":              {newPassword},
 		"client_id":             {client.ClientID},
@@ -216,7 +216,7 @@ func (s *OAuthFlowSuite) TestPasswordResetPasswordMismatch() {
 	s.Require().NoError(err)
 
 	// Submit with mismatched passwords
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/reset-password", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/reset-password", url.Values{
 		"token":            {rawToken},
 		"new_password":     {"newpassword123"},
 		"confirm_password": {"differentpassword"},
@@ -250,7 +250,7 @@ func (s *OAuthFlowSuite) TestPasswordResetTooShort() {
 	s.Require().NoError(err)
 
 	// Submit with too short password
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/reset-password", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/reset-password", url.Values{
 		"token":            {rawToken},
 		"new_password":     {"short"},
 		"confirm_password": {"short"},
@@ -262,7 +262,7 @@ func (s *OAuthFlowSuite) TestPasswordResetTooShort() {
 
 func (s *OAuthFlowSuite) TestForgotPasswordNoEmailEnumeration() {
 	// Request reset for non-existent email - should return same response as valid email
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/forgot-password", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/forgot-password", url.Values{
 		"email": {"nonexistent@example.com"},
 	})
 	s.Require().NoError(err)
@@ -293,7 +293,7 @@ func (s *OAuthFlowSuite) TestForgotUsernameFlow() {
 	s.Require().NoError(err)
 
 	// Request username reminder
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/forgot-username", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/forgot-username", url.Values{
 		"email": {emailAddr},
 	})
 	s.Require().NoError(err)
@@ -308,7 +308,7 @@ func (s *OAuthFlowSuite) TestForgotUsernameFlow() {
 
 func (s *OAuthFlowSuite) TestForgotUsernameNoEmailEnumeration() {
 	// Request reminder for non-existent email - should return same response as valid email
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/forgot-username", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/forgot-username", url.Values{
 		"email": {"nonexistent@example.com"},
 	})
 	s.Require().NoError(err)
@@ -329,7 +329,7 @@ func (s *OAuthFlowSuite) TestForgotUsernameGetPage() {
 }
 
 func (s *OAuthFlowSuite) TestForgotUsernameMissingEmail() {
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/forgot-username", url.Values{})
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/forgot-username", url.Values{})
 	s.Require().NoError(err)
 	defer resp.Body.Close()
 	s.Equal(http.StatusBadRequest, resp.StatusCode)
@@ -361,7 +361,7 @@ func (s *OAuthFlowSuite) TestPasswordResetUpdatesPasswordChangedAt() {
 
 	// Reset password using the token
 	newPassword := s.mustGenerateRandomString(16)
-	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/reset-password", url.Values{
+	resp, err := csrfPostFormLogin(s.T(), s.httpClient, "http://localhost:8080/oauth/reset-password", url.Values{
 		"token":            {rawToken},
 		"new_password":     {newPassword},
 		"confirm_password": {newPassword},

--- a/pkg/httpserver/register.go
+++ b/pkg/httpserver/register.go
@@ -33,6 +33,7 @@ func (s *Server) HandleRegisterGet(w http.ResponseWriter, r *http.Request) {
 		Scope:               strings.Split(r.URL.Query().Get("scope"), " "),
 		CodeChallenge:       r.URL.Query().Get("code_challenge"),
 		CodeChallengeMethod: r.URL.Query().Get("code_challenge_method"),
+		CSRFToken:           s.ensureCSRFToken(w, r),
 	}
 	if err := s.registerTemplate.Execute(w, oauthParams); err != nil {
 		http.Error(w, "An error occurred while rendering the registration page", http.StatusInternalServerError)
@@ -61,7 +62,7 @@ func (s *Server) HandleRegisterPost(w http.ResponseWriter, r *http.Request) {
 
 	// Validate required fields
 	if username == "" || email == "" || password == "" {
-		s.renderRegisterError(w, http.StatusBadRequest, "All fields are required", RegisterPageData{
+		s.renderRegisterError(w, r, http.StatusBadRequest, "All fields are required", RegisterPageData{
 			Username: username,
 			Email:    email,
 		})
@@ -70,7 +71,7 @@ func (s *Server) HandleRegisterPost(w http.ResponseWriter, r *http.Request) {
 
 	// Validate password match
 	if password != confirmPassword {
-		s.renderRegisterError(w, http.StatusBadRequest, "Passwords do not match", RegisterPageData{
+		s.renderRegisterError(w, r, http.StatusBadRequest, "Passwords do not match", RegisterPageData{
 			Username: username,
 			Email:    email,
 		})
@@ -79,7 +80,7 @@ func (s *Server) HandleRegisterPost(w http.ResponseWriter, r *http.Request) {
 
 	// Validate password requirements
 	if err := auth.ValidatePassword(password, username); err != nil {
-		s.renderRegisterError(w, http.StatusBadRequest, err.Error(), RegisterPageData{
+		s.renderRegisterError(w, r, http.StatusBadRequest, err.Error(), RegisterPageData{
 			Username: username,
 			Email:    email,
 		})
@@ -89,7 +90,7 @@ func (s *Server) HandleRegisterPost(w http.ResponseWriter, r *http.Request) {
 	// Hash password
 	hash, err := auth.HashPassword(password)
 	if err != nil {
-		s.renderRegisterError(w, http.StatusInternalServerError, "An error occurred while creating your account", RegisterPageData{
+		s.renderRegisterError(w, r, http.StatusInternalServerError, "An error occurred while creating your account", RegisterPageData{
 			Username: username,
 			Email:    email,
 		})
@@ -112,7 +113,7 @@ func (s *Server) HandleRegisterPost(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Println("Error creating user:", err)
-		s.renderRegisterError(w, http.StatusInternalServerError, "An error occurred while creating your account", RegisterPageData{
+		s.renderRegisterError(w, r, http.StatusInternalServerError, "An error occurred while creating your account", RegisterPageData{
 			Username:            username,
 			Email:               email,
 			ClientID:            clientID,
@@ -152,7 +153,8 @@ func (s *Server) HandleRegisterPost(w http.ResponseWriter, r *http.Request) {
 
 // renderRegisterError renders the registration page with an error message, preserving user input and OAuth parameters.
 // It handles template execution errors gracefully by falling back to the error template.
-func (s *Server) renderRegisterError(w http.ResponseWriter, statusCode int, errorMsg string, data RegisterPageData) {
+func (s *Server) renderRegisterError(w http.ResponseWriter, r *http.Request, statusCode int, errorMsg string, data RegisterPageData) {
+	csrfToken := s.ensureCSRFToken(w, r)
 	w.WriteHeader(statusCode)
 	err := s.registerTemplate.Execute(w, RegisterPageData{
 		Error:               errorMsg,
@@ -164,6 +166,7 @@ func (s *Server) renderRegisterError(w http.ResponseWriter, statusCode int, erro
 		Scope:               data.Scope,
 		CodeChallenge:       data.CodeChallenge,
 		CodeChallengeMethod: data.CodeChallengeMethod,
+		CSRFToken:           csrfToken,
 	})
 	if err != nil {
 		// Fallback to error template if register template fails

--- a/pkg/httpserver/routes.go
+++ b/pkg/httpserver/routes.go
@@ -58,66 +58,85 @@ func (s *Server) registerRoutes() {
 		// Apply CORS middleware to all OAuth routes
 		r.Use(oauthCorsMiddleware)
 
-		// Core auth stuff
+		// --- Machine-to-machine / non-browser endpoints (NO CSRF) ---
+		// These authenticate with Authorization headers, client credentials, or
+		// single-use tokens in the request body and have no browser form or
+		// session_id cookie. Requiring a CSRF token here would break every
+		// programmatic OAuth2/OIDC client, so they are deliberately kept out of the
+		// CSRF-protected group below.
 		r.Get("/authorize", s.HandleOauthAuthorize)
-		r.Get("/login", s.HandleLoginGet)
-		r.Post("/login", s.HandleLoginPost)
-		r.Get("/consent", s.HandleConsentGet)
-		r.Post("/consent", s.HandleConsentPost)
 		r.Post("/token", s.HandleOauthToken)
 		r.Post("/refresh", s.HandleOauthRefresh)
-		// Registration stuff
-		r.Get("/register", s.HandleRegisterGet)
-		r.Post("/register", s.HandleRegisterPost)
-		// Other stuff
-		r.Get("/success", s.HandleSuccess)
-		// Both GET and POST per OIDC RP-Initiated Logout 1.0 — browsers navigating to
-		// end_session_endpoint via redirect use GET; form posts use POST.
-		r.Get("/logout", s.HandleLogout)
-		r.Post("/logout", s.HandleLogout)
-		r.Get("/userinfo", s.HandleOauthUserInfo)
 		r.Post("/introspect", s.HandleIntrospect)
 		r.Post("/revoke", s.HandleOauthRevoke)
-		// Account settings
-		r.Get("/account-settings", s.HandleAccountSettingsGet)
-		// Change password
-		r.Get("/change-password", s.HandleChangePasswordGet)
-		r.Post("/change-password", s.HandleChangePasswordPost)
-		// Change username
-		r.Get("/change-username", s.HandleChangeUsernameGet)
-		r.Post("/change-username", s.HandleChangeUsernamePost)
-		// Change email
-		r.Get("/change-email", s.HandleChangeEmailGet)
-		r.Post("/change-email", s.HandleChangeEmailPost)
-		// Edit profile
-		r.Get("/edit-profile", s.HandleEditProfileGet)
-		r.Post("/edit-profile", s.HandleEditProfilePost)
-		// Change avatar
-		r.Get("/change-avatar", s.HandleChangeAvatarGet)
-		r.Post("/change-avatar", s.HandleChangeAvatarPost)
-		r.Post("/delete-avatar", s.HandleDeleteAvatarPost)
-		// Deactivate account
-		r.Post("/deactivate-account", s.HandleDeactivateAccountPost)
-		// Reactivate account
-		r.Post("/reactivate-account", s.HandleReactivateAccountPost)
-		// MFA verification (during login)
-		r.Get("/mfa", s.HandleMFAGet)
-		r.Post("/mfa", s.HandleMFAPost)
-		// MFA setup (from account settings)
-		r.Get("/mfa-setup", s.HandleMFASetupGet)
-		r.Post("/mfa-setup", s.HandleMFASetupPost)
-		r.Post("/mfa-disable", s.HandleMFADisablePost)
-		// Email verification
+		r.Get("/userinfo", s.HandleOauthUserInfo)
+		r.Get("/success", s.HandleSuccess)
+		// Email verification link (GET, single-use token in the query string).
 		r.Get("/verify-email", s.HandleVerifyEmail)
-		r.Post("/resend-verification", s.HandleResendVerification)
-		// Password reset
-		r.Get("/forgot-password", s.HandleForgotPasswordGet)
-		r.Post("/forgot-password", s.HandleForgotPasswordPost)
-		r.Get("/reset-password", s.HandleResetPasswordGet)
-		r.Post("/reset-password", s.HandleResetPasswordPost)
-		// Username reminder
-		r.Get("/forgot-username", s.HandleForgotUsernameGet)
-		r.Post("/forgot-username", s.HandleForgotUsernamePost)
+		// Logout via GET is the OIDC RP-Initiated Logout redirect target: browsers
+		// navigate to end_session_endpoint, so there is no form to carry a token and
+		// GET is a safe method anyway. The POST form variant lives in the CSRF group.
+		r.Get("/logout", s.HandleLogout)
+
+		// --- Browser, session-cookie form endpoints (CSRF protected) ---
+		// Every state-changing POST here is driven by a server-rendered HTML form
+		// authenticated by the session_id cookie, so it is vulnerable to CSRF and is
+		// guarded by the double-submit-cookie check in csrfMiddleware. Safe GET
+		// handlers are included so the group is cohesive; csrfMiddleware never checks
+		// GET/HEAD/OPTIONS and each GET seeds the csrf_token cookie via ensureCSRFToken.
+		r.Group(func(r chi.Router) {
+			r.Use(s.csrfMiddleware)
+
+			// Core auth
+			r.Get("/login", s.HandleLoginGet)
+			r.Post("/login", s.HandleLoginPost)
+			r.Get("/consent", s.HandleConsentGet)
+			r.Post("/consent", s.HandleConsentPost)
+			// Registration
+			r.Get("/register", s.HandleRegisterGet)
+			r.Post("/register", s.HandleRegisterPost)
+			// Logout (POST form variant)
+			r.Post("/logout", s.HandleLogout)
+			// Account settings
+			r.Get("/account-settings", s.HandleAccountSettingsGet)
+			// Change password
+			r.Get("/change-password", s.HandleChangePasswordGet)
+			r.Post("/change-password", s.HandleChangePasswordPost)
+			// Change username
+			r.Get("/change-username", s.HandleChangeUsernameGet)
+			r.Post("/change-username", s.HandleChangeUsernamePost)
+			// Change email
+			r.Get("/change-email", s.HandleChangeEmailGet)
+			r.Post("/change-email", s.HandleChangeEmailPost)
+			// Edit profile
+			r.Get("/edit-profile", s.HandleEditProfileGet)
+			r.Post("/edit-profile", s.HandleEditProfilePost)
+			// Change avatar
+			r.Get("/change-avatar", s.HandleChangeAvatarGet)
+			r.Post("/change-avatar", s.HandleChangeAvatarPost)
+			r.Post("/delete-avatar", s.HandleDeleteAvatarPost)
+			// Deactivate account
+			r.Post("/deactivate-account", s.HandleDeactivateAccountPost)
+			// Reactivate account
+			r.Post("/reactivate-account", s.HandleReactivateAccountPost)
+			// MFA verification (during login)
+			r.Get("/mfa", s.HandleMFAGet)
+			r.Post("/mfa", s.HandleMFAPost)
+			// MFA setup (from account settings)
+			r.Get("/mfa-setup", s.HandleMFASetupGet)
+			r.Post("/mfa-setup", s.HandleMFASetupPost)
+			r.Post("/mfa-disable", s.HandleMFADisablePost)
+			// Email verification (resend from account settings)
+			r.Post("/resend-verification", s.HandleResendVerification)
+			// Password reset
+			r.Get("/forgot-password", s.HandleForgotPasswordGet)
+			r.Post("/forgot-password", s.HandleForgotPasswordPost)
+			r.Get("/reset-password", s.HandleResetPasswordGet)
+			r.Post("/reset-password", s.HandleResetPasswordPost)
+			// Username reminder
+			r.Get("/forgot-username", s.HandleForgotUsernameGet)
+			r.Post("/forgot-username", s.HandleForgotUsernamePost)
+		})
 	})
 
 	// Admin API endpoints (require Bearer token with admin scopes)
@@ -172,7 +191,9 @@ func (s *Server) HandleSuccess(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
-	if err := s.successTemplate.Execute(w, nil); err != nil {
+	// The success page contains a POST logout form (a CSRF-protected route), so it
+	// must carry a CSRF token even though the success GET itself is not checked.
+	if err := s.successTemplate.Execute(w, struct{ CSRFToken string }{CSRFToken: s.ensureCSRFToken(w, r)}); err != nil {
 		http.Error(w, "An error occurred while rendering the success page", http.StatusInternalServerError)
 	}
 }

--- a/pkg/httpserver/templates.go
+++ b/pkg/httpserver/templates.go
@@ -10,6 +10,7 @@ type LoginPageData struct {
 	CodeChallenge       string
 	CodeChallengeMethod string
 	Nonce               string
+	CSRFToken           string
 }
 
 // RegisterPageData holds the data needed to render the registration page template.
@@ -23,6 +24,7 @@ type RegisterPageData struct {
 	Scope               []string
 	CodeChallenge       string
 	CodeChallengeMethod string
+	CSRFToken           string
 }
 
 // ScopeDescription maps a scope string to a human-readable description.
@@ -44,6 +46,7 @@ type ConsentPageData struct {
 	CodeChallengeMethod string
 	Nonce               string
 	ResponseType        string
+	CSRFToken           string
 }
 
 // ErrorPageData holds the data needed to render the error page template.
@@ -66,12 +69,14 @@ type AccountSettingsPageData struct {
 	IsInactive    bool
 	MfaEnabled    bool
 	EmailVerified bool
+	CSRFToken     string
 }
 
 // ChangePasswordPageData holds the data needed to render the change password page template.
 type ChangePasswordPageData struct {
-	Error   string
-	Success string
+	Error     string
+	Success   string
+	CSRFToken string
 }
 
 // ChangeUsernamePageData holds the data needed to render the change username page template.
@@ -79,6 +84,7 @@ type ChangeUsernamePageData struct {
 	Error           string
 	Success         string
 	CurrentUsername string
+	CSRFToken       string
 }
 
 // ChangeEmailPageData holds the data needed to render the change email page template.
@@ -86,18 +92,21 @@ type ChangeEmailPageData struct {
 	Error        string
 	Success      string
 	CurrentEmail string
+	CSRFToken    string
 }
 
 // ForgotPasswordPageData holds the data needed to render the forgot password page template.
 type ForgotPasswordPageData struct {
-	Error   string
-	Success string
+	Error     string
+	Success   string
+	CSRFToken string
 }
 
 // ResetPasswordPageData holds the data needed to render the reset password page template.
 type ResetPasswordPageData struct {
-	Error string
-	Token string
+	Error     string
+	Token     string
+	CSRFToken string
 }
 
 // EditProfilePageData holds the data needed to render the edit profile page template.
@@ -106,6 +115,7 @@ type EditProfilePageData struct {
 	Success    string
 	GivenName  string
 	FamilyName string
+	CSRFToken  string
 }
 
 // ChangeAvatarPageData holds the data needed to render the change avatar page template.
@@ -113,4 +123,5 @@ type ChangeAvatarPageData struct {
 	Error     string
 	Success   string
 	AvatarURL string
+	CSRFToken string
 }

--- a/templates/account-settings.html
+++ b/templates/account-settings.html
@@ -102,6 +102,7 @@
                     <div class="flex flex-col gap-3 w-full">
                         <p class="text-sm">Your email address is not verified. Some features may be limited until you verify your email.</p>
                         <form method="POST" action="/oauth/resend-verification">
+                            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                             <button type="submit" class="btn btn-sm w-full">Resend Verification Email</button>
                         </form>
                     </div>
@@ -111,6 +112,7 @@
 
             <div class="mb-6 pb-6">
                 <form method="POST" action="/oauth/logout">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                     <button type="submit" class="btn btn-outline btn-error w-full">Log Out</button>
                 </form>
             </div>
@@ -129,6 +131,7 @@
                     <details>
                         <summary class="text-sm text-error cursor-pointer hover:underline">Disable Two-Factor Authentication</summary>
                         <form method="POST" action="/oauth/mfa-disable" class="mt-4 p-4 bg-base-200 rounded-lg">
+                            <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                             <fieldset class="fieldset mb-4">
                                 <label class="fieldset-label" for="mfa-password">Password</label>
                                 <input type="password" id="mfa-password" name="password" placeholder="Enter your password" required autocomplete="current-password" class="input input-bordered w-full">
@@ -151,6 +154,7 @@
                 <h2 class="text-base font-semibold text-warning mb-4 pb-2 border-b border-warning">Account Deactivated</h2>
                 <p class="text-sm text-base-content/60 mb-4">Your account is deactivated. You cannot log in to applications until you reactivate your account.</p>
                 <form method="POST" action="/oauth/reactivate-account" class="mt-4">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                     <fieldset class="fieldset mb-4">
                         <label class="fieldset-label" for="password">Confirm your password to reactivate</label>
                         <input type="password" id="password" name="password" placeholder="Enter your password" required autocomplete="off" class="input input-bordered w-full">
@@ -163,6 +167,7 @@
                 <h2 class="text-base font-semibold text-error mb-4 pb-2 border-b border-error">Danger Zone</h2>
                 <p class="text-sm text-base-content/60 mb-4">Deactivating your account will prevent you from logging in to any applications. You will only be able to access this settings page.</p>
                 <form method="POST" action="/oauth/deactivate-account" class="mt-4">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                     <fieldset class="fieldset mb-4">
                         <label class="fieldset-label" for="password">Confirm your password to deactivate</label>
                         <input type="password" id="password" name="password" placeholder="Enter your password" required autocomplete="off" class="input input-bordered w-full">

--- a/templates/change-avatar.html
+++ b/templates/change-avatar.html
@@ -54,6 +54,7 @@
 
             <!-- Upload Form -->
             <form method="POST" action="/oauth/change-avatar" enctype="multipart/form-data">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="avatar">Select Image</label>
                     <input
@@ -84,6 +85,7 @@
 
             {{if .AvatarURL}}
             <form method="POST" action="/oauth/delete-avatar" class="mt-3">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <button type="submit" class="btn btn-outline btn-error w-full">Remove Avatar</button>
             </form>
             {{end}}

--- a/templates/change-email.html
+++ b/templates/change-email.html
@@ -38,6 +38,7 @@
             </div>
 
             <form method="POST" action="/oauth/change-email">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="new_email">New Email</label>
                     <input

--- a/templates/change-password.html
+++ b/templates/change-password.html
@@ -33,6 +33,7 @@
             {{end}}
 
             <form method="POST" action="/oauth/change-password">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="current_password">Current Password</label>
                     <input

--- a/templates/change-username.html
+++ b/templates/change-username.html
@@ -38,6 +38,7 @@
             </div>
 
             <form method="POST" action="/oauth/change-username">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="new_username">New Username</label>
                     <input

--- a/templates/consent.html
+++ b/templates/consent.html
@@ -40,6 +40,7 @@
             </div>
 
             <form method="POST" action="/oauth/consent" class="space-y-3">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <input type="hidden" name="client_id" value="{{.ClientID}}">
                 <input type="hidden" name="redirect_uri" value="{{.RedirectURI}}">
                 <input type="hidden" name="response_type" value="{{.ResponseType}}">

--- a/templates/edit-profile.html
+++ b/templates/edit-profile.html
@@ -33,6 +33,7 @@
             {{end}}
 
             <form method="POST" action="/oauth/edit-profile">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="given_name">First Name</label>
                     <input

--- a/templates/forgot-password.html
+++ b/templates/forgot-password.html
@@ -32,6 +32,7 @@
             </div>
             {{else}}
             <form method="POST" action="/oauth/forgot-password">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="email">Email Address</label>
                     <input

--- a/templates/forgot-username.html
+++ b/templates/forgot-username.html
@@ -32,6 +32,7 @@
             </div>
             {{else}}
             <form method="POST" action="/oauth/forgot-username">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="email">Email Address</label>
                     <input

--- a/templates/login.html
+++ b/templates/login.html
@@ -33,6 +33,7 @@
             {{end}}
 
             <form method="POST" action="/oauth/login">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="username">Username</label>
                     <input

--- a/templates/mfa-setup.html
+++ b/templates/mfa-setup.html
@@ -41,6 +41,7 @@
             {{end}}
 
             <form method="POST" action="/oauth/mfa-setup">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="code">Verification Code</label>
                     <input

--- a/templates/mfa.html
+++ b/templates/mfa.html
@@ -24,6 +24,7 @@
             {{end}}
 
             <form method="POST" action="/oauth/mfa">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="code">Verification Code</label>
                     <input

--- a/templates/register.html
+++ b/templates/register.html
@@ -24,6 +24,7 @@
             {{end}}
 
             <form method="POST" action="/oauth/register" id="registerForm" novalidate>
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <fieldset class="fieldset mb-4">
                     <label class="fieldset-label" for="username">Username</label>
                     <input

--- a/templates/reset-password.html
+++ b/templates/reset-password.html
@@ -24,6 +24,7 @@
             {{end}}
 
             <form method="POST" action="/oauth/reset-password">
+                <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                 <input type="hidden" name="token" value="{{.Token}}">
 
                 <fieldset class="fieldset mb-4">

--- a/templates/success.html
+++ b/templates/success.html
@@ -29,6 +29,7 @@
 
             <div class="flex flex-col gap-3">
                 <form method="POST" action="/oauth/logout" class="m-0">
+                    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
                     <button type="submit" class="btn btn-primary w-full">Log Out</button>
                 </form>
                 <a href="/oauth/login" class="btn btn-ghost w-full">Back to Login</a>


### PR DESCRIPTION
## Summary

Adds real CSRF protection (defense in depth on top of `SameSite=Lax`) to the server-rendered, session-cookie browser forms, and closes a cookie `Secure`-flag gap. No new dependency, no DB migration.

## Part A — Double-submit-cookie CSRF

`pkg/httpserver/csrf.go`:
- CSRF token = 32 random bytes from `crypto/rand`, base64url-encoded.
- `ensureCSRFToken(w, r)` reads-or-creates the `csrf_token` cookie and returns the value for GET handlers to embed as a hidden `<input name="csrf_token">`. Because the **server** renders the field, the cookie is `HttpOnly` (JS never reads it). Flags: `Path=/`, `HttpOnly`, `SameSite=Lax`, `Secure` from `isSecureContext`; it is a session cookie so the same token survives multi-step flows (login → mfa).
- `csrfMiddleware` validates non-safe methods: both `csrf_token` cookie and form value must be present and equal via `crypto/subtle.ConstantTimeCompare`, else **403** (rendered through the existing `renderError`). GET/HEAD/OPTIONS are never checked.

### Routing — protect vs exempt
`routes.go` splits `/oauth` into two chi groups so the middleware is applied to the **browser-form group only**, never globally-with-exceptions:

- **Protected (CSRF):** `/oauth/login`, `/consent`, `/register`, `/logout` (POST), `/change-password`, `/change-username`, `/change-email`, `/edit-profile`, `/change-avatar`, `/delete-avatar`, `/deactivate-account`, `/reactivate-account`, `/mfa`, `/mfa-setup`, `/mfa-disable`, `/resend-verification`, `/forgot-password`, `/reset-password`, `/forgot-username` (plus their GET form handlers, which only seed the cookie — GET is never checked).
- **Exempt (no CSRF):** `/oauth/token`, `/refresh`, `/introspect`, `/revoke`, and the admin API `/admin/users`. These authenticate with Authorization headers / client credentials / API keys and have no browser form; requiring a token would break programmatic clients. `GET /oauth/logout` (OIDC RP-initiated logout redirect target) stays exempt because GET is safe.

The login→MFA flow works because the `csrf_token` cookie (Path=/) set on the login page persists to the `/oauth/mfa` page, which re-embeds it from the same cookie.

### Templates & page data
Added the hidden `csrf_token` input to every protected form: login, consent, register, change-password, change-username, change-email, edit-profile, change-avatar (upload + delete), mfa, mfa-setup, forgot-password, forgot-username, reset-password, success (its logout form), and all five account-settings forms (resend-verification, logout, mfa-disable, reactivate, deactivate). Added a `CSRFToken` field to each page-data struct (`templates.go`, `MFAPageData`, `MFASetupPageData`) and populated it in the GET handlers and error re-render helpers, via small DRY render helpers where a template had many render sites (`renderAccountSettings`, `renderChangeAvatar`, `renderForgot*`/`renderResetPassword`).

## Part B — cookie Secure-flag audit

Audited all `http.SetCookie` sites. The change-password logout cookie in `account.go` (set with `MaxAge:-1` after a password change) was missing `Secure`; it now uses `s.isSecureContext()`, matching `setSessionCookie`, the logout cookie, and the deactivate cookie. The new `csrf_token` cookie also derives `Secure` the same way. All five cookie sites are now consistent.

## Tests

- New hermetic `csrf_test.go`: missing token → 403, cookie-present/form-missing → 403, mismatch → 403, matching → passes, safe methods never checked, exempt `/oauth/token` not blocked, and `ensureCSRFToken` create/reuse behavior.
- Updated integration helpers to perform the handshake: a shared `fetchCSRFToken` (GET the form, read the `csrf_token` cookie, falling back to the jar) plus `csrfPostForm`/`csrfPostFormLogin` wrappers. `mustCompleteOAuthFlow`, `mustLoginAndConsent`, and `mustLoginAndGetAuthorizeClient` now fetch a token once and submit it on login+consent. The manual flows in `mfa_test.go`, `oidc_test.go`, `oauth_flow_test.go`, `password_reset_flow_test.go`, `email_verification_flow_test.go`, `authorize_consent_test.go` (incl. the logout POST tests), and `admin_test.go` route their protected POSTs through the CSRF-aware wrapper; exempt token/refresh/introspect/revoke calls were left untouched. `avatar_integration_test.go` seeds the cookie in `loginAndGetClient` and adds a `csrf_token` field to each multipart upload / delete-avatar / consent POST.
- Local: `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, and `go test ./...` all pass. The integration suite (`TestOAuthFlowSuite`/`TestAvatarFlowSuite`) requires Postgres/MinIO and could not be run locally — correctness there comes from careful reading; CI will execute it.

### Reviewer caveat
The integration suite was not run locally (no Postgres/MinIO). The CSRF-aware POST wrappers add one extra `GET /oauth/login` per protected POST in the manual flows to seed the token; this is well within the 20 req/IP/min rate limit (reset per test), but is the main thing to watch if CI flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE