### PR TITLE
Sweep expired sessions, auth codes, and dead tokens in the cleanup worker

### DIFF
--- a/db/queries/auth.sql
+++ b/db/queries/auth.sql
@@ -324,6 +324,33 @@ DELETE FROM auth_email_tokens
 WHERE token_type = 'password_reset'
   AND (expires_at <= now() OR used_at IS NOT NULL);
 
+-- name: DeleteExpiredSessions :exec
+-- auth_sessions reads (GetSession) filter on expires_at > now(), so an expired
+-- session can never be used again -- safe to delete outright.
+DELETE FROM auth_sessions
+WHERE expires_at <= now();
+
+-- name: DeleteExpiredAuthorizationCodes :exec
+-- Authorization codes are single-use and short-lived; a consumed OR expired
+-- code can never yield tokens (replay of a consumed code is rejected by the
+-- atomic ConsumeAuthorizationCode update), so both are safe to delete.
+DELETE FROM oauth_authorization_codes
+WHERE expires_at <= now() OR consumed_at IS NOT NULL;
+
+-- name: DeleteDeadTokens :exec
+-- Each row holds both an access token (expires_at) and a refresh token
+-- (refresh_expires_at, which is NULLABLE -- NULL means the refresh token never
+-- expires). A row is only safe to delete once it can never be used again:
+-- either it has been revoked, or the access token is expired AND the refresh
+-- token is also expired (never delete just because expires_at passed -- a
+-- non-revoked row whose refresh token is still valid, or non-expiring, must
+-- be kept since it can still mint new access tokens).
+DELETE FROM oauth_tokens
+WHERE revoked_at IS NOT NULL
+   OR (expires_at <= now()
+       AND refresh_expires_at IS NOT NULL
+       AND refresh_expires_at <= now());
+
 -- Consent queries
 
 -- name: GetUserConsent :one

--- a/pkg/db/auth.sql.go
+++ b/pkg/db/auth.sql.go
@@ -260,6 +260,29 @@ func (q *Queries) DeleteAllUserSessions(ctx context.Context, userID uuid.UUID) e
 	return err
 }
 
+const deleteDeadTokens = `-- name: DeleteDeadTokens :exec
+DELETE FROM oauth_tokens
+WHERE revoked_at IS NOT NULL
+   OR (expires_at <= now()
+       AND refresh_expires_at IS NOT NULL
+       AND refresh_expires_at <= now())
+`
+
+func (q *Queries) DeleteDeadTokens(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, deleteDeadTokens)
+	return err
+}
+
+const deleteExpiredAuthorizationCodes = `-- name: DeleteExpiredAuthorizationCodes :exec
+DELETE FROM oauth_authorization_codes
+WHERE expires_at <= now() OR consumed_at IS NOT NULL
+`
+
+func (q *Queries) DeleteExpiredAuthorizationCodes(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, deleteExpiredAuthorizationCodes)
+	return err
+}
+
 const deleteExpiredEmailTokens = `-- name: DeleteExpiredEmailTokens :exec
 DELETE FROM auth_email_tokens WHERE expires_at <= now()
 `
@@ -295,6 +318,16 @@ WHERE token_type = 'password_reset'
 
 func (q *Queries) DeleteExpiredPasswordResetTokens(ctx context.Context) error {
 	_, err := q.db.ExecContext(ctx, deleteExpiredPasswordResetTokens)
+	return err
+}
+
+const deleteExpiredSessions = `-- name: DeleteExpiredSessions :exec
+DELETE FROM auth_sessions
+WHERE expires_at <= now()
+`
+
+func (q *Queries) DeleteExpiredSessions(ctx context.Context) error {
+	_, err := q.db.ExecContext(ctx, deleteExpiredSessions)
 	return err
 }
 

--- a/pkg/httpserver/cleanup.go
+++ b/pkg/httpserver/cleanup.go
@@ -26,25 +26,29 @@ const cleanupSweepTimeout = 30 * time.Second
 //   - auth_mfa_enrollment_pending (DeleteExpiredMFAEnrollmentPending)
 //   - auth_email_tokens (DeleteExpiredEmailTokens)
 //   - auth_email_tokens, password-reset rows specifically (DeleteExpiredPasswordResetTokens)
+//   - auth_sessions (DeleteExpiredSessions)
+//   - oauth_authorization_codes (DeleteExpiredAuthorizationCodes)
+//   - oauth_tokens (DeleteDeadTokens)
 //
 // These queries already existed but were never called anywhere, so expired
 // rows accumulated in their tables forever (unbounded growth, not a
 // correctness bug -- the read queries all filter on expires_at, so expired
 // rows were never usable).
 //
-// Deliberately NOT covered here: oauth_tokens, auth_sessions, and
-// oauth_authorization_codes also have expires_at and will accumulate rows
-// over time, but there is no DeleteExpired* query for them yet (and, for
-// oauth_tokens, retention may need extra thought, e.g. keeping revoked/expired
-// tokens around briefly for auditing). That's left as a conscious follow-up,
-// not an oversight.
+// oauth_tokens gets the most conservative treatment: each row holds both an
+// access token (expires_at) and a refresh token (refresh_expires_at, which is
+// NULLable -- NULL means the refresh token never expires), so DeleteDeadTokens
+// only removes a row once it can never be used again: it's revoked, or the
+// access token is expired AND the refresh token is also expired. A row whose
+// refresh token is still valid (or non-expiring) is kept even after its
+// access token has expired, since it can still mint new access tokens.
 //
-// Each of the four deletes is independent: if one fails, it is logged and the
-// remaining three still run rather than bailing out early. The sweep is
-// bounded by cleanupSweepTimeout so a hung DB call can't block the worker
-// indefinitely. The return value is the last error encountered (nil if all
-// four succeeded); callers mainly care that the sweep ran; the operational
-// signal is the [ERROR] log line, not this return value.
+// Each of the seven deletes is independent: if one fails, it is logged and
+// the rest still run rather than bailing out early. The sweep is bounded by
+// cleanupSweepTimeout so a hung DB call can't block the worker indefinitely.
+// The return value is the last error encountered (nil if all seven
+// succeeded); callers mainly care that the sweep ran; the operational signal
+// is the [ERROR] log line, not this return value.
 func (s *Server) runExpiryCleanup(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, cleanupSweepTimeout)
 	defer cancel()
@@ -57,6 +61,9 @@ func (s *Server) runExpiryCleanup(ctx context.Context) error {
 		{"auth_mfa_enrollment_pending", s.datastore.Q.DeleteExpiredMFAEnrollmentPending},
 		{"auth_email_tokens", s.datastore.Q.DeleteExpiredEmailTokens},
 		{"auth_email_tokens (password_reset)", s.datastore.Q.DeleteExpiredPasswordResetTokens},
+		{"auth_sessions", s.datastore.Q.DeleteExpiredSessions},
+		{"oauth_authorization_codes", s.datastore.Q.DeleteExpiredAuthorizationCodes},
+		{"oauth_tokens", s.datastore.Q.DeleteDeadTokens},
 	}
 
 	var lastErr error

--- a/pkg/httpserver/cleanup_integration_test.go
+++ b/pkg/httpserver/cleanup_integration_test.go
@@ -3,18 +3,20 @@
 package httpserver
 
 import (
+	"database/sql"
 	"time"
 
 	"github.com/eswan18/identity/pkg/db"
+	"github.com/google/uuid"
 )
 
 // TestExpiryCleanup_DeletesExpiredRows is an end-to-end (real Postgres, via the shared
 // OAuthFlowSuite testcontainer) check that runExpiryCleanup actually deletes rows past
-// their expires_at, for one row in each of the four tables it targets. The hermetic unit
-// test in cleanup_test.go covers the loop/scheduling behavior without a database; this
-// covers the SQL side, which the queries themselves already tested (they're plain
-// generated sqlc :exec statements) but which was never wired up to anything before this
-// change.
+// their expires_at, for one row in each of the four tables it originally targeted. The
+// hermetic unit test in cleanup_test.go covers the loop/scheduling behavior without a
+// database; this covers the SQL side, which the queries themselves already tested
+// (they're plain generated sqlc :exec statements) but which was never wired up to
+// anything before this change.
 func (s *OAuthFlowSuite) TestExpiryCleanup_DeletesExpiredRows() {
 	ctx := s.T().Context()
 	user := s.mustRegisterUser(
@@ -70,6 +72,213 @@ func (s *OAuthFlowSuite) TestExpiryCleanup_DeletesExpiredRows() {
 	s.assertRowCount("auth_mfa_pending", "id = $1", mfaPendingID, 0)
 	s.assertRowCount("auth_mfa_enrollment_pending", "user_id = $1", user.ID, 0)
 	s.assertRowCount("auth_email_tokens", "user_id = $1", user.ID, 0)
+}
+
+// TestExpiryCleanup_DeletesExpiredSessions covers the auth_sessions sweep
+// (DeleteExpiredSessions): a session past its expires_at is deleted, while one that
+// hasn't expired yet survives -- proving the sweep doesn't over-delete.
+func (s *OAuthFlowSuite) TestExpiryCleanup_DeletesExpiredSessions() {
+	ctx := s.T().Context()
+	user := s.mustRegisterUser(
+		s.mustGenerateAlphanumericString(10),
+		s.mustGenerateAlphanumericString(10),
+		s.mustGenerateAlphanumericString(10)+"@example.com",
+	)
+
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	expiredSessionID := s.mustGenerateAlphanumericString(20)
+	err := s.datastore.Q.CreateSession(ctx, db.CreateSessionParams{
+		ID:        expiredSessionID,
+		UserID:    user.ID,
+		ExpiresAt: past,
+	})
+	s.Require().NoError(err)
+
+	activeSessionID := s.mustGenerateAlphanumericString(20)
+	err = s.datastore.Q.CreateSession(ctx, db.CreateSessionParams{
+		ID:        activeSessionID,
+		UserID:    user.ID,
+		ExpiresAt: future,
+	})
+	s.Require().NoError(err)
+
+	s.assertRowCount("auth_sessions", "id = $1", expiredSessionID, 1)
+	s.assertRowCount("auth_sessions", "id = $1", activeSessionID, 1)
+
+	err = s.server.runExpiryCleanup(ctx)
+	s.NoError(err)
+
+	s.assertRowCount("auth_sessions", "id = $1", expiredSessionID, 0)
+	s.assertRowCount("auth_sessions", "id = $1", activeSessionID, 1)
+}
+
+// TestExpiryCleanup_DeletesDeadAuthorizationCodes covers the oauth_authorization_codes
+// sweep (DeleteExpiredAuthorizationCodes): an expired code and a consumed-but-not-expired
+// code are both deleted (neither can ever yield tokens again), while a fresh, unconsumed,
+// non-expired code survives.
+func (s *OAuthFlowSuite) TestExpiryCleanup_DeletesDeadAuthorizationCodes() {
+	ctx := s.T().Context()
+	user := s.mustRegisterUser(
+		s.mustGenerateAlphanumericString(10),
+		s.mustGenerateAlphanumericString(10),
+		s.mustGenerateAlphanumericString(10)+"@example.com",
+	)
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateAlphanumericString(12),
+		Name:           "cleanup-test-client",
+		RedirectUris:   []string{"http://example.com/callback"},
+		AllowedScopes:  []string{"openid"},
+		IsConfidential: false,
+		Audience:       "test-audience",
+	})
+
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	// Expired, unconsumed.
+	expiredCode := s.mustGenerateAlphanumericString(32)
+	err := s.datastore.Q.InsertAuthorizationCode(ctx, db.InsertAuthorizationCodeParams{
+		Code:        expiredCode,
+		UserID:      user.ID,
+		ClientID:    client.ID,
+		RedirectUri: "http://example.com/callback",
+		Scope:       []string{"openid"},
+		ExpiresAt:   past,
+	})
+	s.Require().NoError(err)
+
+	// Not expired, but consumed.
+	consumedCode := s.mustGenerateAlphanumericString(32)
+	err = s.datastore.Q.InsertAuthorizationCode(ctx, db.InsertAuthorizationCodeParams{
+		Code:        consumedCode,
+		UserID:      user.ID,
+		ClientID:    client.ID,
+		RedirectUri: "http://example.com/callback",
+		Scope:       []string{"openid"},
+		ExpiresAt:   future,
+	})
+	s.Require().NoError(err)
+	rows, err := s.datastore.Q.ConsumeAuthorizationCode(ctx, consumedCode)
+	s.Require().NoError(err)
+	s.Require().Equal(int64(1), rows)
+
+	// Fresh, unconsumed, not expired -- must survive.
+	freshCode := s.mustGenerateAlphanumericString(32)
+	err = s.datastore.Q.InsertAuthorizationCode(ctx, db.InsertAuthorizationCodeParams{
+		Code:        freshCode,
+		UserID:      user.ID,
+		ClientID:    client.ID,
+		RedirectUri: "http://example.com/callback",
+		Scope:       []string{"openid"},
+		ExpiresAt:   future,
+	})
+	s.Require().NoError(err)
+
+	s.assertRowCount("oauth_authorization_codes", "code = $1", expiredCode, 1)
+	s.assertRowCount("oauth_authorization_codes", "code = $1", consumedCode, 1)
+	s.assertRowCount("oauth_authorization_codes", "code = $1", freshCode, 1)
+
+	err = s.server.runExpiryCleanup(ctx)
+	s.NoError(err)
+
+	s.assertRowCount("oauth_authorization_codes", "code = $1", expiredCode, 0)
+	s.assertRowCount("oauth_authorization_codes", "code = $1", consumedCode, 0)
+	s.assertRowCount("oauth_authorization_codes", "code = $1", freshCode, 1)
+}
+
+// TestExpiryCleanup_DeletesDeadTokensOnly covers the oauth_tokens sweep
+// (DeleteDeadTokens), which is the most delicate one: each row holds both an access
+// token (expires_at) and a refresh token (refresh_expires_at, which is NULLable --
+// NULL means the refresh token never expires). This asserts the refresh-token caveat
+// is honored: a row is deleted only once it can never be used again (revoked, or both
+// the access and refresh tokens have expired); a row whose refresh token is still
+// valid, or non-expiring, must survive even though its access token has expired.
+func (s *OAuthFlowSuite) TestExpiryCleanup_DeletesDeadTokensOnly() {
+	ctx := s.T().Context()
+	user := s.mustRegisterUser(
+		s.mustGenerateAlphanumericString(10),
+		s.mustGenerateAlphanumericString(10),
+		s.mustGenerateAlphanumericString(10)+"@example.com",
+	)
+	client := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateAlphanumericString(12),
+		Name:           "cleanup-test-client",
+		RedirectUris:   []string{"http://example.com/callback"},
+		AllowedScopes:  []string{"openid"},
+		IsConfidential: false,
+		Audience:       "test-audience",
+	})
+	userID := uuid.NullUUID{UUID: user.ID, Valid: true}
+
+	past := time.Now().Add(-1 * time.Hour)
+	future := time.Now().Add(1 * time.Hour)
+
+	insert := func(refreshExpiresAt sql.NullTime) db.OauthToken {
+		tok, err := s.datastore.Q.InsertToken(ctx, db.InsertTokenParams{
+			AccessToken:      sql.NullString{String: s.mustGenerateAlphanumericString(32), Valid: true},
+			RefreshToken:     sql.NullString{String: s.mustGenerateAlphanumericString(32), Valid: true},
+			UserID:           userID,
+			ClientID:         client.ID,
+			Scope:            []string{"openid"},
+			ExpiresAt:        past,
+			RefreshExpiresAt: refreshExpiresAt,
+		})
+		s.Require().NoError(err)
+		return tok
+	}
+
+	// (a) Revoked -- must be deleted regardless of expiry.
+	revoked, err := s.datastore.Q.InsertToken(ctx, db.InsertTokenParams{
+		AccessToken:      sql.NullString{String: s.mustGenerateAlphanumericString(32), Valid: true},
+		RefreshToken:     sql.NullString{String: s.mustGenerateAlphanumericString(32), Valid: true},
+		UserID:           userID,
+		ClientID:         client.ID,
+		Scope:            []string{"openid"},
+		ExpiresAt:        future,
+		RefreshExpiresAt: sql.NullTime{Time: future, Valid: true},
+	})
+	s.Require().NoError(err)
+	err = s.datastore.Q.RevokeTokenByAccessToken(ctx, revoked.AccessToken)
+	s.Require().NoError(err)
+
+	// (b) Access expired AND refresh expired -- dead, must be deleted.
+	bothExpired := insert(sql.NullTime{Time: past, Valid: true})
+
+	// (c) Access expired but refresh still valid (future) -- must survive.
+	refreshStillValid := insert(sql.NullTime{Time: future, Valid: true})
+
+	// (d) Access expired but refresh_expires_at is NULL (non-expiring refresh),
+	// not revoked -- must survive.
+	refreshNonExpiring := insert(sql.NullTime{Valid: false})
+
+	// (e) Fully valid (access not expired either) -- must survive.
+	fullyValid, err := s.datastore.Q.InsertToken(ctx, db.InsertTokenParams{
+		AccessToken:      sql.NullString{String: s.mustGenerateAlphanumericString(32), Valid: true},
+		RefreshToken:     sql.NullString{String: s.mustGenerateAlphanumericString(32), Valid: true},
+		UserID:           userID,
+		ClientID:         client.ID,
+		Scope:            []string{"openid"},
+		ExpiresAt:        future,
+		RefreshExpiresAt: sql.NullTime{Time: future, Valid: true},
+	})
+	s.Require().NoError(err)
+
+	s.assertRowCount("oauth_tokens", "id = $1", revoked.ID, 1)
+	s.assertRowCount("oauth_tokens", "id = $1", bothExpired.ID, 1)
+	s.assertRowCount("oauth_tokens", "id = $1", refreshStillValid.ID, 1)
+	s.assertRowCount("oauth_tokens", "id = $1", refreshNonExpiring.ID, 1)
+	s.assertRowCount("oauth_tokens", "id = $1", fullyValid.ID, 1)
+
+	err = s.server.runExpiryCleanup(ctx)
+	s.NoError(err)
+
+	s.assertRowCount("oauth_tokens", "id = $1", revoked.ID, 0)
+	s.assertRowCount("oauth_tokens", "id = $1", bothExpired.ID, 0)
+	s.assertRowCount("oauth_tokens", "id = $1", refreshStillValid.ID, 1)
+	s.assertRowCount("oauth_tokens", "id = $1", refreshNonExpiring.ID, 1)
+	s.assertRowCount("oauth_tokens", "id = $1", fullyValid.ID, 1)
 }
 
 // assertRowCount asserts that exactly want rows in table match "WHERE " + whereClause


### PR DESCRIPTION
## Summary

The periodic cleanup worker (`runExpiryCleanup` in `pkg/httpserver/cleanup.go`) already swept four short-lived token tables, but deliberately left `auth_sessions`, `oauth_authorization_codes`, and `oauth_tokens` uncovered as a conscious follow-up. This PR covers them.

Three new sqlc `:exec` queries were added to `db/queries/auth.sql`:

- **`DeleteExpiredSessions`** — `DELETE FROM auth_sessions WHERE expires_at <= now()`. `GetSession` already filters `expires_at > now()`, so an expired session row is unreadable/dead the moment it expires — safe to delete outright.

- **`DeleteExpiredAuthorizationCodes`** — `DELETE FROM oauth_authorization_codes WHERE expires_at <= now() OR consumed_at IS NOT NULL`. Codes are single-use and short-lived; a consumed code can never be exchanged again (`ConsumeAuthorizationCode` atomically rejects replay), and an expired code can never be exchanged either — both conditions make a row permanently dead.

- **`DeleteDeadTokens`** (the delicate one) — `DELETE FROM oauth_tokens WHERE revoked_at IS NOT NULL OR (expires_at <= now() AND refresh_expires_at IS NOT NULL AND refresh_expires_at <= now())`. Each `oauth_tokens` row holds **both** an access token (`expires_at`) and a refresh token (`refresh_expires_at`, which is nullable — NULL means the refresh token never expires). A row must **not** be deleted just because its access token expired, since its refresh token may still be valid (or non-expiring) and able to mint new access tokens. It's only safe to delete once revoked, or once *both* the access token and the refresh token are expired.

In all three cases, no read query ever touches an expired/revoked/consumed row, so sweeping them causes no audit-trail loss — these rows are already permanently unusable before deletion.

## sqlc regeneration

`sqlc` isn't installed and `db/schema.sql` (sqlc's input) is gitignored and only produced locally via `make sqlc` against a live Postgres (`pg_dump --schema-only`), so it wasn't available here. Instead, the generated Go for the three new queries was **hand-written** into `pkg/db/auth.sql.go`, mirroring the existing generated `DeleteExpired*` methods exactly (same `const xSQL = ...` + `func (q *Queries) X(ctx context.Context) error` shape) and inserted at the alphabetical position sqlc's generator would produce them.

## Wiring

`runExpiryCleanup`'s `sweeps` slice now includes:
- `{"auth_sessions", s.datastore.Q.DeleteExpiredSessions}`
- `{"oauth_authorization_codes", s.datastore.Q.DeleteExpiredAuthorizationCodes}`
- `{"oauth_tokens", s.datastore.Q.DeleteDeadTokens}`

The doc comment was updated to list these three tables among those swept, and the old "deliberately NOT covered" deferral note was replaced with an explanation of the `oauth_tokens` refresh-token caveat (now that it's handled, not deferred).

## Tests

Extended `pkg/httpserver/cleanup_integration_test.go` (build tag `integration`, real Postgres via the shared `OAuthFlowSuite` testcontainer) with one test per new table:

- **`auth_sessions`**: an expired session is deleted; a session with a future `expires_at` survives.
- **`oauth_authorization_codes`**: an expired-unconsumed code and a consumed-not-expired code are both deleted; a fresh unconsumed non-expired code survives.
- **`oauth_tokens`** (the important one): a revoked token is deleted; an access-expired token whose refresh token is also expired is deleted; an access-expired token whose refresh token is still valid (future `refresh_expires_at`) survives; an access-expired token with `refresh_expires_at IS NULL` (non-expiring refresh), not revoked, survives; a fully-valid token survives. This is the survive/delete matrix that proves the refresh-token caveat is honored — the case most likely to hide a bug (over-deleting a token whose refresh side is still good).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags integration ./...` (new integration test cases compile)
- [x] `go test ./...` (non-integration suite passes)
- [ ] Integration suite (`go test -tags integration ./...`) — requires Postgres via testcontainers, not runnable in this sandbox; will run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE