### PR TITLE
Gate [DEBUG] logging behind a config flag

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,6 +32,10 @@ type Config struct {
 	StorageSecretKey string
 	StoragePublicURL string // Public URL base for serving files
 	StorageRegion    string // AWS region (default: "auto" for R2)
+
+	// Debug enables verbose [DEBUG] logging of flow/user-ID details in pkg/httpserver
+	// (see Server.debugf). Off by default; set DEBUG=true to enable.
+	Debug bool
 }
 
 func NewFromEnv() *Config {
@@ -56,6 +60,7 @@ func NewFromEnv() *Config {
 			StorageSecretKey: os.Getenv("STORAGE_SECRET_KEY"),
 			StoragePublicURL: os.Getenv("STORAGE_PUBLIC_URL"),
 			StorageRegion:    os.Getenv("STORAGE_REGION"),
+			Debug:            os.Getenv("DEBUG") == "true",
 		}
 	} else {
 		// Local development: load from .env files
@@ -82,6 +87,7 @@ func NewFromEnv() *Config {
 			StorageSecretKey: os.Getenv("STORAGE_SECRET_KEY"),
 			StoragePublicURL: os.Getenv("STORAGE_PUBLIC_URL"),
 			StorageRegion:    os.Getenv("STORAGE_REGION"),
+			Debug:            os.Getenv("DEBUG") == "true",
 		}
 	}
 

--- a/pkg/httpserver/account.go
+++ b/pkg/httpserver/account.go
@@ -42,7 +42,7 @@ func (s *Server) HandleAccountSettingsGet(w http.ResponseWriter, r *http.Request
 	// Get user from session - including inactive users so they can see their account settings
 	user, err := s.getUserFromSessionIncludingInactive(r)
 	if err != nil {
-		log.Printf("[DEBUG] HandleAccountSettingsGet: Failed to get user from session: %v", err)
+		s.debugf("HandleAccountSettingsGet: Failed to get user from session: %v", err)
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -180,7 +180,7 @@ func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	log.Printf("[DEBUG] HandleChangePasswordPost: Password updated successfully for user: %s", user.Username)
+	s.debugf("HandleChangePasswordPost: Password updated successfully for user: %s", user.Username)
 
 	// A password change is a credential change: log the user out everywhere.
 	// Revoke all OAuth tokens and delete all sessions (including the current
@@ -299,7 +299,7 @@ func (s *Server) HandleChangeUsernamePost(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	log.Printf("[DEBUG] HandleChangeUsernamePost: Username updated successfully from %s to %s", user.Username, newUsername)
+	s.debugf("HandleChangeUsernamePost: Username updated successfully from %s to %s", user.Username, newUsername)
 	s.changeUsernameTemplate.Execute(w, ChangeUsernamePageData{
 		Success:         "Username updated successfully",
 		CurrentUsername: newUsername,
@@ -394,7 +394,7 @@ func (s *Server) HandleChangeEmailPost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("[DEBUG] HandleChangeEmailPost: Email updated successfully from %s to %s", user.Email, newEmail)
+	s.debugf("HandleChangeEmailPost: Email updated successfully from %s to %s", user.Email, newEmail)
 
 	// The new address hasn't been verified yet (UpdateUserEmail resets
 	// email_verified to false), so send a fresh verification email to it.
@@ -470,7 +470,7 @@ func (s *Server) HandleEditProfilePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("[DEBUG] HandleEditProfilePost: Profile updated successfully for user: %s", user.Username)
+	s.debugf("HandleEditProfilePost: Profile updated successfully for user: %s", user.Username)
 	s.editProfileTemplate.Execute(w, EditProfilePageData{
 		Success:    "Profile updated successfully",
 		GivenName:  givenName,
@@ -613,7 +613,7 @@ func (s *Server) HandleDeactivateAccountPost(w http.ResponseWriter, r *http.Requ
 		// Continue anyway - account is deactivated, tokens will be rejected on use
 	}
 
-	log.Printf("[DEBUG] HandleDeactivateAccountPost: User %s deactivated successfully", user.Username)
+	s.debugf("HandleDeactivateAccountPost: User %s deactivated successfully", user.Username)
 
 	// Delete the session and clear the cookie
 	cookie, _ := r.Cookie("session_id")
@@ -702,7 +702,7 @@ func (s *Server) HandleReactivateAccountPost(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	log.Printf("[DEBUG] HandleReactivateAccountPost: User %s reactivated successfully", user.Username)
+	s.debugf("HandleReactivateAccountPost: User %s reactivated successfully", user.Username)
 
 	// Redirect to account settings with success message
 	http.Redirect(w, r, "/oauth/account-settings?reactivated=true", http.StatusFound)
@@ -816,7 +816,7 @@ func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	log.Printf("[DEBUG] HandleChangeAvatarPost: Avatar updated for user %s", user.Username)
+	s.debugf("HandleChangeAvatarPost: Avatar updated for user %s", user.Username)
 	s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 		Success:   "Avatar updated successfully.",
 		AvatarURL: avatarURL,
@@ -860,6 +860,6 @@ func (s *Server) HandleDeleteAvatarPost(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	log.Printf("[DEBUG] HandleDeleteAvatarPost: Avatar deleted for user %s", user.Username)
+	s.debugf("HandleDeleteAvatarPost: Avatar deleted for user %s", user.Username)
 	http.Redirect(w, r, "/oauth/change-avatar?success=avatar_deleted", http.StatusFound)
 }

--- a/pkg/httpserver/logging.go
+++ b/pkg/httpserver/logging.go
@@ -40,6 +40,18 @@ func requestLoggingMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+// debugf logs a [DEBUG]-prefixed message when config.Debug is enabled (DEBUG=true), and
+// is a no-op otherwise. Handlers use it for verbose flow/user-ID logging that is useful
+// while debugging auth flows locally but too noisy to leave on unconditionally in
+// production. Callers should not include the "[DEBUG] " prefix or a trailing newline in
+// format; debugf adds the prefix itself (log.Printf already appends the newline).
+func (s *Server) debugf(format string, args ...any) {
+	if !s.config.Debug {
+		return
+	}
+	log.Printf("[DEBUG] "+format, args...)
+}
+
 // redactedRequestPath returns the request path and query string with the value of any
 // sensitive query parameter (see sensitiveQueryParams) replaced by "REDACTED". Requests
 // with no sensitive parameters are returned unmodified (aside from re-serialization via

--- a/pkg/httpserver/logging_test.go
+++ b/pkg/httpserver/logging_test.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/eswan18/identity/pkg/config"
 )
 
 // TestRedactedRequestPath_RedactsToken is a regression test for secrets leaking into
@@ -106,4 +108,45 @@ func TestRequestLoggingMiddleware_DoesNotLogToken(t *testing.T) {
 	if !strings.Contains(logged, "200") {
 		t.Errorf("request log is missing the status code: %q", logged)
 	}
+}
+
+// TestServer_Debugf verifies that debugf is gated on config.Debug: it must be silent
+// by default (Debug: false) and only emit its [DEBUG]-prefixed line when Debug is
+// explicitly enabled. This is a regression test for the [DEBUG] logs in pkg/httpserver
+// firing unconditionally on every request in production.
+func TestServer_Debugf(t *testing.T) {
+	captureLog := func(t *testing.T, fn func()) string {
+		t.Helper()
+		var buf bytes.Buffer
+		oldOutput := log.Writer()
+		oldFlags := log.Flags()
+		log.SetOutput(&buf)
+		log.SetFlags(0)
+		t.Cleanup(func() {
+			log.SetOutput(oldOutput)
+			log.SetFlags(oldFlags)
+		})
+		fn()
+		return buf.String()
+	}
+
+	t.Run("does not log when Debug is false", func(t *testing.T) {
+		s := &Server{config: &config.Config{Debug: false}}
+		logged := captureLog(t, func() {
+			s.debugf("user %s did something", "alice")
+		})
+		if logged != "" {
+			t.Errorf("debugf logged output while config.Debug was false: %q", logged)
+		}
+	})
+
+	t.Run("logs with [DEBUG] prefix when Debug is true", func(t *testing.T) {
+		s := &Server{config: &config.Config{Debug: true}}
+		logged := captureLog(t, func() {
+			s.debugf("user %s did something", "alice")
+		})
+		if !strings.Contains(logged, "[DEBUG] user alice did something") {
+			t.Errorf("debugf output = %q, want it to contain %q", logged, "[DEBUG] user alice did something")
+		}
+	})
 }

--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -116,7 +116,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 // @Failure      401 {string} string "Invalid credentials"
 // @Router       /login [post]
 func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
-	log.Printf("[DEBUG] HandleLoginPost: Starting login request")
+	s.debugf("HandleLoginPost: Starting login request")
 	username := r.FormValue("username")
 	password := r.FormValue("password")
 	clientID := r.FormValue("client_id")
@@ -141,7 +141,7 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	// so we can handle deactivated users appropriately based on the login type
 	user, err := s.validateCredentialsIncludingInactive(r.Context(), username, password)
 	if err != nil {
-		log.Printf("[DEBUG] HandleLoginPost: Credential validation failed: %v", err)
+		s.debugf("HandleLoginPost: Credential validation failed: %v", err)
 		status := http.StatusInternalServerError
 		if errors.Is(err, ErrMissingCredentials) {
 			status = http.StatusBadRequest
@@ -151,19 +151,19 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 		s.renderLoginError(w, r, status, err.Error(), oauthParams)
 		return
 	}
-	log.Printf("[DEBUG] HandleLoginPost: Credentials validated successfully for user ID: %v", user.ID)
+	s.debugf("HandleLoginPost: Credentials validated successfully for user ID: %v", user.ID)
 
 	// Check if user is deactivated and trying to use OAuth login
 	// Deactivated users can only log in directly (no client_id) to access account settings
 	if !user.IsActive && clientID != "" {
-		log.Printf("[DEBUG] HandleLoginPost: Deactivated user (ID: %v) attempted OAuth login", user.ID)
+		s.debugf("HandleLoginPost: Deactivated user (ID: %v) attempted OAuth login", user.ID)
 		s.renderLoginError(w, r, http.StatusForbidden, ErrAccountDeactivated.Error(), oauthParams)
 		return
 	}
 
 	// Check if MFA is enabled for this user
 	if user.MfaEnabled {
-		log.Printf("[DEBUG] HandleLoginPost: MFA enabled for user (ID: %v), creating pending session", user.ID)
+		s.debugf("HandleLoginPost: MFA enabled for user (ID: %v), creating pending session", user.ID)
 		pendingID, err := s.createMFAPendingSession(r, user.ID, oauthParams)
 		if err != nil {
 			log.Printf("[ERROR] HandleLoginPost: Failed to create MFA pending session: %v", err)
@@ -176,7 +176,7 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Create authenticated session
-	log.Printf("[DEBUG] HandleLoginPost: Creating session for user ID: %v", user.ID)
+	s.debugf("HandleLoginPost: Creating session for user ID: %v", user.ID)
 	session, err := s.createSession(r.Context(), user.ID)
 	if err != nil {
 		log.Printf("[ERROR] HandleLoginPost: Failed to create session: %v", err)
@@ -187,7 +187,7 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	// value sent as the session_id cookie, so writing it to logs would let anyone with
 	// log access hijack the session (same class of issue as the reset/verification
 	// tokens -- see the request-logging middleware in logging.go).
-	log.Printf("[DEBUG] HandleLoginPost: Session created successfully for user ID: %v", user.ID)
+	s.debugf("HandleLoginPost: Session created successfully for user ID: %v", user.ID)
 
 	// Update last login timestamp
 	if err := s.datastore.Q.UpdateUserLastLogin(r.Context(), user.ID); err != nil {

--- a/pkg/httpserver/mfa.go
+++ b/pkg/httpserver/mfa.go
@@ -78,7 +78,7 @@ func (s *Server) HandleMFAGet(w http.ResponseWriter, r *http.Request) {
 	// from it (server-side, authoritative) so the rendered form can carry it on submit.
 	pending, err := s.datastore.Q.GetMFAPending(r.Context(), pendingID)
 	if err != nil {
-		log.Printf("[DEBUG] HandleMFAGet: Invalid or expired pending MFA session: %v", err)
+		s.debugf("HandleMFAGet: Invalid or expired pending MFA session: %v", err)
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -118,7 +118,7 @@ func (s *Server) HandleMFAPost(w http.ResponseWriter, r *http.Request) {
 		// duplicate/replayed submit already consumed it. Do NOT discard the OAuth
 		// context — resume the flow so the user returns to the originating app instead
 		// of being stranded on a context-free login (and then the account page).
-		log.Printf("[DEBUG] HandleMFAPost: pending MFA session missing/expired (%v); resuming with carried OAuth context", err)
+		s.debugf("HandleMFAPost: pending MFA session missing/expired (%v); resuming with carried OAuth context", err)
 		s.resumeMFAFlow(w, r, formParams)
 		return
 	}
@@ -143,7 +143,7 @@ func (s *Server) HandleMFAPost(w http.ResponseWriter, r *http.Request) {
 	// Validate the TOTP code. A wrong code leaves the pending row intact so the user can
 	// retry within the validity window.
 	if !mfa.ValidateCode(mfaStatus.MfaSecret.String, code) {
-		log.Printf("[DEBUG] HandleMFAPost: Invalid MFA code for user: %v", pending.UserID)
+		s.debugf("HandleMFAPost: Invalid MFA code for user: %v", pending.UserID)
 		s.renderMFAError(w, r, http.StatusUnauthorized, "Invalid verification code", pendingID, pendingParams)
 		return
 	}

--- a/pkg/httpserver/mfa_setup.go
+++ b/pkg/httpserver/mfa_setup.go
@@ -122,7 +122,7 @@ func (s *Server) HandleMFASetupPost(w http.ResponseWriter, r *http.Request) {
 		// No valid pending secret: enrollment was never started, or it expired while
 		// the user entered their code. Send them back to GET to start fresh so a new
 		// secret and QR are generated together.
-		log.Printf("[DEBUG] HandleMFASetupPost: No valid pending MFA secret for user %s: %v", user.Username, err)
+		s.debugf("HandleMFASetupPost: No valid pending MFA secret for user %s: %v", user.Username, err)
 		http.Redirect(w, r, "/oauth/mfa-setup", http.StatusFound)
 		return
 	}
@@ -155,7 +155,7 @@ func (s *Server) HandleMFASetupPost(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[ERROR] HandleMFASetupPost: Failed to delete pending MFA secret: %v", err)
 	}
 
-	log.Printf("[DEBUG] HandleMFASetupPost: MFA enabled for user: %s", user.Username)
+	s.debugf("HandleMFASetupPost: MFA enabled for user: %s", user.Username)
 
 	// Redirect to account settings with success message
 	http.Redirect(w, r, "/oauth/account-settings?mfa_enabled=true", http.StatusFound)
@@ -246,7 +246,7 @@ func (s *Server) HandleMFADisablePost(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("[DEBUG] HandleMFADisablePost: MFA disabled for user: %s", user.Username)
+	s.debugf("HandleMFADisablePost: MFA disabled for user: %s", user.Username)
 
 	// Redirect to account settings with success message
 	http.Redirect(w, r, "/oauth/account-settings?mfa_disabled=true", http.StatusFound)

--- a/pkg/httpserver/password_reset.go
+++ b/pkg/httpserver/password_reset.go
@@ -88,7 +88,7 @@ func (s *Server) HandleForgotPasswordPost(w http.ResponseWriter, r *http.Request
 	user, err := s.datastore.Q.GetUserByEmail(r.Context(), emailAddr)
 	if err != nil {
 		// User not found - still show success message (no email enumeration)
-		log.Printf("[DEBUG] HandleForgotPasswordPost: No user found for email %s", emailAddr)
+		s.debugf("HandleForgotPasswordPost: No user found for email %s", emailAddr)
 		s.renderForgotPassword(w, r, ForgotPasswordPageData{
 			Success: successMsg,
 		})
@@ -149,7 +149,7 @@ If you didn't request this, you can safely ignore this email.
 		// Still show success to prevent enumeration, but log the error
 	}
 
-	log.Printf("[DEBUG] HandleForgotPasswordPost: Password reset email sent to %s", emailAddr)
+	s.debugf("HandleForgotPasswordPost: Password reset email sent to %s", emailAddr)
 	s.renderForgotPassword(w, r, ForgotPasswordPageData{
 		Success: successMsg,
 	})
@@ -179,7 +179,7 @@ func (s *Server) HandleResetPasswordGet(w http.ResponseWriter, r *http.Request) 
 	tokenHash := hashToken(token)
 	_, err := s.datastore.Q.GetPasswordResetTokenByHash(r.Context(), tokenHash)
 	if err != nil {
-		log.Printf("[DEBUG] HandleResetPasswordGet: Invalid or expired token")
+		s.debugf("HandleResetPasswordGet: Invalid or expired token")
 		w.WriteHeader(http.StatusBadRequest)
 		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "This password reset link is invalid or has expired. Please request a new one.",
@@ -240,7 +240,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 	tokenHash := hashToken(token)
 	tokenRecord, err := s.datastore.Q.GetPasswordResetTokenByHash(r.Context(), tokenHash)
 	if err != nil {
-		log.Printf("[DEBUG] HandleResetPasswordPost: Invalid or expired token")
+		s.debugf("HandleResetPasswordPost: Invalid or expired token")
 		w.WriteHeader(http.StatusBadRequest)
 		s.renderResetPassword(w, r, ResetPasswordPageData{
 			Error: "This password reset link is invalid or has expired. Please request a new one.",
@@ -310,7 +310,7 @@ func (s *Server) HandleResetPasswordPost(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	log.Printf("[DEBUG] HandleResetPasswordPost: Password reset successfully for user %s", tokenRecord.Username)
+	s.debugf("HandleResetPasswordPost: Password reset successfully for user %s", tokenRecord.Username)
 
 	// A password reset is a credential change: log the user out everywhere.
 	// Revoke all OAuth tokens and delete all sessions for this user, same as
@@ -369,7 +369,7 @@ func (s *Server) HandleForgotUsernamePost(w http.ResponseWriter, r *http.Request
 	user, err := s.datastore.Q.GetUserByEmail(r.Context(), emailAddr)
 	if err != nil {
 		// User not found - still show success message (no email enumeration)
-		log.Printf("[DEBUG] HandleForgotUsernamePost: No user found for email %s", emailAddr)
+		s.debugf("HandleForgotUsernamePost: No user found for email %s", emailAddr)
 		s.renderForgotUsername(w, r, ForgotPasswordPageData{
 			Success: successMsg,
 		})
@@ -401,7 +401,7 @@ If you didn't request this, you can safely ignore this email.
 		// Still show success to prevent enumeration, but log the error
 	}
 
-	log.Printf("[DEBUG] HandleForgotUsernamePost: Username reminder email sent to %s", emailAddr)
+	s.debugf("HandleForgotUsernamePost: Username reminder email sent to %s", emailAddr)
 	s.renderForgotUsername(w, r, ForgotPasswordPageData{
 		Success: successMsg,
 	})


### PR DESCRIPTION
## Summary

The ~29 `log.Printf("[DEBUG] ...")` calls in `pkg/httpserver/*.go` fired unconditionally on every request, producing noisy production logs. They no longer log secrets (a prior fix addressed that — they log user IDs and flow events), so this was a hygiene issue rather than a leak, but they should still be off by default in production.

## Changes

- **`pkg/config/config.go`**: added `Config.Debug bool`, read from the `DEBUG` env var (`os.Getenv("DEBUG") == "true"`), defaulting to `false`. Set in both the Koyeb and local-dev config-construction branches, following the existing pattern for every other env-backed field.
- **`pkg/httpserver/logging.go`**: added a `(s *Server) debugf(format string, args ...any)` helper next to the existing request-logging middleware. It logs `"[DEBUG] " + format` via `log.Printf` only when `s.config.Debug` is true; otherwise it's a no-op. The request-logging middleware itself (`requestLoggingMiddleware`) is untouched.
- **`pkg/httpserver/{account,login,mfa,mfa_setup,password_reset}.go`**: converted all 29 `log.Printf("[DEBUG] ...")` call sites to `s.debugf(...)`, stripping the now-redundant `[DEBUG]` prefix from each format string. Every call site was already inside a `*Server` method, so no threading of the server/config was needed and nothing was dropped.
- **`pkg/httpserver/logging_test.go`**: added `TestServer_Debugf`, a hermetic test (captures `log`'s output via `log.SetOutput`) asserting `debugf` is silent when `config.Debug` is false and emits the `[DEBUG]`-prefixed line when it's true.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags integration ./...`
- [x] `go test ./...` (all packages pass, including the new `TestServer_Debugf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE