### PR TITLE
Exempt static assets from the rate limiter

### DIFF
--- a/pkg/httpserver/ratelimit.go
+++ b/pkg/httpserver/ratelimit.go
@@ -3,6 +3,7 @@ package httpserver
 import (
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -123,10 +124,24 @@ func getClientIP(r *http.Request) string {
 	return host
 }
 
-// rateLimitMiddleware creates a middleware that enforces rate limiting
+// rateLimitMiddleware creates a middleware that enforces rate limiting.
+//
+// Requests under staticPathPrefix (see routes.go, which mounts the static
+// file server on that same constant) are exempt: a single page load pulls
+// the HTML plus several static assets (CSS, JS, images), so applying the
+// same per-IP budget meant to limit abuse of auth/API endpoints to static
+// assets too caused ordinary navigation to burn through the whole budget
+// and start getting 429'd. Static asset serving doesn't need per-IP abuse
+// protection the way endpoints like login/token do, so it simply bypasses
+// the limiter rather than consuming a request from it.
 func rateLimitMiddleware(store *rateLimitStore, requestsPerMinute int) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, staticPathPrefix) {
+				next.ServeHTTP(w, r)
+				return
+			}
+
 			ip := getClientIP(r)
 			limiter := store.getLimiter(ip, requestsPerMinute)
 

--- a/pkg/httpserver/ratelimit_test.go
+++ b/pkg/httpserver/ratelimit_test.go
@@ -145,6 +145,54 @@ func TestRateLimitMiddleware_SpoofedXFFSharesLimiter(t *testing.T) {
 	}
 }
 
+// TestRateLimitMiddleware_StaticAssetsExempt verifies that requests under
+// staticPathPrefix ("/static/...") bypass the limiter entirely - a burst of
+// requests to a static asset path must all succeed - while a request to a
+// normal route sharing the same limiter (requestsPerMinute=1) is still
+// throttled on the second attempt. This is the regression test for a single
+// page load (HTML + CSS/JS from /static) burning through the whole per-IP
+// budget and getting legitimate navigation 429'd.
+func TestRateLimitMiddleware_StaticAssetsExempt(t *testing.T) {
+	store := newRateLimitStore()
+	t.Cleanup(store.Stop)
+	handler := rateLimitMiddleware(store, 1)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	doStaticRequest := func(path string) int {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.RemoteAddr = "203.0.113.20:33333"
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	// A burst of requests to static asset paths must all succeed, even
+	// though requestsPerMinute is 1 and they share a RemoteAddr/IP.
+	for i, path := range []string{"/static/css/main.css", "/static/js/app.js", "/static/img/logo.png"} {
+		if code := doStaticRequest(path); code != http.StatusOK {
+			t.Fatalf("static request %d (%s): got status %d, want %d", i, path, code, http.StatusOK)
+		}
+	}
+
+	// The same IP hitting a normal (non-static) route is still limited:
+	// first request succeeds, second is rejected.
+	if code := doRateLimitedRequest(handler, "203.0.113.20:33333", nil); code != http.StatusOK {
+		t.Fatalf("first non-static request: got status %d, want %d", code, http.StatusOK)
+	}
+	if code := doRateLimitedRequest(handler, "203.0.113.20:33333", nil); code != http.StatusTooManyRequests {
+		t.Fatalf("second non-static request: got status %d, want %d", code, http.StatusTooManyRequests)
+	}
+
+	// Only the non-static route should have consumed a limiter bucket.
+	store.mu.RLock()
+	numLimiters := len(store.limiters)
+	store.mu.RUnlock()
+	if numLimiters != 1 {
+		t.Errorf("expected exactly 1 rate limiter bucket (static requests shouldn't create one), got %d", numLimiters)
+	}
+}
+
 // TestRateLimitMiddleware_CFConnectingIPIsTheKey verifies that behind the
 // Cloudflare Tunnel (where all requests share the cloudflared connector's
 // RemoteAddr) the limiter is keyed on CF-Connecting-IP: requests with the

--- a/pkg/httpserver/routes.go
+++ b/pkg/httpserver/routes.go
@@ -35,14 +35,26 @@ var corsMiddleware = newCorsMiddleware("GET, OPTIONS", "Content-Type")
 // oauthCorsMiddleware allows GET/POST requests with Authorization headers from any origin.
 var oauthCorsMiddleware = newCorsMiddleware("GET, POST, OPTIONS", "Content-Type, Authorization")
 
+// staticPathPrefix is the URL path prefix under which static assets (CSS,
+// JS, images) are served. It's a package-level constant, rather than a
+// literal duplicated in two places, so that rateLimitMiddleware (see
+// ratelimit.go) can exempt static-asset requests from per-IP rate limiting
+// using the exact same prefix the static file server is mounted on below -
+// keeping the mount point and the exemption from silently drifting apart.
+const staticPathPrefix = "/static/"
+
 // registerRoutes registers all routes on the given router.
 func (s *Server) registerRoutes() {
 	// Root redirect - sends to login or account settings based on auth status
 	s.router.Get("/", s.HandleRoot)
 
-	// Static files (CSS, JS, images)
+	// Static files (CSS, JS, images). Exempt from rateLimitMiddleware (see
+	// staticPathPrefix above and the exemption check in ratelimit.go): a
+	// single page load pulls the HTML plus several static assets, and the
+	// per-IP budget is meant to limit abuse of auth/API endpoints, not
+	// ordinary asset fetches.
 	fileServer := http.FileServer(http.Dir("static"))
-	s.router.Handle("/static/*", http.StripPrefix("/static/", fileServer))
+	s.router.Handle(staticPathPrefix+"*", http.StripPrefix(staticPathPrefix, fileServer))
 
 	// Health check with CORS enabled for all origins (safe - no sensitive data)
 	s.router.With(corsMiddleware).Get("/health", s.HandleHealthCheck)


### PR DESCRIPTION
## Problem

The global rate limiter (`rateLimitMiddleware`, 20 requests/min/IP, applied via a single `r.Use(...)` in `server.go`) covers every route, including static asset serving mounted at `/static/*` in `routes.go`. A single page load pulls the HTML plus CSS/JS (and possibly more) from `/static`, so a couple of page loads from one IP can burn through the whole 20/min budget and start getting legitimate navigation 429'd. Static assets don't need per-IP abuse protection the way auth endpoints (login, token, etc.) do.

## Approach (Option B)

`rateLimitMiddleware` (in `pkg/httpserver/ratelimit.go`) now skips the limiter entirely for requests whose path is under a shared `staticPathPrefix` constant ("/static/") - it calls `next.ServeHTTP` directly without touching the limiter store. `staticPathPrefix` is defined once in `pkg/httpserver/routes.go`, where the static file server is mounted, and referenced from `ratelimit.go`, so the mount point and the exemption can't drift apart.

I picked Option B (skip-in-middleware) over Option A (mounting static on a separate router outside the middleware's scope) because the whole middleware stack (RequestID, security headers, request logging, Recoverer, timeout, then rate limiting) is registered as a single `r.Use(...)` chain in `server.go` before any routes are registered. Carving static out from just the rate limiter while still keeping security headers/logging/recoverer/timeout applied to it would require restructuring that shared chain; a targeted path check inside `rateLimitMiddleware` achieves the same result with a much smaller, more obviously-correct diff.

All other routes keep the exact same limit (20/min) and the exact same per-IP keying via `getClientIP` (unchanged) - only requests under `/static/` now bypass the limiter.

## Follow-up considered, not implemented

The review that flagged this also noted the single global 20/min bucket covers everything (auth endpoints and everything else). A tighter, separate limit for auth endpoints could be worth adding, but it's out of scope here to keep this change small and reviewable - noting it as a possible follow-up.

## Testing

- `go build ./...` - passes
- `go vet ./...` - passes
- `go vet -tags integration ./...` - passes (compiles)
- `go test ./...` - all passing
- Added `TestRateLimitMiddleware_StaticAssetsExempt` in `pkg/httpserver/ratelimit_test.go`: a burst of requests to `/static/...` paths from the same IP all succeed even with `requestsPerMinute=1`, while a request to a normal route sharing the same limiter is still throttled on the second attempt, and only the non-static request creates a limiter bucket.
- Confirmed no integration tests reference `/static` directly, and existing rate-limit tests (`TestRateLimitMiddleware_SpoofedXFFSharesLimiter`, `TestRateLimitMiddleware_CFConnectingIPIsTheKey`) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE