### PR TITLE
Fix: mask account existence in password-reset/username-recovery flows

### DIFF
--- a/pkg/httpserver/password_reset.go
+++ b/pkg/httpserver/password_reset.go
@@ -1,6 +1,7 @@
 package httpserver
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -17,6 +18,12 @@ import (
 const (
 	passwordResetTokenTTL = 1 * time.Hour
 	passwordResetTokenLen = 32 // bytes
+
+	// asyncMailWorkTimeout bounds the background token-generation/store/email-send
+	// work kicked off by HandleForgotPasswordPost and HandleForgotUsernamePost. It
+	// must be independent of the request context, which is cancelled the moment the
+	// handler returns the unified response to the client.
+	asyncMailWorkTimeout = 30 * time.Second
 )
 
 // generateResetToken generates a cryptographically secure random token
@@ -81,7 +88,11 @@ func (s *Server) HandleForgotPasswordPost(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Always show success message to prevent email enumeration
+	// Always show success message to prevent email enumeration. This response
+	// must be returned identically (same status, same body, roughly the same
+	// latency) whether or not an account exists for emailAddr - see the
+	// goroutine dispatch below for why the account-exists case doesn't do any
+	// of its work inline.
 	successMsg := "If an account with that email exists, we've sent a password reset link."
 
 	// Look up user by email
@@ -95,34 +106,59 @@ func (s *Server) HandleForgotPasswordPost(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// The account exists. Generating the token, storing its hash, and sending
+	// the email are all deferred to a background goroutine so that this
+	// request returns the same unified response at the same latency as the
+	// "account not found" branch above - doing this work inline would let an
+	// attacker distinguish existing from non-existing accounts purely by
+	// response time, and any failure here would otherwise have to surface as
+	// a distinct error response, leaking existence a second way.
+	//
+	// The goroutine must not use r.Context(): that context is cancelled as
+	// soon as this handler returns, which happens immediately after this
+	// point, and would abort the DB write / email send mid-flight. Instead it
+	// gets its own detached context with a bounded timeout. Only plain values
+	// (userID, username, emailAddr, issuer) are captured, not any
+	// request-scoped mutable state.
+	go s.sendPasswordResetEmailAsync(user.ID, emailAddr)
+
+	s.renderForgotPassword(w, r, ForgotPasswordPageData{
+		Success: successMsg,
+	})
+}
+
+// sendPasswordResetEmailAsync generates a password reset token, stores its
+// hash, and emails the reset link. It runs in a background goroutine kicked
+// off by HandleForgotPasswordPost after the HTTP response has already been
+// sent, so it uses its own detached, timeout-bounded context rather than the
+// (by-then-cancelled) request context. Any failure is logged server-side
+// only: by design, nothing here can change what the client already saw.
+func (s *Server) sendPasswordResetEmailAsync(userID uuid.UUID, emailAddr string) {
+	ctx, cancel := context.WithTimeout(context.Background(), asyncMailWorkTimeout)
+	defer cancel()
+
 	// Generate token
 	rawToken, tokenHash, err := generateResetToken()
 	if err != nil {
-		log.Printf("[ERROR] HandleForgotPasswordPost: Failed to generate token: %v", err)
-		s.renderForgotPassword(w, r, ForgotPasswordPageData{
-			Error: "An error occurred. Please try again.",
-		})
+		log.Printf("[ERROR] HandleForgotPasswordPost: Failed to generate token for %s: %v", emailAddr, err)
 		return
 	}
 
 	// Store token hash in database
 	expiresAt := time.Now().Add(passwordResetTokenTTL)
-	err = s.datastore.Q.CreatePasswordResetToken(r.Context(), db.CreatePasswordResetTokenParams{
-		UserID:    user.ID,
+	err = s.datastore.Q.CreatePasswordResetToken(ctx, db.CreatePasswordResetTokenParams{
+		UserID:    userID,
 		TokenHash: tokenHash,
 		ExpiresAt: expiresAt,
 	})
 	if err != nil {
-		log.Printf("[ERROR] HandleForgotPasswordPost: Failed to store token: %v", err)
-		s.renderForgotPassword(w, r, ForgotPasswordPageData{
-			Error: "An error occurred. Please try again.",
-		})
+		log.Printf("[ERROR] HandleForgotPasswordPost: Failed to store token for %s: %v", emailAddr, err)
 		return
 	}
 
 	// Send password reset email
 	resetURL := fmt.Sprintf("%s/oauth/reset-password?token=%s", s.config.JWTIssuer, rawToken)
-	err = s.emailSender.Send(r.Context(), email.Message{
+	err = s.emailSender.Send(ctx, email.Message{
 		To:      emailAddr,
 		Subject: "Reset Your Password",
 		HTML: fmt.Sprintf(`
@@ -145,14 +181,11 @@ If you didn't request this, you can safely ignore this email.
 		`, resetURL),
 	})
 	if err != nil {
-		log.Printf("[ERROR] HandleForgotPasswordPost: Failed to send email: %v", err)
-		// Still show success to prevent enumeration, but log the error
+		log.Printf("[ERROR] HandleForgotPasswordPost: Failed to send email to %s: %v", emailAddr, err)
+		return
 	}
 
 	s.debugf("HandleForgotPasswordPost: Password reset email sent to %s", emailAddr)
-	s.renderForgotPassword(w, r, ForgotPasswordPageData{
-		Success: successMsg,
-	})
 }
 
 // HandleResetPasswordGet godoc
@@ -362,7 +395,9 @@ func (s *Server) HandleForgotUsernamePost(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Always show success message to prevent email enumeration
+	// Always show success message to prevent email enumeration. As with
+	// HandleForgotPasswordPost, this response must look and take the same
+	// time whether or not the account exists.
 	successMsg := "If an account with that email exists, we've sent your username."
 
 	// Look up user by email
@@ -376,8 +411,29 @@ func (s *Server) HandleForgotUsernamePost(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Send username reminder email
-	err = s.emailSender.Send(r.Context(), email.Message{
+	// Send the username reminder in the background for the same reason
+	// HandleForgotPasswordPost defers its email send: keep the response
+	// timing and content identical to the account-not-found case, and never
+	// let an email-send failure surface as a different HTTP response. Uses a
+	// detached context since r.Context() is cancelled once this handler
+	// returns (which happens right after this call).
+	go s.sendUsernameReminderEmailAsync(user.Username, emailAddr)
+
+	s.renderForgotUsername(w, r, ForgotPasswordPageData{
+		Success: successMsg,
+	})
+}
+
+// sendUsernameReminderEmailAsync emails the username reminder. It runs in a
+// background goroutine kicked off by HandleForgotUsernamePost after the HTTP
+// response has already been sent, so it uses its own detached,
+// timeout-bounded context rather than the (by-then-cancelled) request
+// context. Failures are logged server-side only.
+func (s *Server) sendUsernameReminderEmailAsync(username, emailAddr string) {
+	ctx, cancel := context.WithTimeout(context.Background(), asyncMailWorkTimeout)
+	defer cancel()
+
+	err := s.emailSender.Send(ctx, email.Message{
 		To:      emailAddr,
 		Subject: "Your Username Reminder",
 		HTML: fmt.Sprintf(`
@@ -385,7 +441,7 @@ func (s *Server) HandleForgotUsernamePost(w http.ResponseWriter, r *http.Request
 			<p>You requested a reminder of your username for your account.</p>
 			<p>Your username is: <strong>%s</strong></p>
 			<p>If you didn't request this, you can safely ignore this email.</p>
-		`, user.Username),
+		`, username),
 		Text: fmt.Sprintf(`
 Username Reminder
 
@@ -394,15 +450,12 @@ You requested a reminder of your username for your account.
 Your username is: %s
 
 If you didn't request this, you can safely ignore this email.
-		`, user.Username),
+		`, username),
 	})
 	if err != nil {
-		log.Printf("[ERROR] HandleForgotUsernamePost: Failed to send email: %v", err)
-		// Still show success to prevent enumeration, but log the error
+		log.Printf("[ERROR] HandleForgotUsernamePost: Failed to send email to %s: %v", emailAddr, err)
+		return
 	}
 
 	s.debugf("HandleForgotUsernamePost: Username reminder email sent to %s", emailAddr)
-	s.renderForgotUsername(w, r, ForgotPasswordPageData{
-		Success: successMsg,
-	})
 }

--- a/pkg/httpserver/password_reset_flow_test.go
+++ b/pkg/httpserver/password_reset_flow_test.go
@@ -93,17 +93,23 @@ func (s *OAuthFlowSuite) TestPasswordResetFlow() {
 	defer resp.Body.Close()
 	s.Equal(http.StatusOK, resp.StatusCode)
 
-	// Get the token from the database (in real scenario, user would get it from email)
-	tokens, err := s.datastore.DB.QueryContext(s.T().Context(),
-		"SELECT token_hash FROM auth_email_tokens WHERE user_id = $1 AND token_type = 'password_reset' ORDER BY created_at DESC LIMIT 1",
-		user.ID)
-	s.Require().NoError(err)
-	defer tokens.Close()
-
-	s.True(tokens.Next(), "should have a password reset token")
+	// HandleForgotPasswordPost now dispatches token generation, storage, and
+	// email-send to a background goroutine so that the HTTP response (above)
+	// returns at the same latency regardless of whether the account exists -
+	// this closes a timing side-channel that used to leak account existence.
+	// That means the token row is not guaranteed to exist the instant the
+	// response comes back, so poll for it briefly instead of asserting it's
+	// there on the first read. In steady state the goroutine finishes in
+	// microseconds (local Postgres, no real network call in tests), so this
+	// polls a handful of times at most; the 5s ceiling is just a generous
+	// backstop against CI slowness, not the expected wait.
 	var storedHash string
-	err = tokens.Scan(&storedHash)
-	s.Require().NoError(err)
+	s.Require().Eventually(func() bool {
+		row := s.datastore.DB.QueryRowContext(s.T().Context(),
+			"SELECT token_hash FROM auth_email_tokens WHERE user_id = $1 AND token_type = 'password_reset' ORDER BY created_at DESC LIMIT 1",
+			user.ID)
+		return row.Scan(&storedHash) == nil
+	}, 5*time.Second, 20*time.Millisecond, "password reset token should eventually be created by the background goroutine")
 
 	// Generate a token that hashes to the stored hash (we need the raw token)
 	// Since we can't reverse the hash, we'll create a new token for testing


### PR DESCRIPTION
## Summary

`HandleForgotPasswordPost` and `HandleForgotUsernamePost` already returned a
unified "if an account exists, we've sent..." message regardless of
whether the account existed, but two side channels still leaked account
existence:

1. **Timing leak.** For an existing account, the handler synchronously
   generated a reset token, hashed and stored it in the DB, and sent an
   email — all before responding. For a non-existing account it returned
   immediately. The measurable latency difference reveals whether the
   account exists.
2. **Error-path leak.** The token-generation / DB-store / email-send
   failure branches rendered a distinct error response. Those branches are
   only reachable when the account exists (a non-existing account
   short-circuits before them), so an internal error doubled as an
   existence oracle — and more importantly, existing vs. non-existing
   accounts could produce visibly different responses.

## Fix

After the account lookup confirms the account exists, token generation +
storage + email-send are deferred to a background goroutine
(`sendPasswordResetEmailAsync` / `sendUsernameReminderEmailAsync`), and the
handler always renders the *same* unified success response immediately,
whether or not the account exists. Failures inside the goroutine are
logged at `[ERROR]` server-side but never change what the client already
received — there's no error branch left in the request path for the
account-exists case.

Genuine input-validation errors (empty email field) are untouched — they
don't depend on account existence and still render their normal validation
message before any lookup happens.

**Detached context.** The goroutine cannot use `r.Context()`: that context
is cancelled the moment the handler returns, which now happens immediately
after dispatching the goroutine. Using it would abort the DB write /
email send mid-flight. Instead each goroutine builds its own
`context.Background()` wrapped in a bounded timeout
(`asyncMailWorkTimeout`, 30s) so the work can finish even after the HTTP
response is gone. Only plain values (user ID, username, email address) are
captured by the goroutine closure — no request-scoped mutable state.

Token format, hashing, expiry, single-use semantics, and email contents
are unchanged — only *when* the work runs and how failures map to the
response changed.

Both `HandleForgotPasswordPost` and `HandleForgotUsernamePost` got the
identical treatment since they had the identical leak.

## Integration test fix (avoiding flakiness)

`TestPasswordResetFlow` (Postgres, `//go:build integration`) POSTs
forgot-password, then immediately queried `auth_email_tokens` expecting a
row to already exist. With token creation now happening in a background
goroutine, that read could run before the write lands — a race, not
present when everything was synchronous.

Changed the assertion to poll with `s.Require().Eventually(...)` (5s
ceiling, 20ms tick) instead of asserting presence on the first read. In
steady state the goroutine finishes in microseconds against a local test
Postgres, so this polls only a handful of times in practice; the 5s
ceiling is a generous backstop against CI slowness, not the expected wait.
This makes the test deterministic (it always converges once the async
write lands) without reintroducing synchronous coupling to the handler.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go vet -tags integration ./...` (compiles)
- [x] `go test ./...` (all packages pass)
- [x] `go test -race ./pkg/httpserver/...` (no data races)
- [ ] Integration suite (`password_reset_flow_test.go`, requires Postgres) — not run here (no local Postgres in this environment); reasoned through manually and updated per above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE