### PR TITLE
Cleanup: remove verified dead code

### DIFF
--- a/db/queries/auth.sql
+++ b/db/queries/auth.sql
@@ -335,7 +335,3 @@ INSERT INTO oauth_user_consents (user_id, client_id, scopes)
 VALUES ($1, $2, $3)
 ON CONFLICT (user_id, client_id)
 DO UPDATE SET scopes = $3, updated_at = now();
-
--- name: DeleteUserConsent :exec
-DELETE FROM oauth_user_consents
-WHERE user_id = $1 AND client_id = $2;

--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -104,20 +104,6 @@ func (s *Service) Delete(ctx context.Context, currentURL string) error {
 	return s.storage.Delete(ctx, key)
 }
 
-// ValidateImage checks if the uploaded file is a valid image.
-// Deprecated: Use the detection in Upload instead. This is kept for backwards compatibility.
-func ValidateImage(contentType string, size int64) error {
-	if size > MaxAvatarSize {
-		return &ValidationError{"File size exceeds the maximum of 5MB"}
-	}
-
-	if !AllowedMimeTypes[contentType] {
-		return &ValidationError{"File type not allowed. Please upload a JPEG, PNG, GIF, or WebP image."}
-	}
-
-	return nil
-}
-
 // ResizeImage resizes an image to the standard avatar dimensions.
 // Returns the resized image data and content type (always JPEG for consistency).
 func ResizeImage(input io.Reader, contentType string) ([]byte, string, error) {

--- a/pkg/db/auth.sql.go
+++ b/pkg/db/auth.sql.go
@@ -336,21 +336,6 @@ func (q *Queries) DeleteSession(ctx context.Context, id string) error {
 	return err
 }
 
-const deleteUserConsent = `-- name: DeleteUserConsent :exec
-DELETE FROM oauth_user_consents
-WHERE user_id = $1 AND client_id = $2
-`
-
-type DeleteUserConsentParams struct {
-	UserID   uuid.UUID `json:"user_id"`
-	ClientID uuid.UUID `json:"client_id"`
-}
-
-func (q *Queries) DeleteUserConsent(ctx context.Context, arg DeleteUserConsentParams) error {
-	_, err := q.db.ExecContext(ctx, deleteUserConsent, arg.UserID, arg.ClientID)
-	return err
-}
-
 const deleteUserEmailTokens = `-- name: DeleteUserEmailTokens :exec
 DELETE FROM auth_email_tokens WHERE user_id = $1 AND token_type = $2
 `

--- a/pkg/httpserver/credentials.go
+++ b/pkg/httpserver/credentials.go
@@ -37,7 +37,6 @@ var (
 var (
 	ErrInvalidClient      = errors.New("invalid client")
 	ErrInvalidRedirectURI = errors.New("invalid redirect URI")
-	ErrInvalidScope       = errors.New("invalid scope")
 )
 
 // ErrConfidentialClientRequired is returned when an endpoint that requires a fully
@@ -125,42 +124,6 @@ func (s *Server) validateOAuthClientRedirect(ctx context.Context, clientID, redi
 		return db.OauthClient{}, ErrInvalidRedirectURI
 	}
 	return client, nil
-}
-
-// validateOAuthClient validates that the client exists and the redirect URI and scopes are allowed.
-// Returns the client on success. On failure, returns one of:
-//   - ErrInvalidClient (client doesn't exist)
-//   - ErrInvalidRedirectURI (redirect URI not in allowlist)
-//   - ErrInvalidScope (requested scopes not allowed)
-func (s *Server) validateOAuthClient(ctx context.Context, clientID, redirectURI string, scopes []string) (db.OauthClient, error) {
-	client, err := s.datastore.Q.GetOAuthClientByClientID(ctx, clientID)
-	if err != nil {
-		log.Printf("validateOAuthClient: error getting client by client ID: %s\n", err)
-		return db.OauthClient{}, ErrInvalidClient
-	}
-	if !slices.Contains(client.RedirectUris, redirectURI) {
-		log.Printf("validateOAuthClient: redirect URI %s not in allowlist for client: %s\n", redirectURI, clientID)
-		return db.OauthClient{}, ErrInvalidRedirectURI
-	}
-	if scopesAreAllowed, invalidScopes := containsAll(client.AllowedScopes, scopes); !scopesAreAllowed {
-		log.Printf("validateOAuthClient: scopes %v not allowed for client: %s\n", invalidScopes, clientID)
-		return db.OauthClient{}, fmt.Errorf("%w: scopes %v not allowed", ErrInvalidScope, invalidScopes)
-	}
-	return client, nil
-}
-
-// validateCredentials validates a username and password against the database.
-// Returns the user on success. On failure, returns one of:
-//   - ErrMissingCredentials (400)
-//   - ErrInvalidCredentials (401)
-//   - ErrInternal (500)
-//
-// Security: Always returns ErrInvalidCredentials for invalid username/password
-// to prevent username enumeration attacks. The specific reason (user not found vs
-// wrong password) is logged for debugging but not exposed to the client.
-// Note: This function only returns active users.
-func (s *Server) validateCredentials(ctx context.Context, username, password string) (db.AuthUser, error) {
-	return s.doValidateCredentials(ctx, username, password, s.datastore.Q.GetUserByUsername)
 }
 
 // validateCredentialsIncludingInactive validates a username and password against the database,


### PR DESCRIPTION
Removes code confirmed unused via `staticcheck` (U1000) and `golang.org/x/tools/cmd/deadcode`, cross-checked against test usage:

- `validateOAuthClient` (superseded by `validateAuthorizeParams` / `validateOAuthClientRedirect`) and the `ErrInvalidScope` sentinel it was the only user of.
- `validateCredentials` — `validateCredentialsIncludingInactive` and the shared `doValidateCredentials` remain in use (login flow).
- `avatar.ValidateImage` — deprecated, no callers.
- The `DeleteUserConsent` sqlc query — no references anywhere; removed from `db/queries/auth.sql` and its generated method in `pkg/db/auth.sql.go`.

**Deliberately kept:** `Server.Close`/`IsListening`/`ResetRateLimits` and `rateLimitStore.Stop`/`Reset` — `deadcode` flags these as unreachable from `main`, but they are used by the integration test harness, so they are test-support, not dead.

After removal, `staticcheck` reports zero unused symbols and `deadcode` reports only the test-support functions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE