### PR TITLE
Add periodic cleanup worker for expired auth rows

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -36,6 +37,34 @@ type Config struct {
 	// Debug enables verbose [DEBUG] logging of flow/user-ID details in pkg/httpserver
 	// (see Server.debugf). Off by default; set DEBUG=true to enable.
 	Debug bool
+
+	// CleanupInterval controls how often the background expiry-cleanup worker
+	// (see pkg/httpserver/cleanup.go) sweeps expired MFA pending/enrollment
+	// rows, email verification tokens, and password reset tokens. Read from
+	// CLEANUP_INTERVAL as a Go duration string (e.g. "1h", "30m"); defaults to
+	// 1 hour when unset or unparseable (see parseCleanupInterval).
+	CleanupInterval time.Duration
+}
+
+// defaultCleanupInterval is the fallback for CleanupInterval when CLEANUP_INTERVAL
+// is unset or fails to parse as a Go duration.
+const defaultCleanupInterval = 1 * time.Hour
+
+// parseCleanupInterval reads CLEANUP_INTERVAL and parses it as a Go duration
+// string (e.g. "1h", "30m"). It falls back to defaultCleanupInterval when the
+// variable is unset or its value can't be parsed by time.ParseDuration, logging
+// a warning in the latter case so a typo doesn't silently produce the default.
+func parseCleanupInterval() time.Duration {
+	raw := os.Getenv("CLEANUP_INTERVAL")
+	if raw == "" {
+		return defaultCleanupInterval
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		log.Printf("CLEANUP_INTERVAL=%q is not a valid duration (%v); using default of %s", raw, err, defaultCleanupInterval)
+		return defaultCleanupInterval
+	}
+	return d
 }
 
 func NewFromEnv() *Config {
@@ -61,6 +90,7 @@ func NewFromEnv() *Config {
 			StoragePublicURL: os.Getenv("STORAGE_PUBLIC_URL"),
 			StorageRegion:    os.Getenv("STORAGE_REGION"),
 			Debug:            os.Getenv("DEBUG") == "true",
+			CleanupInterval:  parseCleanupInterval(),
 		}
 	} else {
 		// Local development: load from .env files
@@ -88,6 +118,7 @@ func NewFromEnv() *Config {
 			StoragePublicURL: os.Getenv("STORAGE_PUBLIC_URL"),
 			StorageRegion:    os.Getenv("STORAGE_REGION"),
 			Debug:            os.Getenv("DEBUG") == "true",
+			CleanupInterval:  parseCleanupInterval(),
 		}
 	}
 

--- a/pkg/httpserver/cleanup.go
+++ b/pkg/httpserver/cleanup.go
@@ -1,0 +1,125 @@
+package httpserver
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// fallbackCleanupInterval is used if Server.config.CleanupInterval is unset
+// (zero), e.g. when a Config is constructed directly as a struct literal (as
+// integration tests do) instead of via config.NewFromEnv, which always
+// populates it. A zero interval would make time.NewTicker panic, so
+// startCleanupWorker substitutes this instead. It mirrors the default applied
+// by config.NewFromEnv itself.
+const fallbackCleanupInterval = 1 * time.Hour
+
+// cleanupSweepTimeout bounds a single expiry-cleanup sweep (see
+// runExpiryCleanup) so that a hung database call can't block the worker -- and
+// therefore delay process shutdown -- forever.
+const cleanupSweepTimeout = 30 * time.Second
+
+// runExpiryCleanup performs one sweep of the expired-row cleanup queries for
+// the auth tables that accumulate short-lived, single-use records:
+//
+//   - auth_mfa_pending (DeleteExpiredMFAPending)
+//   - auth_mfa_enrollment_pending (DeleteExpiredMFAEnrollmentPending)
+//   - auth_email_tokens (DeleteExpiredEmailTokens)
+//   - auth_email_tokens, password-reset rows specifically (DeleteExpiredPasswordResetTokens)
+//
+// These queries already existed but were never called anywhere, so expired
+// rows accumulated in their tables forever (unbounded growth, not a
+// correctness bug -- the read queries all filter on expires_at, so expired
+// rows were never usable).
+//
+// Deliberately NOT covered here: oauth_tokens, auth_sessions, and
+// oauth_authorization_codes also have expires_at and will accumulate rows
+// over time, but there is no DeleteExpired* query for them yet (and, for
+// oauth_tokens, retention may need extra thought, e.g. keeping revoked/expired
+// tokens around briefly for auditing). That's left as a conscious follow-up,
+// not an oversight.
+//
+// Each of the four deletes is independent: if one fails, it is logged and the
+// remaining three still run rather than bailing out early. The sweep is
+// bounded by cleanupSweepTimeout so a hung DB call can't block the worker
+// indefinitely. The return value is the last error encountered (nil if all
+// four succeeded); callers mainly care that the sweep ran; the operational
+// signal is the [ERROR] log line, not this return value.
+func (s *Server) runExpiryCleanup(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, cleanupSweepTimeout)
+	defer cancel()
+
+	sweeps := []struct {
+		table string
+		fn    func(context.Context) error
+	}{
+		{"auth_mfa_pending", s.datastore.Q.DeleteExpiredMFAPending},
+		{"auth_mfa_enrollment_pending", s.datastore.Q.DeleteExpiredMFAEnrollmentPending},
+		{"auth_email_tokens", s.datastore.Q.DeleteExpiredEmailTokens},
+		{"auth_email_tokens (password_reset)", s.datastore.Q.DeleteExpiredPasswordResetTokens},
+	}
+
+	var lastErr error
+	for _, sw := range sweeps {
+		if err := sw.fn(ctx); err != nil {
+			log.Printf("[ERROR] expiry cleanup: failed to delete expired rows from %s: %v", sw.table, err)
+			lastErr = err
+			continue
+		}
+	}
+
+	s.debugf("expiry cleanup sweep completed")
+	return lastErr
+}
+
+// startCleanupWorker is the goroutine body that periodically runs
+// runExpiryCleanup. It is intended to be launched with `go s.startCleanupWorker(ctx)`
+// from Server.Run (never from New, so constructing a Server in tests does not
+// spawn background work), and stops as soon as ctx is cancelled.
+//
+// The actual loop mechanics live in cleanupLoop below so they can be tested
+// hermetically (no database) with a fake sweep function and a short interval.
+func (s *Server) startCleanupWorker(ctx context.Context) {
+	interval := effectiveCleanupInterval(s.config.CleanupInterval)
+	cleanupLoop(ctx, interval, func(sweepCtx context.Context) {
+		s.runExpiryCleanup(sweepCtx)
+	})
+}
+
+// effectiveCleanupInterval returns interval, unless it is zero or negative (e.g.
+// because config.CleanupInterval was left at its zero value, as happens when a
+// Config is built as a struct literal in tests instead of via
+// config.NewFromEnv, which always populates it), in which case it returns
+// fallbackCleanupInterval. This guards against ever passing a non-positive
+// duration to time.NewTicker, which panics.
+func effectiveCleanupInterval(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return fallbackCleanupInterval
+	}
+	return interval
+}
+
+// cleanupLoop runs sweep once immediately (so cleanup starts shortly after
+// the worker is launched rather than waiting a full interval for the first
+// run), then again every time the interval elapses, until ctx.Done() fires.
+// The ticker is always stopped before returning.
+//
+// It is factored out from startCleanupWorker purely for testability: unit
+// tests can call cleanupLoop directly with a fake sweep function and a short
+// interval/context to verify the loop's timing and shutdown behavior without
+// touching a real database.
+func cleanupLoop(ctx context.Context, interval time.Duration, sweep func(context.Context)) {
+	sweep(ctx)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			sweep(ctx)
+		}
+	}
+}

--- a/pkg/httpserver/cleanup_integration_test.go
+++ b/pkg/httpserver/cleanup_integration_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package httpserver
+
+import (
+	"time"
+
+	"github.com/eswan18/identity/pkg/db"
+)
+
+// TestExpiryCleanup_DeletesExpiredRows is an end-to-end (real Postgres, via the shared
+// OAuthFlowSuite testcontainer) check that runExpiryCleanup actually deletes rows past
+// their expires_at, for one row in each of the four tables it targets. The hermetic unit
+// test in cleanup_test.go covers the loop/scheduling behavior without a database; this
+// covers the SQL side, which the queries themselves already tested (they're plain
+// generated sqlc :exec statements) but which was never wired up to anything before this
+// change.
+func (s *OAuthFlowSuite) TestExpiryCleanup_DeletesExpiredRows() {
+	ctx := s.T().Context()
+	user := s.mustRegisterUser(
+		s.mustGenerateAlphanumericString(10),
+		s.mustGenerateAlphanumericString(10),
+		s.mustGenerateAlphanumericString(10)+"@example.com",
+	)
+
+	past := time.Now().Add(-1 * time.Hour)
+
+	// auth_mfa_pending
+	mfaPendingID := s.mustGenerateAlphanumericString(20)
+	err := s.datastore.Q.CreateMFAPending(ctx, db.CreateMFAPendingParams{
+		ID:        mfaPendingID,
+		UserID:    user.ID,
+		ExpiresAt: past,
+	})
+	s.Require().NoError(err)
+
+	// auth_mfa_enrollment_pending
+	err = s.datastore.Q.CreateMFAEnrollmentPending(ctx, db.CreateMFAEnrollmentPendingParams{
+		UserID:    user.ID,
+		Secret:    "JBSWY3DPEHPK3PXP",
+		ExpiresAt: past,
+	})
+	s.Require().NoError(err)
+
+	// auth_email_tokens (a non-password-reset token type, e.g. email verification)
+	err = s.datastore.Q.CreateEmailToken(ctx, db.CreateEmailTokenParams{
+		UserID:    user.ID,
+		TokenHash: s.mustGenerateAlphanumericString(32),
+		TokenType: "email_verification",
+		ExpiresAt: past,
+	})
+	s.Require().NoError(err)
+
+	// auth_email_tokens with token_type = 'password_reset', which
+	// DeleteExpiredPasswordResetTokens specifically targets.
+	err = s.datastore.Q.CreatePasswordResetToken(ctx, db.CreatePasswordResetTokenParams{
+		UserID:    user.ID,
+		TokenHash: s.mustGenerateAlphanumericString(32),
+		ExpiresAt: past,
+	})
+	s.Require().NoError(err)
+
+	s.assertRowCount("auth_mfa_pending", "id = $1", mfaPendingID, 1)
+	s.assertRowCount("auth_mfa_enrollment_pending", "user_id = $1", user.ID, 1)
+	s.assertRowCount("auth_email_tokens", "user_id = $1", user.ID, 2)
+
+	err = s.server.runExpiryCleanup(ctx)
+	s.NoError(err)
+
+	s.assertRowCount("auth_mfa_pending", "id = $1", mfaPendingID, 0)
+	s.assertRowCount("auth_mfa_enrollment_pending", "user_id = $1", user.ID, 0)
+	s.assertRowCount("auth_email_tokens", "user_id = $1", user.ID, 0)
+}
+
+// assertRowCount asserts that exactly want rows in table match "WHERE " + whereClause
+// (with arg as $1). It's a small raw-SQL helper since sqlc doesn't generate ad hoc count
+// queries and adding one purely for this test isn't warranted.
+func (s *OAuthFlowSuite) assertRowCount(table, whereClause string, arg any, want int) {
+	s.T().Helper()
+	var got int
+	query := "SELECT COUNT(*) FROM " + table + " WHERE " + whereClause
+	err := s.datastore.DB.QueryRowContext(s.T().Context(), query, arg).Scan(&got)
+	s.Require().NoError(err)
+	s.Equal(want, got, "unexpected row count in %s", table)
+}

--- a/pkg/httpserver/cleanup_test.go
+++ b/pkg/httpserver/cleanup_test.go
@@ -1,0 +1,82 @@
+package httpserver
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestCleanupLoop_RunsPeriodicallyAndStopsOnCancel is a hermetic (no database) test of
+// the timing/shutdown behavior behind startCleanupWorker. runExpiryCleanup itself talks
+// to Postgres and is hard to unit test without one, so the loop mechanics are factored
+// out into cleanupLoop (see cleanup.go), which takes the sweep as a plain
+// func(context.Context) and can be exercised with a fake here.
+func TestCleanupLoop_RunsPeriodicallyAndStopsOnCancel(t *testing.T) {
+	const interval = 10 * time.Millisecond
+
+	var calls int32
+	sweep := func(context.Context) {
+		atomic.AddInt32(&calls, 1)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		cleanupLoop(ctx, interval, sweep)
+		close(done)
+	}()
+
+	// cleanupLoop runs sweep once immediately and then every interval. Waiting for
+	// several multiples of the interval should comfortably yield multiple calls even
+	// under CI scheduling jitter, while keeping the test fast.
+	time.Sleep(12 * interval)
+
+	callsBeforeCancel := atomic.LoadInt32(&calls)
+	if callsBeforeCancel < 3 {
+		t.Fatalf("expected at least 3 sweep calls within %s, got %d", 12*interval, callsBeforeCancel)
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+		// cleanupLoop returned promptly after cancellation, as expected.
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanupLoop did not return promptly after context cancellation (possible goroutine leak)")
+	}
+
+	// Confirm the loop actually stopped sweeping once it reported done, rather than
+	// racing a stray tick in afterward.
+	callsAtDone := atomic.LoadInt32(&calls)
+	time.Sleep(5 * interval)
+	if got := atomic.LoadInt32(&calls); got != callsAtDone {
+		t.Fatalf("sweep was called again after cleanupLoop returned: at-done=%d after-wait=%d", callsAtDone, got)
+	}
+}
+
+// TestEffectiveCleanupInterval covers the fallback startCleanupWorker relies on to
+// avoid ever handing time.NewTicker a non-positive duration, which panics. This matters
+// in practice because several tests in this package (e.g. integration_common_test.go's
+// OAuthFlowSuite) build a config.Config as a struct literal rather than via
+// config.NewFromEnv, leaving CleanupInterval at its zero value, and then call
+// Server.Run (which launches the cleanup worker).
+func TestEffectiveCleanupInterval(t *testing.T) {
+	tests := []struct {
+		name  string
+		input time.Duration
+		want  time.Duration
+	}{
+		{name: "positive value is kept as-is", input: 5 * time.Minute, want: 5 * time.Minute},
+		{name: "zero falls back to default", input: 0, want: fallbackCleanupInterval},
+		{name: "negative falls back to default", input: -1 * time.Second, want: fallbackCleanupInterval},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveCleanupInterval(tt.input); got != tt.want {
+				t.Errorf("effectiveCleanupInterval(%v) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/httpserver/server.go
+++ b/pkg/httpserver/server.go
@@ -24,6 +24,7 @@ type Server struct {
 	datastore               *store.Store
 	router                  chi.Router
 	httpServer              *http.Server
+	cleanupCancel           context.CancelFunc
 	rateLimitStore          *rateLimitStore
 	jwtGenerator            *jwt.Generator
 	emailSender             email.Sender
@@ -190,6 +191,19 @@ func (s *Server) Run() error {
 		Addr:    s.config.HTTPAddress,
 		Handler: s.router,
 	}
+
+	// Launch the periodic expiry-cleanup worker (see cleanup.go) here, not in
+	// New, so constructing a Server for tests never spawns background work.
+	// cleanupCancel lets Close (or the deferred cancel below, once
+	// ListenAndServe returns) stop the goroutine cleanly. In production, Run
+	// blocks on ListenAndServe for the life of the process, so the worker
+	// effectively runs until the process is killed and is cancelled as part
+	// of an orderly Close/shutdown.
+	cleanupCtx, cancel := context.WithCancel(context.Background())
+	s.cleanupCancel = cancel
+	defer cancel()
+	go s.startCleanupWorker(cleanupCtx)
+
 	return s.httpServer.ListenAndServe()
 }
 
@@ -201,6 +215,9 @@ func (s *Server) Close() error {
 		if shutdownErr := s.httpServer.Shutdown(ctx); shutdownErr != nil {
 			err = shutdownErr
 		}
+	}
+	if s.cleanupCancel != nil {
+		s.cleanupCancel()
 	}
 	if s.rateLimitStore != nil {
 		s.rateLimitStore.Stop()


### PR DESCRIPTION
## Summary

Four sqlc-generated `:exec` queries that delete expired rows already existed but were never called anywhere, so expired rows have been accumulating forever in their tables (not a correctness bug — every read query already filters on `expires_at`, so expired rows were never usable — just unbounded table growth):

- `DeleteExpiredMFAPending` (`auth_mfa_pending`)
- `DeleteExpiredMFAEnrollmentPending` (`auth_mfa_enrollment_pending`)
- `DeleteExpiredEmailTokens` (`auth_email_tokens`)
- `DeleteExpiredPasswordResetTokens` (`auth_email_tokens`, `token_type = 'password_reset'`)

This PR wires all four into a periodic background worker. No new sqlc queries, no schema changes.

## Config

Added `Config.CleanupInterval time.Duration`, read from env var `CLEANUP_INTERVAL` as a Go duration string (e.g. `"1h"`, `"30m"`). Defaults to `1 * time.Hour` when the var is unset or fails to parse (a parse failure logs a warning via `log.Printf` rather than failing silently). Set in both the Koyeb and local-dev branches of `config.NewFromEnv` (`pkg/config/config.go`).

## Worker structure (`pkg/httpserver/cleanup.go`)

- `(s *Server) runExpiryCleanup(ctx) error` — one sweep. Runs all four deletes; each is independent, so a failure in one is logged at `[ERROR]` with the affected table and the remaining three still run (no early return). Bounded by a 30s per-sweep `context.WithTimeout` so a hung DB call can't block the worker indefinitely. Successful sweeps only log via the existing gated `s.debugf(...)` helper, so production logs stay quiet.
- `(s *Server) startCleanupWorker(ctx)` — the goroutine body. Runs an initial sweep immediately, then on every tick of a `time.NewTicker(interval)`, returning (and stopping the ticker) as soon as `ctx.Done()` fires.
- The loop mechanics are factored into a standalone `cleanupLoop(ctx, interval, sweep func(context.Context))` purely so it's unit-testable without a database.
- `effectiveCleanupInterval` guards against a zero/negative interval (e.g. a `config.Config` built as a struct literal in tests, which several existing tests do) ever reaching `time.NewTicker`, which would panic.

## Startup / shutdown wiring (`pkg/httpserver/server.go`)

- `Server` gained a `cleanupCancel context.CancelFunc` field.
- `Run()` creates a `context.WithCancel(context.Background())`, stores the cancel func, `defer cancel()`s it, and does `go s.startCleanupWorker(cleanupCtx)` before calling `ListenAndServe`. The worker is **not** started from `New()`, so constructing a `Server` in tests never spawns background work.
- `Close()` also calls `cleanupCancel()` (if set) alongside the existing `httpServer.Shutdown` and `rateLimitStore.Stop()`, so an explicit `Close()` stops the worker promptly rather than waiting on `Run()`'s deferred cancel.
- No signal handling or full graceful-HTTP-shutdown was added — out of scope; the worker is just made cleanly stoppable via context cancellation.

## Deferred follow-up (intentional, not an oversight)

`oauth_tokens`, `auth_sessions`, and `oauth_authorization_codes` also have `expires_at` and will accumulate rows over time, but have no `DeleteExpired*` query yet (and, for `oauth_tokens` specifically, retention needs more thought — e.g. whether to keep recently-revoked/expired tokens around briefly for audit purposes). Noted in a doc comment on `runExpiryCleanup` as a conscious deferral.

## Testing

- **Hermetic (required) test** — `pkg/httpserver/cleanup_test.go`:
  - `TestCleanupLoop_RunsPeriodicallyAndStopsOnCancel`: drives `cleanupLoop` with a fake sweep function and a 10ms interval, asserts it fires repeatedly and then returns promptly after the context is cancelled (with a follow-up check that it truly stopped calling the fake). No database involved.
  - `TestEffectiveCleanupInterval`: table test covering positive/zero/negative interval inputs.
  - Verified non-flaky with `go test -count=5 -run 'TestCleanupLoop|TestEffectiveCleanupInterval' ./pkg/httpserver/` (5/5 green) and again under `-race`.
- **Optional integration test** — `pkg/httpserver/cleanup_integration_test.go` (`//go:build integration`), added to the existing `OAuthFlowSuite` testcontainer harness: inserts one expired row into each of the four targeted queries, calls `runExpiryCleanup` directly, and asserts (via a small raw-SQL row-count helper) that all four are gone. `go vet -tags integration ./...` compiles it cleanly. I wasn't able to fully execute it in this sandboxed dev environment — the Postgres testcontainer got stuck at `Created` and never reached `Running`, which looks like a Docker/network restriction in this particular sandbox rather than an issue with the test itself (other pre-existing integration tests in the repo use the identical harness and would hit the same wall here). Worth running in CI/a normal dev machine to confirm.

## Verification run

- `go build ./...` ✅
- `go vet ./...` ✅
- `go vet -tags integration ./...` ✅ (compiles)
- `go test ./...` ✅ (all non-integration tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE