### PR TITLE
Fix: bound avatar upload request body size

### DIFF
--- a/pkg/avatar/avatar.go
+++ b/pkg/avatar/avatar.go
@@ -19,8 +19,25 @@ import (
 )
 
 const (
-	// MaxAvatarSize is the maximum file size for avatar uploads (5MB).
+	// MaxAvatarSize is the maximum file size for avatar uploads (5MB). This is
+	// the application-level image size cap, enforced by Upload below.
 	MaxAvatarSize = 5 * 1024 * 1024
+	// MaxAvatarRequestBodySize is the hard ceiling placed on the raw HTTP
+	// request body of an avatar upload (multipart/form-data), via
+	// http.MaxBytesReader, BEFORE any multipart parsing happens. It is
+	// intentionally larger than MaxAvatarSize so that:
+	//   - legitimate uploads (a ~5MB image, plus multipart boundaries/headers
+	//     and the small csrf_token form field) are never rejected by the
+	//     network-level cap, and
+	//   - uploads that are moderately over MaxAvatarSize still reach the
+	//     friendlier, more specific "File size exceeds the maximum of 5MB"
+	//     validation error from Upload below (a 200 response with an inline
+	//     error) instead of being hard-rejected by the network layer.
+	// Only requests that are drastically oversized (the actual DoS scenario
+	// this constant guards against: multi-megabyte-to-gigabyte bodies that
+	// would otherwise be spooled to memory/disk in full before any size check
+	// runs) are stopped here.
+	MaxAvatarRequestBodySize = 10 * 1024 * 1024
 	// AvatarSize is the target dimension for resized avatars.
 	AvatarSize = 256
 	// MaxImageDimension is the maximum width/height allowed to prevent decompression bombs.

--- a/pkg/httpserver/account.go
+++ b/pkg/httpserver/account.go
@@ -744,6 +744,7 @@ func (s *Server) HandleChangeAvatarGet(w http.ResponseWriter, r *http.Request) {
 // @Success      200 {string} string "HTML change avatar page with success message"
 // @Failure      400 {string} string "Invalid request - invalid file"
 // @Failure      401 {string} string "Unauthorized - no valid session"
+// @Failure      413 {string} string "Request body too large"
 // @Router       /change-avatar [post]
 func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) {
 	user, ok := userFromContext(r.Context())
@@ -752,8 +753,15 @@ func (s *Server) HandleChangeAvatarPost(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Parse multipart form with max file size
-	if err := r.ParseMultipartForm(avatar.MaxAvatarSize); err != nil {
+	// Parse multipart form with max file size. In normal operation the
+	// request body has already been bounded and parsed by maxAvatarUploadBytes
+	// (see middleware.go and routes.go), which runs earlier in the chain -
+	// before csrfMiddleware, even - specifically so an oversized body never
+	// reaches this handler (or csrfMiddleware's own implicit parse) unbounded.
+	// This call is therefore normally a cheap no-op against the
+	// already-parsed form; it's kept as defense in depth in case this handler
+	// is ever reached without going through that middleware.
+	if err := r.ParseMultipartForm(avatar.MaxAvatarRequestBodySize); err != nil {
 		s.renderChangeAvatar(w, r, ChangeAvatarPageData{
 			Error:     "File too large. Maximum size is 5MB.",
 			AvatarURL: user.Picture.String,

--- a/pkg/httpserver/avatar_body_limit_test.go
+++ b/pkg/httpserver/avatar_body_limit_test.go
@@ -1,0 +1,153 @@
+package httpserver
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/eswan18/identity/pkg/avatar"
+)
+
+// newAvatarMultipartRequest builds a POST /oauth/change-avatar request whose
+// multipart/form-data body contains an "avatar" file part of exactly fileSize
+// bytes plus a csrf_token field, mirroring the shape of a real browser upload
+// (see avatar_integration_test.go's TestAvatarUpload for the same construction
+// against a live server).
+func newAvatarMultipartRequest(t *testing.T, fileSize int) *http.Request {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	part, err := writer.CreateFormFile("avatar", "test.jpg")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := io.CopyN(part, zeroReader{}, int64(fileSize)); err != nil {
+		t.Fatalf("writing %d bytes into avatar part: %v", fileSize, err)
+	}
+	if err := writer.WriteField("csrf_token", "some-csrf-token-value"); err != nil {
+		t.Fatalf("WriteField: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/change-avatar", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+// zeroReader is an io.Reader that produces an endless stream of zero bytes,
+// used so tests can synthesize large multipart file parts without allocating
+// a giant byte slice up front.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}
+
+// TestMaxAvatarUploadBytes_RejectsOversizedBody is a regression test for the
+// avatar-upload DoS gap: without a cap on the raw request body,
+// r.ParseMultipartForm's "maxMemory" argument only controls the in-memory vs.
+// on-disk split, not the overall amount read, so a client could previously
+// POST an effectively unbounded body to /oauth/change-avatar. This verifies
+// maxAvatarUploadBytes now stops that at avatar.MaxAvatarRequestBodySize with a
+// 413, before the wrapped handler (which would include csrfMiddleware and the
+// upload handler itself in the real chain) ever runs.
+func TestMaxAvatarUploadBytes_RejectsOversizedBody(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	h := s.maxAvatarUploadBytes(okHandler(&reached))
+
+	// One byte of file content over the hard cap is enough to trip the
+	// MaxBytesReader; multipart framing overhead only makes the total larger.
+	req := newAvatarMultipartRequest(t, avatar.MaxAvatarRequestBodySize+1)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized body: expected %d, got %d: %s",
+			http.StatusRequestEntityTooLarge, rec.Code, rec.Body.String())
+	}
+	if reached {
+		t.Fatal("oversized body: next handler must not be reached")
+	}
+}
+
+// TestMaxAvatarUploadBytes_AllowsLegitimateUpload verifies a realistically
+// sized upload (a ~1KB stand-in for a real image, plus the csrf_token field)
+// comfortably clears the bound and reaches the wrapped handler, with the
+// multipart form already parsed and its fields available.
+func TestMaxAvatarUploadBytes_AllowsLegitimateUpload(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	var sawCSRFToken string
+	h := s.maxAvatarUploadBytes(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		sawCSRFToken = r.FormValue("csrf_token")
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := newAvatarMultipartRequest(t, 1024)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("legitimate upload: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !reached {
+		t.Fatal("legitimate upload: next handler must be reached")
+	}
+	if sawCSRFToken != "some-csrf-token-value" {
+		t.Fatalf("legitimate upload: expected csrf_token field to survive parsing, got %q", sawCSRFToken)
+	}
+}
+
+// TestMaxAvatarUploadBytes_AllowsUpToMaxAvatarSizePlusOverhead is a sanity
+// check that a file at the application-level image cap (avatar.MaxAvatarSize)
+// still fits under the request-body bound once multipart framing and the
+// csrf_token field are added -- i.e. the hard network cap is not tighter than
+// the cap the handler itself enforces.
+func TestMaxAvatarUploadBytes_AllowsUpToMaxAvatarSizePlusOverhead(t *testing.T) {
+	s := newHermeticTestServer(t)
+	reached := false
+	h := s.maxAvatarUploadBytes(okHandler(&reached))
+
+	req := newAvatarMultipartRequest(t, avatar.MaxAvatarSize)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("MaxAvatarSize upload: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !reached {
+		t.Fatal("MaxAvatarSize upload: next handler must be reached")
+	}
+}
+
+// TestChangeAvatarRoute_OversizedBodyRejectedBeforeCSRF drives the request
+// through the real router (registerRoutes) rather than calling the middleware
+// directly, confirming the route is wired so the body-size limit applies
+// ahead of csrfMiddleware: with no csrf_token cookie at all (which would
+// normally trip csrfMiddleware's 403 "missing CSRF token" check first if it
+// ran before the size check), an oversized body still gets the 413 from
+// maxAvatarUploadBytes, proving that middleware runs first.
+func TestChangeAvatarRoute_OversizedBodyRejectedBeforeCSRF(t *testing.T) {
+	s := newHermeticTestServer(t)
+
+	req := newAvatarMultipartRequest(t, avatar.MaxAvatarRequestBodySize+1)
+	rec := httptest.NewRecorder()
+	s.router.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 from the body-size limit ahead of CSRF, got %d: %s",
+			rec.Code, rec.Body.String())
+	}
+}

--- a/pkg/httpserver/middleware.go
+++ b/pkg/httpserver/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/eswan18/identity/pkg/avatar"
 	"github.com/eswan18/identity/pkg/db"
 )
 
@@ -53,5 +54,48 @@ func (s *Server) requireUserWith(next http.Handler, lookup func(*http.Request) (
 			return
 		}
 		next.ServeHTTP(w, r.WithContext(contextWithUser(r.Context(), user)))
+	})
+}
+
+// maxAvatarUploadBytes bounds the raw HTTP request body of a change-avatar
+// upload to avatar.MaxAvatarRequestBodySize BEFORE any form parsing occurs, and
+// eagerly parses the multipart form so that bound is actually enforced at this
+// point in the middleware chain rather than later.
+//
+// Why this has to run here, ahead of csrfMiddleware:
+//
+// POST /oauth/change-avatar sits behind csrfMiddleware (see routes.go), which
+// calls r.FormValue(csrfFormField) to read the csrf_token field. Because this
+// route's content type is multipart/form-data, that FormValue call triggers
+// r.ParseMultipartForm(32<<20) internally (Go's default). The "maxMemory"
+// argument to ParseMultipartForm is NOT an overall body-size limit - it only
+// controls how much of the body is buffered in memory before the rest is
+// spooled to a temporary file on disk. Without a cap on r.Body itself, a
+// client can POST a multi-gigabyte body to this route and csrfMiddleware's
+// implicit parse (or, previously, the handler's own ParseMultipartForm call)
+// will read and spool the entire thing to disk before any size check - the
+// handler's 5MB avatar.MaxAvatarSize check included - ever runs. That is the
+// DoS this middleware closes.
+//
+// Wrapping r.Body in http.MaxBytesReader and forcing the parse here, ahead of
+// csrfMiddleware in the chain (see the r.With(...) registration in
+// routes.go), makes the limit bind on the very first parse of the body,
+// whoever triggers it. If the body is within bounds, ParseMultipartForm
+// succeeds and caches the result on the request (r.MultipartForm), so both
+// csrfMiddleware's later FormValue call and the handler's own
+// ParseMultipartForm call are cheap no-ops against the already-parsed form -
+// including the csrf_token field, which parses normally since the bound
+// leaves it comfortably room (see avatar.MaxAvatarRequestBodySize). If the
+// body exceeds the limit, ParseMultipartForm returns an error and we respond
+// immediately with 413, before the CSRF check or the handler ever run.
+func (s *Server) maxAvatarUploadBytes(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, avatar.MaxAvatarRequestBodySize)
+		if err := r.ParseMultipartForm(avatar.MaxAvatarRequestBodySize); err != nil {
+			s.renderError(w, http.StatusRequestEntityTooLarge, "File Too Large",
+				"The file you uploaded is too large. Maximum upload size is 5MB.", "")
+			return
+		}
+		next.ServeHTTP(w, r)
 	})
 }

--- a/pkg/httpserver/routes.go
+++ b/pkg/httpserver/routes.go
@@ -77,6 +77,18 @@ func (s *Server) registerRoutes() {
 		// GET is a safe method anyway. The POST form variant lives in the CSRF group.
 		r.Get("/logout", s.HandleLogout)
 
+		// Change avatar upload (POST only). Registered here, ahead of the CSRF
+		// group below, with its own explicit middleware chain - maxAvatarUploadBytes,
+		// THEN csrfMiddleware, THEN requireActiveUser - specifically so the
+		// request-body size cap in maxAvatarUploadBytes takes effect before
+		// csrfMiddleware's r.FormValue call, which would otherwise trigger an
+		// unbounded multipart parse of this route's multipart/form-data body
+		// first. See maxAvatarUploadBytes in middleware.go for the full
+		// explanation. The GET variant has no body to bound, so it stays in the
+		// CSRF group below like every other account route.
+		r.With(s.maxAvatarUploadBytes, s.csrfMiddleware, s.requireActiveUser).
+			Post("/change-avatar", s.HandleChangeAvatarPost)
+
 		// --- Browser, session-cookie form endpoints (CSRF protected) ---
 		// Every state-changing POST here is driven by a server-rendered HTML form
 		// authenticated by the session_id cookie, so it is vulnerable to CSRF and is
@@ -132,9 +144,10 @@ func (s *Server) registerRoutes() {
 				// Edit profile
 				r.Get("/edit-profile", s.HandleEditProfileGet)
 				r.Post("/edit-profile", s.HandleEditProfilePost)
-				// Change avatar
+				// Change avatar (GET only here; the POST upload is registered
+				// separately above, ahead of this CSRF group - see the comment
+				// by that registration for why).
 				r.Get("/change-avatar", s.HandleChangeAvatarGet)
-				r.Post("/change-avatar", s.HandleChangeAvatarPost)
 				r.Post("/delete-avatar", s.HandleDeleteAvatarPost)
 				// MFA setup / disable (post-auth account operations)
 				r.Get("/mfa-setup", s.HandleMFASetupGet)


### PR DESCRIPTION
## Problem

`HandleChangeAvatarPost` (`pkg/httpserver/account.go`) calls
`r.ParseMultipartForm(avatar.MaxAvatarSize)` to parse the avatar upload. The
argument to `ParseMultipartForm` is **not** an overall body-size limit — it
only controls how much of the body is buffered in memory before the rest is
spooled to a temporary file on disk. There was no cap on the total request
body size, so a client could POST a multi-gigabyte body to
`/oauth/change-avatar` and have the entire thing read and spooled to disk
before the existing `header.Size > MaxAvatarSize` check (in
`avatar.Service.Upload`) ever ran.

It's worse than it looks: `csrfMiddleware` (`pkg/httpserver/csrf.go`) calls
`r.FormValue(csrf_token)` on every POST in the CSRF-protected route group,
including `/oauth/change-avatar`. Because that route's content type is
`multipart/form-data`, `FormValue` triggers `r.ParseMultipartForm(32<<20)`
internally — with Go's *default* memory threshold — **before the handler
ever runs**. So simply wrapping `r.Body` inside `HandleChangeAvatarPost`
would have been too late: the unbounded parse (and disk-spool) would already
have happened in the CSRF middleware.

## Fix

Added `maxAvatarUploadBytes` middleware (`pkg/httpserver/middleware.go`) and
wired it in `pkg/httpserver/routes.go` to run **before** `csrfMiddleware`,
specifically for `POST /oauth/change-avatar` (the GET variant has no body and
is untouched). The route registration was pulled out of the shared CSRF
route group and given its own explicit middleware chain so the ordering is
guaranteed:

```go
r.With(s.maxAvatarUploadBytes, s.csrfMiddleware, s.requireActiveUser).
	Post("/change-avatar", s.HandleChangeAvatarPost)
```

`maxAvatarUploadBytes` wraps `r.Body` in `http.MaxBytesReader` and eagerly
calls `r.ParseMultipartForm` itself, against the new
`avatar.MaxAvatarRequestBodySize` constant. This makes the cap bind on the
very first parse of the body, whoever triggers it:

- If the body is within bounds, the parse succeeds and Go caches the result
  on the request (`r.MultipartForm`), so `csrfMiddleware`'s later
  `FormValue` call and the handler's own `ParseMultipartForm` call become
  cheap no-ops against the already-parsed form — the `csrf_token` field
  included.
- If the body exceeds the bound, `ParseMultipartForm` errors and the
  middleware responds immediately with `413 Request Entity Too Large`,
  before the CSRF check or the handler (or a temp file) ever exist.

The existing `avatar.MaxAvatarSize` (5MB) check inside
`avatar.Service.Upload` is left completely in place as defense in depth — it
still produces the friendlier "File size exceeds the maximum of 5MB"
message for uploads that are over the *image* cap but not egregiously so.

### Why 10MB, not `MaxAvatarSize + 64KB`

The existing integration test suite
(`pkg/httpserver/avatar_integration_test.go`,
`TestAvatarUploadOversizedFile`) intentionally uploads a 6MB payload and
asserts a `200 OK` with an inline error (the friendly
`avatar.Service.Upload` size-check path), not a hard rejection. A tight
`MaxAvatarSize + 64KB` network cap would have turned that into a `413` and
broken the test. Instead, `avatar.MaxAvatarRequestBodySize` (10MB, defined
in `pkg/avatar/avatar.go`) sits comfortably above that 6MB test payload —
preserving the "friendlier oversize message" UX for moderately-oversized
uploads — while still cutting off the actual DoS scenario (multi-MB-to-GB
bodies) far below any meaningful resource cost. A real ~5MB image plus
multipart framing and the `csrf_token` field fits with room to spare.

## Testing

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./...` all
  pass.
- `go test ./...` passes.
- Added `pkg/httpserver/avatar_body_limit_test.go` (hermetic, no DB/MinIO
  needed):
  - oversized body (`MaxAvatarRequestBodySize + 1`) is rejected with 413 by
    `maxAvatarUploadBytes` directly, and via the real router
    (`registerRoutes`), confirming it's rejected *before* CSRF would have
    run (no CSRF cookie is set in that test, yet the response is 413, not
    the CSRF 403).
  - a realistic ~1KB upload plus `csrf_token` field passes through the
    middleware and the field is readable via `r.FormValue` afterward.
  - a file at exactly `avatar.MaxAvatarSize` (5MB) still fits under the
    request-body bound once multipart framing is added.
- Could not run the `integration` build-tagged suite locally (no
  Postgres/MinIO available here), but confirmed it compiles under
  `-tags integration` and reasoned through `TestAvatarUpload`,
  `TestAvatarUploadOversizedFile`, `TestAvatarUploadInvalidFileType`,
  `TestAvatarUpdate`, `TestAvatarDelete`, and `TestUserInfoReturnsPicture`
  against the new limit — none of their payloads exceed 10MB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE