### PR TITLE
Refactor: extract shared base layout and alert partials for templates

### DIFF
--- a/pkg/httpserver/server.go
+++ b/pkg/httpserver/server.go
@@ -46,24 +46,44 @@ type Server struct {
 	consentTemplate         *template.Template
 }
 
+// mustParsePageTemplate parses a page template together with the shared
+// base.html layout and partials.html partials (alert boxes, icons, footer)
+// into a single template set, and panics if parsing fails (mirroring the
+// prior template.Must(template.ParseFiles(...)) behavior at startup).
+//
+// base.html is parsed first, so the returned *template.Template is named
+// "base.html" and its top-level body is the full page skeleton (doctype,
+// head, card wrapper). That skeleton references {{block "title" .}},
+// {{block "content" .}}, etc., which page (the last file parsed) then
+// overrides with its own {{define "title"}}/{{define "content"}} blocks -
+// later definitions in the same parse win, so callers can keep calling
+// Execute(w, data) exactly as before and get the fully rendered page.
+func mustParsePageTemplate(templatesDir, page string) *template.Template {
+	return template.Must(template.ParseFiles(
+		templatesDir+"/base.html",
+		templatesDir+"/partials.html",
+		templatesDir+"/"+page,
+	))
+}
+
 func New(config *config.Config, datastore *store.Store, emailSender email.Sender, storageProvider storage.Storage) *Server {
 	r := chi.NewRouter()
-	loginTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/login.html"))
-	registerTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/register.html"))
-	errorTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/error.html"))
-	successTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/success.html"))
-	accountSettingsTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/account-settings.html"))
-	changePasswordTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/change-password.html"))
-	changeUsernameTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/change-username.html"))
-	changeEmailTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/change-email.html"))
-	mfaTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/mfa.html"))
-	mfaSetupTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/mfa-setup.html"))
-	forgotPasswordTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/forgot-password.html"))
-	resetPasswordTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/reset-password.html"))
-	forgotUsernameTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/forgot-username.html"))
-	editProfileTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/edit-profile.html"))
-	changeAvatarTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/change-avatar.html"))
-	consentTemplate := template.Must(template.ParseFiles(config.TemplatesDir + "/consent.html"))
+	loginTemplate := mustParsePageTemplate(config.TemplatesDir, "login.html")
+	registerTemplate := mustParsePageTemplate(config.TemplatesDir, "register.html")
+	errorTemplate := mustParsePageTemplate(config.TemplatesDir, "error.html")
+	successTemplate := mustParsePageTemplate(config.TemplatesDir, "success.html")
+	accountSettingsTemplate := mustParsePageTemplate(config.TemplatesDir, "account-settings.html")
+	changePasswordTemplate := mustParsePageTemplate(config.TemplatesDir, "change-password.html")
+	changeUsernameTemplate := mustParsePageTemplate(config.TemplatesDir, "change-username.html")
+	changeEmailTemplate := mustParsePageTemplate(config.TemplatesDir, "change-email.html")
+	mfaTemplate := mustParsePageTemplate(config.TemplatesDir, "mfa.html")
+	mfaSetupTemplate := mustParsePageTemplate(config.TemplatesDir, "mfa-setup.html")
+	forgotPasswordTemplate := mustParsePageTemplate(config.TemplatesDir, "forgot-password.html")
+	resetPasswordTemplate := mustParsePageTemplate(config.TemplatesDir, "reset-password.html")
+	forgotUsernameTemplate := mustParsePageTemplate(config.TemplatesDir, "forgot-username.html")
+	editProfileTemplate := mustParsePageTemplate(config.TemplatesDir, "edit-profile.html")
+	changeAvatarTemplate := mustParsePageTemplate(config.TemplatesDir, "change-avatar.html")
+	consentTemplate := mustParsePageTemplate(config.TemplatesDir, "consent.html")
 
 	r.Use(middleware.RequestID)
 	// NOTE: chi's middleware.RealIP is intentionally NOT used here. It

--- a/pkg/httpserver/templates_render_test.go
+++ b/pkg/httpserver/templates_render_test.go
@@ -1,0 +1,389 @@
+package httpserver
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// testTemplatesDir mirrors the relative path used by other package tests
+// (see login_test.go) to point at the repo's templates/ directory.
+const testTemplatesDir = "../../templates"
+
+// requireContainsAll fails the test with a helpful message for any substring
+// missing from html.
+func requireContainsAll(t *testing.T, html string, subs ...string) {
+	t.Helper()
+	for _, s := range subs {
+		if !strings.Contains(html, s) {
+			t.Errorf("expected rendered output to contain %q, but it did not.\n--- rendered output ---\n%s", s, html)
+		}
+	}
+}
+
+// render parses the given page together with base.html/partials.html exactly
+// the way Server.New does, executes it with data, and returns the output.
+// It fails the test immediately on any parse or execute error.
+func render(t *testing.T, page string, data any) string {
+	t.Helper()
+	tmpl := mustParsePageTemplate(testTemplatesDir, page)
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		t.Fatalf("executing %s: %v", page, err)
+	}
+	return buf.String()
+}
+
+func TestPageTemplatesRenderLogin(t *testing.T) {
+	// Plain error branch.
+	html := render(t, "login.html", LoginPageData{
+		Error:               "Invalid username or password",
+		ClientID:            "client-abc",
+		RedirectURI:         "https://example.com/callback",
+		State:               "state-123",
+		Scope:               []string{"openid", "profile"},
+		CodeChallenge:       "challenge-xyz",
+		CodeChallengeMethod: "S256",
+		Nonce:               "nonce-1",
+		CSRFToken:           "csrf-token-value",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Sign In</title>",
+		`action="/oauth/login"`,
+		`name="csrf_token" value="csrf-token-value"`,
+		"Invalid username or password",
+		`alert-error`,
+		"client-abc",
+		"nonce-1",
+	)
+	if strings.Contains(html, "alert-success") {
+		t.Errorf("plain error should not render the success alert styling")
+	}
+
+	// Special-cased success-styled message (uses .Error, not .Success).
+	html = render(t, "login.html", LoginPageData{
+		Error:     "Account created successfully! Please check your email to verify your account.",
+		CSRFToken: "csrf-2",
+	})
+	requireContainsAll(t, html, "alert-success", "Account created successfully! Please check your email to verify your account.")
+}
+
+func TestPageTemplatesRenderRegister(t *testing.T) {
+	html := render(t, "register.html", RegisterPageData{
+		Error:               "Username already taken",
+		Username:            "alice",
+		Email:               "alice@example.com",
+		ClientID:            "client-abc",
+		RedirectURI:         "https://example.com/callback",
+		State:               "state-1",
+		Scope:               []string{"openid"},
+		CodeChallenge:       "chal",
+		CodeChallengeMethod: "S256",
+		CSRFToken:           "csrf-register",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Sign Up</title>",
+		`action="/oauth/register"`,
+		`name="csrf_token" value="csrf-register"`,
+		"Username already taken",
+		`value="alice"`,
+		`value="alice@example.com"`,
+	)
+	if strings.Contains(html, "function previewImage") {
+		t.Errorf("register.html should not contain change-avatar's script")
+	}
+}
+
+func TestPageTemplatesRenderError(t *testing.T) {
+	html := render(t, "error.html", ErrorPageData{
+		Title:       "Invalid Request",
+		Message:     "The request could not be completed.",
+		Details:     "missing redirect_uri",
+		ErrorCode:   "E123",
+		RedirectURI: "https://example.com/back",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Error</title>",
+		"Invalid Request",
+		"The request could not be completed.",
+		"missing redirect_uri",
+		"Error code: E123",
+		`href="https://example.com/back"`,
+		"card-body text-center",
+	)
+}
+
+func TestPageTemplatesRenderSuccess(t *testing.T) {
+	html := render(t, "success.html", struct{ CSRFToken string }{CSRFToken: "csrf-success"})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Login Successful</title>",
+		`action="/oauth/logout"`,
+		`name="csrf_token" value="csrf-success"`,
+	)
+}
+
+func TestPageTemplatesRenderAccountSettings(t *testing.T) {
+	html := render(t, "account-settings.html", AccountSettingsPageData{
+		Error:         "",
+		Success:       "Password updated",
+		Username:      "bob",
+		Email:         "bob@example.com",
+		Name:          "Bob Bobson",
+		AvatarURL:     "",
+		IsInactive:    false,
+		MfaEnabled:    true,
+		EmailVerified: true,
+		CSRFToken:     "csrf-acct",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Account Settings</title>",
+		"Password updated",
+		"bob",
+		"bob@example.com",
+		"Bob Bobson",
+		`name="csrf_token" value="csrf-acct"`,
+		"Enabled", // MFA enabled badge
+		"Danger Zone",
+	)
+}
+
+func TestPageTemplatesRenderChangePassword(t *testing.T) {
+	html := render(t, "change-password.html", ChangePasswordPageData{
+		Error:     "Current password is incorrect",
+		CSRFToken: "csrf-cp",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Change Password</title>",
+		`action="/oauth/change-password"`,
+		`name="csrf_token" value="csrf-cp"`,
+		"Current password is incorrect",
+	)
+}
+
+func TestPageTemplatesRenderChangeUsername(t *testing.T) {
+	html := render(t, "change-username.html", ChangeUsernamePageData{
+		Success:         "Username updated",
+		CurrentUsername: "olduser",
+		CSRFToken:       "csrf-cu",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Change Username</title>",
+		"Username updated",
+		"olduser",
+		`name="csrf_token" value="csrf-cu"`,
+	)
+}
+
+func TestPageTemplatesRenderChangeEmail(t *testing.T) {
+	html := render(t, "change-email.html", ChangeEmailPageData{
+		Error:        "Email already in use",
+		CurrentEmail: "old@example.com",
+		CSRFToken:    "csrf-ce",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Change Email</title>",
+		"Email already in use",
+		"old@example.com",
+		`name="csrf_token" value="csrf-ce"`,
+	)
+}
+
+func TestPageTemplatesRenderMFA(t *testing.T) {
+	html := render(t, "mfa.html", MFAPageData{
+		Error:               "Invalid code",
+		PendingID:           "pending-123",
+		ClientID:            "client-abc",
+		RedirectURI:         "https://example.com/cb",
+		State:               "state-9",
+		Scope:               []string{"openid"},
+		CodeChallenge:       "chal",
+		CodeChallengeMethod: "S256",
+		Nonce:               "nonce-9",
+		CSRFToken:           "csrf-mfa",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Two-Factor Authentication</title>",
+		`action="/oauth/mfa"`,
+		`name="csrf_token" value="csrf-mfa"`,
+		"Invalid code",
+		"pending-123",
+	)
+}
+
+func TestPageTemplatesRenderMFASetup(t *testing.T) {
+	html := render(t, "mfa-setup.html", MFASetupPageData{
+		QRCode:    "ZmFrZS1xci1kYXRh",
+		Secret:    "JBSWY3DPEHPK3PXP",
+		CSRFToken: "csrf-mfasetup",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Set Up Two-Factor Authentication</title>",
+		`action="/oauth/mfa-setup"`,
+		`name="csrf_token" value="csrf-mfasetup"`,
+		"data:image/png;base64,ZmFrZS1xci1kYXRh",
+		"JBSWY3DPEHPK3PXP",
+	)
+}
+
+func TestPageTemplatesRenderForgotPassword(t *testing.T) {
+	// Form branch (no success message yet).
+	html := render(t, "forgot-password.html", ForgotPasswordPageData{CSRFToken: "csrf-fp"})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Forgot Password</title>",
+		`action="/oauth/forgot-password"`,
+		`name="csrf_token" value="csrf-fp"`,
+	)
+
+	// Success branch (form should be hidden).
+	html = render(t, "forgot-password.html", ForgotPasswordPageData{Success: "Check your email", CSRFToken: "csrf-fp2"})
+	requireContainsAll(t, html, "Check your email")
+	if strings.Contains(html, `action="/oauth/forgot-password"`) {
+		t.Errorf("expected form to be hidden once .Success is set")
+	}
+}
+
+func TestPageTemplatesRenderForgotUsername(t *testing.T) {
+	html := render(t, "forgot-username.html", ForgotPasswordPageData{CSRFToken: "csrf-fu"})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Forgot Username</title>",
+		`action="/oauth/forgot-username"`,
+		`name="csrf_token" value="csrf-fu"`,
+	)
+}
+
+func TestPageTemplatesRenderResetPassword(t *testing.T) {
+	html := render(t, "reset-password.html", ResetPasswordPageData{
+		Error:     "Token expired",
+		Token:     "reset-token-xyz",
+		CSRFToken: "csrf-rp",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Reset Password</title>",
+		`action="/oauth/reset-password"`,
+		`name="csrf_token" value="csrf-rp"`,
+		`name="token" value="reset-token-xyz"`,
+		"Token expired",
+	)
+}
+
+func TestPageTemplatesRenderEditProfile(t *testing.T) {
+	html := render(t, "edit-profile.html", EditProfilePageData{
+		Success:    "Profile saved",
+		GivenName:  "Ada",
+		FamilyName: "Lovelace",
+		CSRFToken:  "csrf-ep",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Edit Profile</title>",
+		"Profile saved",
+		`value="Ada"`,
+		`value="Lovelace"`,
+		`name="csrf_token" value="csrf-ep"`,
+	)
+}
+
+func TestPageTemplatesRenderChangeAvatar(t *testing.T) {
+	html := render(t, "change-avatar.html", ChangeAvatarPageData{
+		Success:   "Avatar updated",
+		AvatarURL: "https://example.com/avatar.png",
+		CSRFToken: "csrf-ca",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Change Avatar</title>",
+		"Avatar updated",
+		"https://example.com/avatar.png",
+		`name="csrf_token" value="csrf-ca"`,
+		"function previewImage",
+	)
+}
+
+func TestPageTemplatesRenderConsent(t *testing.T) {
+	html := render(t, "consent.html", ConsentPageData{
+		ClientName:  "Example App",
+		ClientID:    "client-abc",
+		RedirectURI: "https://example.com/cb",
+		State:       "state-5",
+		Scope:       []string{"openid", "email"},
+		ScopeDescriptions: []ScopeDescription{
+			{Scope: "openid", Description: "Verify your identity"},
+			{Scope: "email", Description: "View your email address"},
+		},
+		CodeChallenge:       "chal",
+		CodeChallengeMethod: "S256",
+		Nonce:               "nonce-5",
+		ResponseType:        "code",
+		CSRFToken:           "csrf-consent",
+	})
+	requireContainsAll(t, html,
+		"<!DOCTYPE html>",
+		"<title>Authorize Application</title>",
+		"Example App",
+		"Verify your identity",
+		"View your email address",
+		`name="csrf_token" value="csrf-consent"`,
+		`action="/oauth/consent"`,
+	)
+}
+
+// TestPageTemplatesAllHaveFooterAndDoctype is a lightweight smoke test that
+// every page template composes cleanly with base.html + partials.html and
+// renders the shared skeleton once.
+func TestPageTemplatesAllHaveFooterAndDoctype(t *testing.T) {
+	pages := []struct {
+		name string
+		data any
+	}{
+		{"login.html", LoginPageData{CSRFToken: "t"}},
+		{"register.html", RegisterPageData{CSRFToken: "t"}},
+		{"error.html", ErrorPageData{}},
+		{"success.html", struct{ CSRFToken string }{CSRFToken: "t"}},
+		{"account-settings.html", AccountSettingsPageData{CSRFToken: "t"}},
+		{"change-password.html", ChangePasswordPageData{CSRFToken: "t"}},
+		{"change-username.html", ChangeUsernamePageData{CSRFToken: "t"}},
+		{"change-email.html", ChangeEmailPageData{CSRFToken: "t"}},
+		{"mfa.html", MFAPageData{CSRFToken: "t"}},
+		{"mfa-setup.html", MFASetupPageData{CSRFToken: "t"}},
+		{"forgot-password.html", ForgotPasswordPageData{CSRFToken: "t"}},
+		{"reset-password.html", ResetPasswordPageData{CSRFToken: "t"}},
+		{"forgot-username.html", ForgotPasswordPageData{CSRFToken: "t"}},
+		{"edit-profile.html", EditProfilePageData{CSRFToken: "t"}},
+		{"change-avatar.html", ChangeAvatarPageData{CSRFToken: "t"}},
+		{"consent.html", ConsentPageData{CSRFToken: "t"}},
+	}
+	for _, p := range pages {
+		t.Run(p.name, func(t *testing.T) {
+			html := render(t, p.name, p.data)
+			requireContainsAll(t, html,
+				"<!DOCTYPE html>",
+				`<link rel="stylesheet" href="/static/style.css">`,
+				"Identity Service", // shared footer partial
+				`<div class="divider"></div>`,
+			)
+			if !strings.HasSuffix(strings.TrimSpace(html), "</html>") {
+				t.Errorf("%s: expected output to end with </html>, got tail: %q", p.name, tail(html, 80))
+			}
+		})
+	}
+}
+
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}

--- a/templates/account-settings.html
+++ b/templates/account-settings.html
@@ -1,35 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Account Settings</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Account Settings{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Account Settings</h1>
                 <p class="text-sm text-base-content/60">Manage your account details</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .Success}}
-            <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
-                <span>{{.Success}}</span>
-            </div>
+            {{template "alert-success" .}}
             {{end}}
 
             <div class="mb-8">
@@ -177,11 +159,5 @@
             </div>
             {{end}}
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{block "title" .}}Identity Service{{end}}</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <div class="card bg-base-100 shadow-xl w-full max-w-md">
+        <div class="{{block "card-body-class" .}}card-body{{end}}">
+            {{block "content" .}}{{end}}
+        </div>
+    </div>
+    {{block "scripts" .}}{{end}}
+</body>
+</html>

--- a/templates/change-avatar.html
+++ b/templates/change-avatar.html
@@ -1,35 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Change Avatar</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Change Avatar{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Change Avatar</h1>
                 <p class="text-sm text-base-content/60">Upload a new profile picture</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .Success}}
-            <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
-                <span>{{.Success}}</span>
-            </div>
+            {{template "alert-success" .}}
             {{end}}
 
             <!-- Current Avatar -->
@@ -92,13 +74,10 @@
 
             <a href="/oauth/account-settings" class="btn btn-ghost w-full mt-3">Back to Account Settings</a>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
+            {{template "footer" .}}
+{{end}}
 
+{{define "scripts"}}
     <script>
         function previewImage(input) {
             const preview = document.getElementById('preview-image');
@@ -116,5 +95,4 @@
             }
         }
     </script>
-</body>
-</html>
+{{end}}

--- a/templates/change-email.html
+++ b/templates/change-email.html
@@ -1,35 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Change Email</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Change Email{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Change Email</h1>
                 <p class="text-sm text-base-content/60">Update your account email address</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .Success}}
-            <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
-                <span>{{.Success}}</span>
-            </div>
+            {{template "alert-success" .}}
             {{end}}
 
             <div class="bg-base-200 rounded-lg p-4 mb-6">
@@ -70,11 +52,5 @@
 
             <a href="/oauth/account-settings" class="btn btn-ghost w-full mt-3">Back to Account Settings</a>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/change-password.html
+++ b/templates/change-password.html
@@ -1,35 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Change Password</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Change Password{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Change Password</h1>
                 <p class="text-sm text-base-content/60">Update your account password</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .Success}}
-            <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
-                <span>{{.Success}}</span>
-            </div>
+            {{template "alert-success" .}}
             {{end}}
 
             <form method="POST" action="/oauth/change-password">
@@ -78,11 +60,5 @@
 
             <a href="/oauth/account-settings" class="btn btn-ghost w-full mt-3">Back to Account Settings</a>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/change-username.html
+++ b/templates/change-username.html
@@ -1,35 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Change Username</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Change Username{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Change Username</h1>
                 <p class="text-sm text-base-content/60">Update your account username</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .Success}}
-            <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
-                <span>{{.Success}}</span>
-            </div>
+            {{template "alert-success" .}}
             {{end}}
 
             <div class="bg-base-200 rounded-lg p-4 mb-6">
@@ -70,11 +52,5 @@
 
             <a href="/oauth/account-settings" class="btn btn-ghost w-full mt-3">Back to Account Settings</a>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/consent.html
+++ b/templates/consent.html
@@ -1,14 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Authorize Application</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Authorize Application{{end}}
+
+{{define "content"}}
             <div class="text-center mb-6">
                 <h1 class="card-title justify-center text-2xl">Authorize Application</h1>
                 <p class="text-sm text-base-content/60 mt-2">
@@ -17,12 +9,7 @@
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             <div class="mb-6">
@@ -54,11 +41,5 @@
                 <button type="submit" name="decision" value="deny" class="btn btn-outline w-full">Deny</button>
             </form>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/edit-profile.html
+++ b/templates/edit-profile.html
@@ -1,35 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Edit Profile</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Edit Profile{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Edit Profile</h1>
                 <p class="text-sm text-base-content/60">Update your profile information</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .Success}}
-            <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
-                <span>{{.Success}}</span>
-            </div>
+            {{template "alert-success" .}}
             {{end}}
 
             <form method="POST" action="/oauth/edit-profile">
@@ -65,11 +47,5 @@
 
             <a href="/oauth/account-settings" class="btn btn-ghost w-full mt-3">Back to Account Settings</a>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,14 +1,8 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Error</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body text-center">
+{{define "title"}}Error{{end}}
+
+{{define "card-body-class"}}card-body text-center{{end}}
+
+{{define "content"}}
             <div class="w-14 h-14 mx-auto mb-6 bg-error/10 rounded-full flex items-center justify-center">
                 <svg class="text-error" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <circle cx="12" cy="12" r="10"/>
@@ -42,11 +36,5 @@
             <a href="/oauth/login" class="btn btn-primary">Return to Login</a>
             {{end}}
 
-            <div class="divider"></div>
-            <div class="text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/forgot-password.html
+++ b/templates/forgot-password.html
@@ -1,35 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Forgot Password</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Forgot Password{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Forgot Password</h1>
                 <p class="text-sm text-base-content/60">Enter your email to receive a password reset link</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .Success}}
-            <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
-                <span>{{.Success}}</span>
-            </div>
+            {{template "alert-success" .}}
             {{else}}
             <form method="POST" action="/oauth/forgot-password">
                 <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
@@ -55,11 +37,5 @@
                 Remember your password? <a href="/oauth/login" class="link link-primary">Sign in</a>
             </div>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/forgot-username.html
+++ b/templates/forgot-username.html
@@ -1,35 +1,17 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Forgot Username</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Forgot Username{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Forgot Username</h1>
                 <p class="text-sm text-base-content/60">Enter your email to receive your username</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .Success}}
-            <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
-                <span>{{.Success}}</span>
-            </div>
+            {{template "alert-success" .}}
             {{else}}
             <form method="POST" action="/oauth/forgot-username">
                 <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
@@ -55,11 +37,5 @@
                 Remember your username? <a href="/oauth/login" class="link link-primary">Sign in</a>
             </div>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,14 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sign In</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Sign In{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Sign In</h1>
                 <p class="text-sm text-base-content/60">Enter your credentials to continue</p>
@@ -17,16 +9,12 @@
             {{if .Error}}
             {{if or (eq .Error "Account created successfully! Please check your email to verify your account.") (eq .Error "Email verified successfully! Please sign in.") (eq .Error "Password reset successfully! Please sign in with your new password.")}}
             <div class="alert alert-success mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
-                </svg>
+                {{template "icon-success" .}}
                 <span>{{.Error}}</span>
             </div>
             {{else}}
             <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
+                {{template "icon-error" .}}
                 <span>{{.Error}}</span>
             </div>
             {{end}}
@@ -81,11 +69,5 @@
                 Don't have an account? <a href="/oauth/register?client_id={{.ClientID}}&redirect_uri={{.RedirectURI}}&state={{.State}}&scope={{range $i, $s := .Scope}}{{if $i}}%20{{end}}{{$s}}{{end}}&code_challenge={{.CodeChallenge}}&code_challenge_method={{.CodeChallengeMethod}}&nonce={{.Nonce}}" class="link link-primary">Sign up</a>
             </div>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/mfa-setup.html
+++ b/templates/mfa-setup.html
@@ -1,26 +1,13 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Set Up Two-Factor Authentication</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Set Up Two-Factor Authentication{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Set Up Two-Factor Authentication</h1>
                 <p class="text-sm text-base-content/60">Scan the QR code with your authenticator app</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             {{if .QRCode}}
@@ -66,11 +53,5 @@
                 <a href="/oauth/account-settings" class="link link-primary">Cancel</a>
             </div>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/mfa.html
+++ b/templates/mfa.html
@@ -1,26 +1,13 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Two-Factor Authentication</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Two-Factor Authentication{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Two-Factor Authentication</h1>
                 <p class="text-sm text-base-content/60">Enter the code from your authenticator app</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             <form method="POST" action="/oauth/mfa">
@@ -58,11 +45,5 @@
                 <a href="/oauth/login" class="link link-primary">Back to login</a>
             </div>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/partials.html
+++ b/templates/partials.html
@@ -1,0 +1,30 @@
+{{/* Shared icon glyphs used by the alert partials below (and by login.html's
+     custom success/error branching, which can't use the alert-* partials
+     directly because it doesn't use a .Success field). */}}
+{{define "icon-error"}}<svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
+                </svg>{{end}}
+{{define "icon-success"}}<svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm3.78 5.28-4.5 6a.75.75 0 0 1-1.18.02l-2.25-2.5a.75.75 0 1 1 1.12-1l1.63 1.81 3.92-5.23a.75.75 0 1 1 1.26.9z"/>
+                </svg>{{end}}
+
+{{/* alert-error / alert-success render the markup for a dismissable-looking
+     inline alert box. The caller is responsible for the surrounding
+     {{if .Error}} / {{if .Success}} guard, since some pages need an
+     {{if .Success}}...{{else}}...{{end}} structure around the success case
+     (e.g. forgot-password.html hides its form when a success message is
+     shown). */}}
+{{define "alert-error"}}<div class="alert alert-error mb-6">
+                {{template "icon-error" .}}
+                <span>{{.Error}}</span>
+            </div>{{end}}
+{{define "alert-success"}}<div class="alert alert-success mb-6">
+                {{template "icon-success" .}}
+                <span>{{.Success}}</span>
+            </div>{{end}}
+
+{{/* footer is the "Identity Service" byline shared by every page. */}}
+{{define "footer"}}<div class="divider"></div>
+            <div class="text-center text-xs text-base-content/50">
+                Identity Service
+            </div>{{end}}

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,26 +1,13 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sign Up</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Sign Up{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Create Account</h1>
                 <p class="text-sm text-base-content/60">Sign up to get started</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             <form method="POST" action="/oauth/register" id="registerForm" novalidate>
@@ -97,13 +84,10 @@
                 Already have an account? <a href="/oauth/login?client_id={{.ClientID}}&redirect_uri={{.RedirectURI}}&state={{.State}}&scope={{range $i, $s := .Scope}}{{if $i}}%20{{end}}{{$s}}{{end}}&code_challenge={{.CodeChallenge}}&code_challenge_method={{.CodeChallengeMethod}}" class="link link-primary">Sign in</a>
             </div>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
+            {{template "footer" .}}
+{{end}}
 
+{{define "scripts"}}
     <script>
         (function() {
             const form = document.getElementById('registerForm');
@@ -135,5 +119,4 @@
             });
         })();
     </script>
-</body>
-</html>
+{{end}}

--- a/templates/reset-password.html
+++ b/templates/reset-password.html
@@ -1,26 +1,13 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Reset Password</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Reset Password{{end}}
+
+{{define "content"}}
             <div class="text-center mb-8">
                 <h1 class="card-title justify-center text-2xl">Reset Password</h1>
                 <p class="text-sm text-base-content/60">Enter your new password</p>
             </div>
 
             {{if .Error}}
-            <div class="alert alert-error mb-6">
-                <svg class="shrink-0" width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm-.75 4.75a.75.75 0 0 1 1.5 0v3.5a.75.75 0 0 1-1.5 0v-3.5zM8 12a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
-                </svg>
-                <span>{{.Error}}</span>
-            </div>
+            {{template "alert-error" .}}
             {{end}}
 
             <form method="POST" action="/oauth/reset-password">
@@ -61,11 +48,5 @@
                 Remember your password? <a href="/oauth/login" class="link link-primary">Sign in</a>
             </div>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}

--- a/templates/success.html
+++ b/templates/success.html
@@ -1,14 +1,6 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Login Successful</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="card bg-base-100 shadow-xl w-full max-w-md">
-        <div class="card-body">
+{{define "title"}}Login Successful{{end}}
+
+{{define "content"}}
             <div class="w-14 h-14 mx-auto mb-6 bg-success/10 rounded-full flex items-center justify-center">
                 <svg class="text-success" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <polyline points="20 6 9 17 4 12"/>
@@ -35,11 +27,5 @@
                 <a href="/oauth/login" class="btn btn-ghost w-full">Back to Login</a>
             </div>
 
-            <div class="divider"></div>
-            <div class="text-center text-xs text-base-content/50">
-                Identity Service
-            </div>
-        </div>
-    </div>
-</body>
-</html>
+            {{template "footer" .}}
+{{end}}


### PR DESCRIPTION
## Summary

The 16 server-rendered pages under `templates/*.html` each repeated the full page skeleton (doctype, `<head>` styles/meta, the card/container wrapper, footer) and identical alert/error/success markup (including the same inline SVG icons). This is a pure DRY refactor: no visible/behavioral change, no route/handler-signature changes.

- **`templates/base.html`** — the shared page skeleton (doctype, head, card wrapper, body) with `{{block "title" .}}`, `{{block "card-body-class" .}}` (only `error.html` overrides this, to add `text-center`), `{{block "content" .}}`, and `{{block "scripts" .}}` holes.
- **`templates/partials.html`** — `icon-error` / `icon-success` (the two shared inline SVGs), `alert-error` / `alert-success` (the alert box markup), and `footer` (the "Identity Service" byline). Callers keep their own `{{if .Error}}` / `{{if .Success}}` guards since a couple of pages (forgot-password, forgot-username) need an `if/else` around the success case to hide the form.
- Each of the 16 page templates (`login.html`, `register.html`, `error.html`, `success.html`, `account-settings.html`, `change-password.html`, `change-username.html`, `change-email.html`, `mfa.html`, `mfa-setup.html`, `forgot-password.html`, `reset-password.html`, `forgot-username.html`, `edit-profile.html`, `change-avatar.html`, `consent.html`) now only defines its own `{{define "title"}}` / `{{define "content"}}` (and `{{define "scripts"}}` for register.html and change-avatar.html, which had inline `<script>` blocks).

## Template loading change (server.go)

Previously `New()` had 16 near-identical `template.Must(template.ParseFiles(config.TemplatesDir + "/X.html"))` calls. These are replaced with a single helper:

```go
func mustParsePageTemplate(templatesDir, page string) *template.Template {
	return template.Must(template.ParseFiles(
		templatesDir+"/base.html",
		templatesDir+"/partials.html",
		templatesDir+"/"+page,
	))
}
```

`base.html` is parsed **first**, so the resulting `*template.Template`'s name is `"base.html"` and its top-level (un-defined) body is the full page skeleton. The page file is parsed **last**, so its `{{define "title"}}`/`{{define "content"}}` blocks override the `{{block}}` defaults from base.html (later definitions win when multiple files define the same name in one `ParseFiles` call — this is the standard Go base-layout-override idiom, verified locally with a throwaway program before touching real templates).

This means **no handler call sites changed** — every `s.xTemplate.Execute(w, data)` in login.go/register.go/account.go/mfa.go/mfa_setup.go/password_reset.go/oauth.go/routes.go/email_verification.go keeps working exactly as before, since `Execute` still runs the template named after the first parsed file.

## Verifying identical rendering

Added `pkg/httpserver/templates_render_test.go`, a real (kept) regression test that:
- Parses every page exactly the way `server.go` does (via the same `mustParsePageTemplate` helper) and executes it with a representative `*PageData` struct per page.
- Asserts each render succeeds, contains `<!DOCTYPE html>`, the correct `<title>`, the form's `action`, `name="csrf_token" value="..."` for every page with a form, and sample dynamic values (error/success messages, username/email fields, tokens, etc.) actually appear in the output.
- Covers login.html's special-cased success-styled alert (it reuses `.Error`, not a `.Success` field, to flag specific known messages), forgot-password/forgot-username's if/else that hides the form once `.Success` is set, and the shared script blocks in register.html/change-avatar.html.

Separately (not committed — a throwaway local tool), I rendered every page's **old** (pre-refactor) template standalone and the **new** composed template with identical data for every branch (error/success/empty, with/without redirect, MFA on/off, inactive/active account, avatar present/absent, etc.), normalized away insignificant whitespace, and diffed. The only differences across all 16 pages and all branches:
1. `aria-hidden="true"` is now added consistently to the alert SVG icons (2 of 16 pages — account-settings.html and change-avatar.html — already had it; the other 14 didn't). Purely an accessibility attribute, invisible to rendering.
2. `error.html`'s footer `<div>` now carries an already-inherited `text-center` class (its parent `.card-body` is already `text-center`), so this is a no-op visually.

No CSRF token was dropped from any form, no field names/routes/methods changed, no visible content changed.

`go build ./...`, `go vet ./...`, and `go test ./...` (non-integration) all pass.

## Line count

`templates/*.html`: 436 deletions, 156 insertions (including the 2 new shared files) — net **-280 lines** of duplicated markup removed.

## Caveats for the reviewer

- The two micro-normalizations above (aria-hidden, redundant text-center) are intentional and harmless, but worth a second look if byte-for-byte output parity matters for any downstream snapshot tests (there weren't any in this repo).
- Did not touch the TOCTOU/invalid_client or DEBUG logging issues — those are out of scope per the task and owned by other work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE