### PR TITLE
Refactor: extract requireUser middleware for authenticated routes

### DIFF
--- a/pkg/httpserver/account.go
+++ b/pkg/httpserver/account.go
@@ -39,10 +39,10 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /account-settings [get]
 func (s *Server) HandleAccountSettingsGet(w http.ResponseWriter, r *http.Request) {
-	// Get user from session - including inactive users so they can see their account settings
-	user, err := s.getUserFromSessionIncludingInactive(r)
-	if err != nil {
-		s.debugf("HandleAccountSettingsGet: Failed to get user from session: %v", err)
+	// The user (including deactivated users) is resolved by the requireUser
+	// middleware and stored in the request context.
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -99,11 +99,7 @@ func (s *Server) HandleAccountSettingsGet(w http.ResponseWriter, r *http.Request
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /change-password [get]
 func (s *Server) HandleChangePasswordGet(w http.ResponseWriter, r *http.Request) {
-	_, err := s.getUserFromSession(r)
-	if err != nil {
-		http.Redirect(w, r, "/oauth/login", http.StatusFound)
-		return
-	}
+	// Authentication is enforced by the requireActiveUser middleware.
 	s.changePasswordTemplate.Execute(w, ChangePasswordPageData{CSRFToken: s.ensureCSRFToken(w, r)})
 }
 
@@ -121,8 +117,8 @@ func (s *Server) HandleChangePasswordGet(w http.ResponseWriter, r *http.Request)
 // @Failure      401 {string} string "Unauthorized - invalid current password"
 // @Router       /change-password [post]
 func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -221,8 +217,8 @@ func (s *Server) HandleChangePasswordPost(w http.ResponseWriter, r *http.Request
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /change-username [get]
 func (s *Server) HandleChangeUsernameGet(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -242,8 +238,8 @@ func (s *Server) HandleChangeUsernameGet(w http.ResponseWriter, r *http.Request)
 // @Failure      401 {string} string "Unauthorized - invalid password"
 // @Router       /change-username [post]
 func (s *Server) HandleChangeUsernamePost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -316,8 +312,8 @@ func (s *Server) HandleChangeUsernamePost(w http.ResponseWriter, r *http.Request
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /change-email [get]
 func (s *Server) HandleChangeEmailGet(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -337,8 +333,8 @@ func (s *Server) HandleChangeEmailGet(w http.ResponseWriter, r *http.Request) {
 // @Failure      401 {string} string "Unauthorized - invalid password"
 // @Router       /change-email [post]
 func (s *Server) HandleChangeEmailPost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -420,8 +416,8 @@ func (s *Server) HandleChangeEmailPost(w http.ResponseWriter, r *http.Request) {
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /edit-profile [get]
 func (s *Server) HandleEditProfileGet(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -444,8 +440,8 @@ func (s *Server) HandleEditProfileGet(w http.ResponseWriter, r *http.Request) {
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /edit-profile [post]
 func (s *Server) HandleEditProfilePost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -454,7 +450,7 @@ func (s *Server) HandleEditProfilePost(w http.ResponseWriter, r *http.Request) {
 	familyName := r.FormValue("family_name")
 
 	// Update profile in database
-	err = s.datastore.Q.UpdateUserProfile(r.Context(), db.UpdateUserProfileParams{
+	err := s.datastore.Q.UpdateUserProfile(r.Context(), db.UpdateUserProfileParams{
 		GivenName:  toNullString(givenName),
 		FamilyName: toNullString(familyName),
 		ID:         user.ID,
@@ -555,8 +551,10 @@ func (s *Server) doGetUserFromSession(r *http.Request, getUserByID func(context.
 // @Failure      401 {string} string "Unauthorized - invalid password"
 // @Router       /deactivate-account [post]
 func (s *Server) HandleDeactivateAccountPost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSessionIncludingInactive(r)
-	if err != nil {
+	// The user (including deactivated users) is resolved by the requireUser
+	// middleware and stored in the request context.
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -647,8 +645,10 @@ func (s *Server) HandleDeactivateAccountPost(w http.ResponseWriter, r *http.Requ
 // @Failure      401 {string} string "Unauthorized - invalid password"
 // @Router       /reactivate-account [post]
 func (s *Server) HandleReactivateAccountPost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSessionIncludingInactive(r)
-	if err != nil {
+	// The user (including deactivated users) is resolved by the requireUser
+	// middleware and stored in the request context.
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -717,8 +717,8 @@ func (s *Server) HandleReactivateAccountPost(w http.ResponseWriter, r *http.Requ
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /change-avatar [get]
 func (s *Server) HandleChangeAvatarGet(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -746,8 +746,8 @@ func (s *Server) HandleChangeAvatarGet(w http.ResponseWriter, r *http.Request) {
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /change-avatar [post]
 func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -833,8 +833,8 @@ func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) 
 // @Failure      401 {string} string "Unauthorized - no valid session"
 // @Router       /delete-avatar [post]
 func (s *Server) HandleDeleteAvatarPost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}

--- a/pkg/httpserver/email_verification.go
+++ b/pkg/httpserver/email_verification.go
@@ -169,9 +169,10 @@ func (s *Server) HandleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 
 // HandleResendVerification handles requests to resend the verification email.
 func (s *Server) HandleResendVerification(w http.ResponseWriter, r *http.Request) {
-	// Get the current user from session
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	// The active user is resolved by the requireActiveUser middleware and stored
+	// in the request context.
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}

--- a/pkg/httpserver/mfa_setup.go
+++ b/pkg/httpserver/mfa_setup.go
@@ -62,8 +62,8 @@ func (s *Server) renderMFASetupPage(w http.ResponseWriter, r *http.Request, user
 
 // HandleMFASetupGet displays the MFA setup page with QR code.
 func (s *Server) HandleMFASetupGet(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -101,8 +101,8 @@ func (s *Server) HandleMFASetupGet(w http.ResponseWriter, r *http.Request) {
 
 // HandleMFASetupPost verifies the TOTP code and enables MFA.
 func (s *Server) HandleMFASetupPost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}
@@ -163,8 +163,8 @@ func (s *Server) HandleMFASetupPost(w http.ResponseWriter, r *http.Request) {
 
 // HandleMFADisablePost disables MFA for the user.
 func (s *Server) HandleMFADisablePost(w http.ResponseWriter, r *http.Request) {
-	user, err := s.getUserFromSession(r)
-	if err != nil {
+	user, ok := userFromContext(r.Context())
+	if !ok {
 		http.Redirect(w, r, "/oauth/login", http.StatusFound)
 		return
 	}

--- a/pkg/httpserver/middleware.go
+++ b/pkg/httpserver/middleware.go
@@ -1,0 +1,57 @@
+package httpserver
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/eswan18/identity/pkg/db"
+)
+
+// userCtxKey is the unexported context key under which the authenticated user is
+// stored by the requireUser middlewares. Using a distinct unexported type avoids
+// collisions with any other context value.
+type userCtxKey struct{}
+
+// userFromContext returns the authenticated user previously stored in ctx by one
+// of the requireUser middlewares. ok is false when no user is present (which,
+// behind the middleware, should not happen).
+func userFromContext(ctx context.Context) (db.AuthUser, bool) {
+	user, ok := ctx.Value(userCtxKey{}).(db.AuthUser)
+	return user, ok
+}
+
+// contextWithUser returns a copy of ctx carrying the given authenticated user.
+func contextWithUser(ctx context.Context, user db.AuthUser) context.Context {
+	return context.WithValue(ctx, userCtxKey{}, user)
+}
+
+// requireActiveUser is middleware that loads the active (non-deactivated) user
+// from the session cookie using the same logic as getUserFromSession. On failure
+// it performs the same redirect the account handlers previously did inline
+// (302 Found to /oauth/login); on success it stores the user in the request
+// context (retrievable via userFromContext) and calls next.
+func (s *Server) requireActiveUser(next http.Handler) http.Handler {
+	return s.requireUserWith(next, s.getUserFromSession)
+}
+
+// requireUser is middleware identical to requireActiveUser except it also accepts
+// deactivated users (via getUserFromSessionIncludingInactive). It is used for the
+// account-settings, deactivate-account, and reactivate-account routes, which must
+// remain reachable for a user whose account is inactive.
+func (s *Server) requireUser(next http.Handler) http.Handler {
+	return s.requireUserWith(next, s.getUserFromSessionIncludingInactive)
+}
+
+// requireUserWith is the shared implementation for the requireUser middlewares.
+// The lookup function selects which session helper (active-only vs including
+// inactive) is used to resolve the user.
+func (s *Server) requireUserWith(next http.Handler, lookup func(*http.Request) (db.AuthUser, error)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, err := lookup(r)
+		if err != nil {
+			http.Redirect(w, r, "/oauth/login", http.StatusFound)
+			return
+		}
+		next.ServeHTTP(w, r.WithContext(contextWithUser(r.Context(), user)))
+	})
+}

--- a/pkg/httpserver/middleware_test.go
+++ b/pkg/httpserver/middleware_test.go
@@ -1,0 +1,91 @@
+package httpserver
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eswan18/identity/pkg/db"
+	"github.com/google/uuid"
+)
+
+// TestRequireActiveUser_NoSessionRedirectsToLogin verifies that the
+// requireActiveUser middleware, when the request carries no session cookie,
+// redirects to /oauth/login with a 302 (the exact behavior the account handlers
+// previously implemented inline) and never invokes the wrapped handler. This is
+// hermetic: doGetUserFromSession fails on the missing cookie before ever touching
+// the (unreachable) database.
+func TestRequireActiveUser_NoSessionRedirectsToLogin(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	h := s.requireActiveUser(okHandler(&reached))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/oauth/change-password", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302 Found, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/oauth/login" {
+		t.Fatalf("expected redirect to /oauth/login, got %q", loc)
+	}
+	if reached {
+		t.Fatal("next handler must not be reached when unauthenticated")
+	}
+}
+
+// TestRequireUser_NoSessionRedirectsToLogin verifies the allow-inactive
+// middleware performs the same redirect on a missing session.
+func TestRequireUser_NoSessionRedirectsToLogin(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	h := s.requireUser(okHandler(&reached))
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/oauth/account-settings", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFound {
+		t.Fatalf("expected 302 Found, got %d", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != "/oauth/login" {
+		t.Fatalf("expected redirect to /oauth/login, got %q", loc)
+	}
+	if reached {
+		t.Fatal("next handler must not be reached when unauthenticated")
+	}
+}
+
+// TestRequireUserWith_InjectsUserIntoContext verifies that on a successful lookup
+// the middleware stores the resolved user in the request context (retrievable via
+// userFromContext) and calls next. It uses requireUserWith with a stub lookup so
+// no database is required.
+func TestRequireUserWith_InjectsUserIntoContext(t *testing.T) {
+	s := newHermeticTestServer(t)
+	want := db.AuthUser{ID: uuid.New(), Username: "alice", Email: "alice@example.com"}
+
+	var gotUser db.AuthUser
+	var gotOK bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUser, gotOK = userFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	lookup := func(r *http.Request) (db.AuthUser, error) { return want, nil }
+	h := s.requireUserWith(next, lookup)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/oauth/change-password", nil)
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if !gotOK {
+		t.Fatal("next handler did not find a user in the request context")
+	}
+	if gotUser.ID != want.ID || gotUser.Username != want.Username {
+		t.Fatalf("context user mismatch: got %+v, want %+v", gotUser, want)
+	}
+}

--- a/pkg/httpserver/routes.go
+++ b/pkg/httpserver/routes.go
@@ -96,37 +96,11 @@ func (s *Server) registerRoutes() {
 			r.Post("/register", s.HandleRegisterPost)
 			// Logout (POST form variant)
 			r.Post("/logout", s.HandleLogout)
-			// Account settings
-			r.Get("/account-settings", s.HandleAccountSettingsGet)
-			// Change password
-			r.Get("/change-password", s.HandleChangePasswordGet)
-			r.Post("/change-password", s.HandleChangePasswordPost)
-			// Change username
-			r.Get("/change-username", s.HandleChangeUsernameGet)
-			r.Post("/change-username", s.HandleChangeUsernamePost)
-			// Change email
-			r.Get("/change-email", s.HandleChangeEmailGet)
-			r.Post("/change-email", s.HandleChangeEmailPost)
-			// Edit profile
-			r.Get("/edit-profile", s.HandleEditProfileGet)
-			r.Post("/edit-profile", s.HandleEditProfilePost)
-			// Change avatar
-			r.Get("/change-avatar", s.HandleChangeAvatarGet)
-			r.Post("/change-avatar", s.HandleChangeAvatarPost)
-			r.Post("/delete-avatar", s.HandleDeleteAvatarPost)
-			// Deactivate account
-			r.Post("/deactivate-account", s.HandleDeactivateAccountPost)
-			// Reactivate account
-			r.Post("/reactivate-account", s.HandleReactivateAccountPost)
-			// MFA verification (during login)
+			// MFA verification (during login). This is the login-time challenge
+			// that runs BEFORE the user is fully authenticated; it does not use
+			// getUserFromSession and so stays out of the requireUser groups below.
 			r.Get("/mfa", s.HandleMFAGet)
 			r.Post("/mfa", s.HandleMFAPost)
-			// MFA setup (from account settings)
-			r.Get("/mfa-setup", s.HandleMFASetupGet)
-			r.Post("/mfa-setup", s.HandleMFASetupPost)
-			r.Post("/mfa-disable", s.HandleMFADisablePost)
-			// Email verification (resend from account settings)
-			r.Post("/resend-verification", s.HandleResendVerification)
 			// Password reset
 			r.Get("/forgot-password", s.HandleForgotPasswordGet)
 			r.Post("/forgot-password", s.HandleForgotPasswordPost)
@@ -135,6 +109,54 @@ func (s *Server) registerRoutes() {
 			// Username reminder
 			r.Get("/forgot-username", s.HandleForgotUsernameGet)
 			r.Post("/forgot-username", s.HandleForgotUsernamePost)
+
+			// --- Authenticated account routes ---
+			// These handlers all resolve the current user from the session
+			// cookie. The requireUser middlewares perform that lookup once (and
+			// redirect to /oauth/login on failure), so the handlers pull the user
+			// from the request context instead of repeating the boilerplate.
+
+			// requireActiveUser: account operations that require an ACTIVE user.
+			r.Group(func(r chi.Router) {
+				r.Use(s.requireActiveUser)
+
+				// Change password
+				r.Get("/change-password", s.HandleChangePasswordGet)
+				r.Post("/change-password", s.HandleChangePasswordPost)
+				// Change username
+				r.Get("/change-username", s.HandleChangeUsernameGet)
+				r.Post("/change-username", s.HandleChangeUsernamePost)
+				// Change email
+				r.Get("/change-email", s.HandleChangeEmailGet)
+				r.Post("/change-email", s.HandleChangeEmailPost)
+				// Edit profile
+				r.Get("/edit-profile", s.HandleEditProfileGet)
+				r.Post("/edit-profile", s.HandleEditProfilePost)
+				// Change avatar
+				r.Get("/change-avatar", s.HandleChangeAvatarGet)
+				r.Post("/change-avatar", s.HandleChangeAvatarPost)
+				r.Post("/delete-avatar", s.HandleDeleteAvatarPost)
+				// MFA setup / disable (post-auth account operations)
+				r.Get("/mfa-setup", s.HandleMFASetupGet)
+				r.Post("/mfa-setup", s.HandleMFASetupPost)
+				r.Post("/mfa-disable", s.HandleMFADisablePost)
+				// Email verification (resend from account settings)
+				r.Post("/resend-verification", s.HandleResendVerification)
+			})
+
+			// requireUser: account operations that must remain reachable for a
+			// DEACTIVATED user (these previously used
+			// getUserFromSessionIncludingInactive).
+			r.Group(func(r chi.Router) {
+				r.Use(s.requireUser)
+
+				// Account settings
+				r.Get("/account-settings", s.HandleAccountSettingsGet)
+				// Deactivate account
+				r.Post("/deactivate-account", s.HandleDeactivateAccountPost)
+				// Reactivate account
+				r.Post("/reactivate-account", s.HandleReactivateAccountPost)
+			})
 		})
 	})
 


### PR DESCRIPTION
## What & why

The same "resolve the authenticated user from the session cookie, or redirect to `/oauth/login`" block was copy-pasted across ~18 account handlers. This PR extracts that boilerplate into middleware and injects the resolved user into the request context, so each handler pulls the user with a single `userFromContext(r.Context())` call instead of repeating the lookup + redirect.

## The two middlewares (`pkg/httpserver/middleware.go`)

Both look up the user with the existing session helpers (reused, not duplicated) and, on failure, perform the exact same redirect the handlers did before: `http.Redirect(w, r, "/oauth/login", http.StatusFound)`. On success they store the user in the request context.

- **`requireActiveUser`** — resolves the ACTIVE user via `getUserFromSession`. Deactivated users get an error and are redirected.
- **`requireUser`** — resolves the user INCLUDING deactivated accounts via `getUserFromSessionIncludingInactive`. This exists specifically for the three routes that must remain reachable for an inactive user (account settings, deactivate, reactivate).

A typed unexported context key plus `userFromContext` / `contextWithUser` helpers carry the user.

## Route grouping (`pkg/httpserver/routes.go`)

The authenticated account routes are split into two nested `r.Group(...)` blocks **inside** the existing CSRF-protected group, so CSRF + user middleware both still apply to everything they did before.

- `requireActiveUser` group: change-password (GET+POST), change-username (GET+POST), change-email (GET+POST), edit-profile (GET+POST), change-avatar (GET+POST), delete-avatar (POST), mfa-setup (GET+POST), mfa-disable (POST), resend-verification (POST).
- `requireUser` (allow-inactive) group: account-settings (GET), deactivate-account (POST), reactivate-account (POST).
- Left OUTSIDE both groups (unchanged): login, consent, register, logout, forgot/reset-password, forgot-username, and the login-time `/mfa` challenge GET+POST. `/mfa` runs before full authentication and does not use `getUserFromSession`, so it stays out; `/mfa-setup` and `/mfa-disable` are post-auth account operations and go into the active-user group.

`HandleRoot` (`/`) is on the root router (outside the CSRF group), so it is left unchanged and still calls `getUserFromSession` directly; the old helpers therefore remain in use.

## Behavior preservation

This is a behavior-preserving refactor. The redirect target and status (302 Found -> `/oauth/login`) are byte-for-byte identical to what the handlers produced before. The active-vs-inactive distinction is preserved by routing the three inactive-allowing handlers through `requireUser`. Handlers keep a minimal `if !ok { redirect }` guard as a safety net.

## Testing

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...`, `go test ./...` all pass locally.
- Added hermetic unit tests (`middleware_test.go`): both middlewares redirect to `/oauth/login` with 302 when no session cookie is present (DB never touched), and a stubbed-lookup test confirms the resolved user is injected into the request context on success.
- Integration tests (which log in and exercise these authenticated routes against Postgres) were not run locally (no Postgres) but compile under the `integration` tag and drive the routes through the router, so the middleware runs exactly as in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE