### PR TITLE
Fix: parse argon2 parameters from stored hash during verification

### DIFF
--- a/pkg/auth/password.go
+++ b/pkg/auth/password.go
@@ -43,6 +43,25 @@ func VerifyPassword(password, encodedHash string) (bool, error) {
 		return false, fmt.Errorf("invalid hash format")
 	}
 
+	// Parse and validate the version field, e.g. "v=19"
+	var version int
+	if _, err := fmt.Sscanf(parts[2], "v=%d", &version); err != nil {
+		return false, fmt.Errorf("invalid hash format")
+	}
+	if version != argon2.Version {
+		return false, fmt.Errorf("incompatible argon2 version")
+	}
+
+	// Parse the parameters embedded in the hash, e.g. "m=65536,t=3,p=2".
+	// These reflect whatever memory/iterations/parallelism were in effect
+	// when this particular hash was created, which may differ from the
+	// package's current constants.
+	var hashMemory, hashIterations uint32
+	var hashParallelism uint8
+	if n, err := fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", &hashMemory, &hashIterations, &hashParallelism); err != nil || n != 3 {
+		return false, fmt.Errorf("invalid hash format")
+	}
+
 	// Decode salt and hash
 	salt, err := base64.RawStdEncoding.DecodeString(parts[4])
 	if err != nil {
@@ -54,7 +73,10 @@ func VerifyPassword(password, encodedHash string) (bool, error) {
 		return false, err
 	}
 
-	// Verify
-	otherHash := argon2.IDKey([]byte(password), salt, iterations, memory, parallelism, uint32(len(hash)))
+	// Verify using the parameters parsed from the stored hash, not the
+	// package's current constants, so that changing the current
+	// memory/iterations/parallelism defaults doesn't break verification
+	// of existing hashes.
+	otherHash := argon2.IDKey([]byte(password), salt, hashIterations, hashMemory, hashParallelism, uint32(len(hash)))
 	return subtle.ConstantTimeCompare(hash, otherHash) == 1, nil
 }

--- a/pkg/auth/password_test.go
+++ b/pkg/auth/password_test.go
@@ -1,7 +1,13 @@
 package auth
 
 import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
 	"testing"
+
+	"golang.org/x/crypto/argon2"
 )
 
 func TestHashAndVerifyPassword(t *testing.T) {
@@ -57,5 +63,106 @@ func TestHashPasswordUniqueSalts(t *testing.T) {
 	valid, _ = VerifyPassword(password, hash2)
 	if !valid {
 		t.Error("Second hash doesn't verify")
+	}
+}
+
+// buildEncodedHash constructs an argon2id encoded hash string using
+// caller-supplied parameters, mirroring the format produced by
+// HashPassword but without relying on the package's current constants.
+func buildEncodedHash(password string, mem, iters uint32, par uint8, keyLen uint32) (string, error) {
+	salt := make([]byte, saltLength)
+	if _, err := rand.Read(salt); err != nil {
+		return "", err
+	}
+	hash := argon2.IDKey([]byte(password), salt, iters, mem, par, keyLen)
+
+	b64Salt := base64.RawStdEncoding.EncodeToString(salt)
+	b64Hash := base64.RawStdEncoding.EncodeToString(hash)
+
+	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
+		argon2.Version, mem, iters, par, b64Salt, b64Hash), nil
+}
+
+// TestVerifyPasswordUsesHashEmbeddedParams proves that VerifyPassword
+// derives its comparison hash from the memory/iterations/parallelism
+// parameters embedded in the stored encoded hash, not from the package's
+// current memory/iterations/parallelism constants. It builds a hash with
+// parameters that are clearly different from the current constants; if
+// VerifyPassword ignored the embedded params (the old, buggy behavior)
+// this test would fail because the re-derived hash would use the wrong
+// parameters and never match.
+func TestVerifyPasswordUsesHashEmbeddedParams(t *testing.T) {
+	password := "correct horse battery staple"
+
+	// Sanity check: these custom params must differ from the current
+	// package constants, or this test wouldn't actually exercise the fix.
+	customMemory := uint32(32768)
+	customIterations := uint32(2)
+	customParallelism := uint8(1)
+	if customMemory == uint32(memory) && customIterations == uint32(iterations) && customParallelism == uint8(parallelism) {
+		t.Fatal("custom params must differ from package constants for this test to be meaningful")
+	}
+
+	hash, err := buildEncodedHash(password, customMemory, customIterations, customParallelism, keyLength)
+	if err != nil {
+		t.Fatalf("buildEncodedHash failed: %v", err)
+	}
+
+	valid, err := VerifyPassword(password, hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if !valid {
+		t.Error("VerifyPassword returned false for a hash built with non-default params and the correct password")
+	}
+
+	valid, err = VerifyPassword("wrong password", hash)
+	if err != nil {
+		t.Fatalf("VerifyPassword failed: %v", err)
+	}
+	if valid {
+		t.Error("VerifyPassword returned true for a hash built with non-default params and a wrong password")
+	}
+}
+
+func TestVerifyPasswordMalformedHash(t *testing.T) {
+	password := "mysecretpassword"
+
+	hash, err := HashPassword(password)
+	if err != nil {
+		t.Fatalf("HashPassword failed: %v", err)
+	}
+
+	parts := strings.Split(hash, "$")
+
+	cases := []struct {
+		name string
+		hash string
+	}{
+		{
+			name: "bad version",
+			hash: fmt.Sprintf("$%s$v=18$%s$%s$%s", parts[1], parts[3], parts[4], parts[5]),
+		},
+		{
+			name: "non-numeric version",
+			hash: fmt.Sprintf("$%s$v=abc$%s$%s$%s", parts[1], parts[3], parts[4], parts[5]),
+		},
+		{
+			name: "non-numeric params",
+			hash: fmt.Sprintf("$%s$%s$m=abc,t=3,p=2$%s$%s", parts[1], parts[2], parts[4], parts[5]),
+		},
+		{
+			name: "too few parts",
+			hash: fmt.Sprintf("$%s$%s$%s$%s", parts[1], parts[2], parts[3], parts[4]),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := VerifyPassword(password, tc.hash)
+			if err == nil {
+				t.Errorf("expected an error for malformed hash %q, got nil", tc.hash)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

`HashPassword` writes an argon2id encoded hash containing the memory
(`m=`), iterations (`t=`), and parallelism (`p=`) used to create it —
that's the whole point of the standard `$argon2id$v=19$m=...,t=...,p=...$salt$hash`
encoding. But `VerifyPassword` was only parsing far enough to grab the
salt and hash, then re-deriving the comparison hash using the
**package's current** `memory`/`iterations`/`parallelism` constants
instead of the parameters actually embedded in the hash.

**Lock-out risk:** the day anyone tunes those constants (a normal,
expected change as hardware improves), every existing password hash
in the database would silently stop verifying — all users with
pre-existing hashes would be locked out, since verification would run
the new constants against a hash computed with the old ones.

## Fix

`VerifyPassword` now:
1. Parses `parts[2]` (`v=<n>`) and confirms it equals `argon2.Version`
   (19), returning `"incompatible argon2 version"` if not.
2. Parses `parts[3]` (`m=<mem>,t=<iters>,p=<par>`) via
   `fmt.Sscanf(parts[3], "m=%d,t=%d,p=%d", ...)`, checking for a scan
   error, returning `"invalid hash format"` on malformed input.
3. Derives the comparison hash with `argon2.IDKey(...)` using **those
   parsed parameters**, not the package constants, then compares with
   `subtle.ConstantTimeCompare` as before.

`HashPassword` is unchanged — new hashes still use the current
constants as the "current" hashing strength; each hash simply carries
its own params forward for verification.

## Test proving the fix

`TestVerifyPasswordUsesHashEmbeddedParams` builds an argon2id encoded
hash directly with `argon2.IDKey` using parameters (`m=32768,t=2,p=1`)
that are deliberately different from the package's current constants,
then asserts `VerifyPassword` succeeds for the correct password and
fails for a wrong one. I manually reverted `password.go` to the old
constant-using logic and confirmed this test fails against it
(`VerifyPassword returned false for a hash built with non-default
params and the correct password`), then restored the fix — so the
test genuinely exercises the bug. Also added
`TestVerifyPasswordMalformedHash` covering a bad version, a
non-numeric version, non-numeric params, and a truncated hash.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `go test ./pkg/auth/ -v` (all auth tests pass, including new ones)
- [x] Manually reverted to old logic and confirmed the new proof test fails, then restored the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE