### PR TITLE
Housekeeping: UTC admin timestamps, drop unused config, CLI returns errors

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -2,7 +2,6 @@
 # Copy this to .env.dev and fill in your values
 
 # Database connection
-ADMIN_DATABASE_URL="postgresql://..."
 DATABASE_URL="postgresql://..."
 
 # Server configuration

--- a/cmd/identity-cli/cmd/client_create.go
+++ b/cmd/identity-cli/cmd/client_create.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/eswan18/identity/cmd/identity-cli/internal"
@@ -53,14 +52,11 @@ func runClientCreate(cmd *cobra.Command, args []string) error {
 
 	// Get shared datastore
 	datastore := getDatastore()
-	if datastore == nil {
-		log.Fatal("Failed to get database connection")
-	}
 
 	// Generate client_id (random 32-byte string, base64 encoded = 44 chars)
 	clientID, err := internal.GenerateRandomString(32)
 	if err != nil {
-		log.Fatalf("Failed to generate client_id: %v", err)
+		return fmt.Errorf("failed to generate client_id: %w", err)
 	}
 
 	// Generate client_secret if confidential. The plaintext is shown to the
@@ -71,7 +67,7 @@ func runClientCreate(cmd *cobra.Command, args []string) error {
 	if createIsConfidential {
 		secret, err := internal.GenerateRandomString(32)
 		if err != nil {
-			log.Fatalf("Failed to generate client_secret: %v", err)
+			return fmt.Errorf("failed to generate client_secret: %w", err)
 		}
 		plaintextSecret = secret
 		clientSecret = sql.NullString{String: auth.HashClientSecret(secret), Valid: true}
@@ -89,7 +85,7 @@ func runClientCreate(cmd *cobra.Command, args []string) error {
 		Audience:       createAudience,
 	})
 	if err != nil {
-		log.Fatalf("Failed to create OAuth client: %v", err)
+		return fmt.Errorf("failed to create OAuth client: %w", err)
 	}
 
 	// Output credentials

--- a/cmd/identity-cli/cmd/client_delete.go
+++ b/cmd/identity-cli/cmd/client_delete.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -36,16 +35,13 @@ func runClientDelete(cmd *cobra.Command, args []string) error {
 	clientID := args[0]
 
 	datastore := getDatastore()
-	if datastore == nil {
-		log.Fatal("Failed to get database connection")
-	}
 
 	ctx := context.Background()
 
 	// Get client to show what we're deleting
 	client, err := datastore.Q.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
-		log.Fatalf("Failed to get OAuth client: %v", err)
+		return fmt.Errorf("failed to get OAuth client: %w", err)
 	}
 
 	// Confirm deletion unless --force
@@ -54,7 +50,7 @@ func runClientDelete(cmd *cobra.Command, args []string) error {
 		reader := bufio.NewReader(os.Stdin)
 		response, err := reader.ReadString('\n')
 		if err != nil {
-			log.Fatalf("Failed to read input: %v", err)
+			return fmt.Errorf("failed to read input: %w", err)
 		}
 		response = strings.TrimSpace(strings.ToLower(response))
 		if response != "y" && response != "yes" {
@@ -66,7 +62,7 @@ func runClientDelete(cmd *cobra.Command, args []string) error {
 	// Delete the client
 	err = datastore.Q.DeleteOAuthClient(ctx, clientID)
 	if err != nil {
-		log.Fatalf("Failed to delete OAuth client: %v", err)
+		return fmt.Errorf("failed to delete OAuth client: %w", err)
 	}
 
 	fmt.Printf("\n✅ OAuth client '%s' (%s) deleted successfully!\n\n", client.Name, clientID)

--- a/cmd/identity-cli/cmd/client_get.go
+++ b/cmd/identity-cli/cmd/client_get.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -21,14 +20,11 @@ func runClientGet(cmd *cobra.Command, args []string) error {
 	clientID := args[0]
 
 	datastore := getDatastore()
-	if datastore == nil {
-		log.Fatal("Failed to get database connection")
-	}
 
 	ctx := context.Background()
 	client, err := datastore.Q.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
-		log.Fatalf("Failed to get OAuth client: %v", err)
+		return fmt.Errorf("failed to get OAuth client: %w", err)
 	}
 
 	fmt.Println("\nClient Details:")

--- a/cmd/identity-cli/cmd/client_list.go
+++ b/cmd/identity-cli/cmd/client_list.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"text/tabwriter"
 
@@ -19,14 +18,11 @@ var clientListCmd = &cobra.Command{
 
 func runClientList(cmd *cobra.Command, args []string) error {
 	datastore := getDatastore()
-	if datastore == nil {
-		log.Fatal("Failed to get database connection")
-	}
 
 	ctx := context.Background()
 	clients, err := datastore.Q.ListOAuthClients(ctx)
 	if err != nil {
-		log.Fatalf("Failed to list OAuth clients: %v", err)
+		return fmt.Errorf("failed to list OAuth clients: %w", err)
 	}
 
 	if len(clients) == 0 {

--- a/cmd/identity-cli/cmd/client_update.go
+++ b/cmd/identity-cli/cmd/client_update.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/eswan18/identity/cmd/identity-cli/internal"
@@ -57,16 +57,13 @@ func runClientUpdate(cmd *cobra.Command, args []string) error {
 	clientID := args[0]
 
 	datastore := getDatastore()
-	if datastore == nil {
-		log.Fatal("Failed to get database connection")
-	}
 
 	ctx := context.Background()
 
 	// Get current client to preserve values
 	currentClient, err := datastore.Q.GetOAuthClientByClientID(ctx, clientID)
 	if err != nil {
-		log.Fatalf("Failed to get OAuth client: %v", err)
+		return fmt.Errorf("failed to get OAuth client: %w", err)
 	}
 
 	// Build update params - only include fields that were provided
@@ -121,12 +118,12 @@ func runClientUpdate(cmd *cobra.Command, args []string) error {
 	if params.IsConfidential.Bool && !currentClient.ClientSecret.Valid {
 		// Note: We can't update the secret with the current UpdateOAuthClient query
 		// This would require a separate query or updating the SQL
-		log.Fatalf("Cannot make a public client confidential - secret generation not yet supported in update")
+		return errors.New("cannot make a public client confidential - secret generation not yet supported in update")
 	}
 
 	updatedClient, err := datastore.Q.UpdateOAuthClient(ctx, params)
 	if err != nil {
-		log.Fatalf("Failed to update OAuth client: %v", err)
+		return fmt.Errorf("failed to update OAuth client: %w", err)
 	}
 
 	fmt.Println("\n✅ OAuth client updated successfully!")

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -81,7 +81,7 @@ kubectl get pods -n identity-prod -o jsonpath='{.items[0].spec.containers[0].ima
 - DATABASE_URL
 - JWT_PRIVATE_KEY
 - RESEND_API_KEY
-- STORAGE_ACCESS_KEY, STORAGE_SECRET_KEY, STORAGE_TOKEN
+- STORAGE_ACCESS_KEY, STORAGE_SECRET_KEY
 
 ## Secrets Management
 

--- a/k8s/prod/deployment-patch.yaml
+++ b/k8s/prod/deployment-patch.yaml
@@ -39,11 +39,6 @@ spec:
                 secretKeyRef:
                   name: identity-prod-secrets
                   key: STORAGE_SECRET_KEY
-            - name: STORAGE_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: identity-prod-secrets
-                  key: STORAGE_TOKEN
       volumes:
         - name: secrets-store
           csi:

--- a/k8s/prod/secret-provider-class.yaml
+++ b/k8s/prod/secret-provider-class.yaml
@@ -17,8 +17,6 @@ spec:
         path: "STORAGE_ACCESS_KEY"
       - resourceName: "projects/ethans-services/secrets/identity_prod_storage_secret_key/versions/latest"
         path: "STORAGE_SECRET_KEY"
-      - resourceName: "projects/ethans-services/secrets/identity_prod_storage_token/versions/latest"
-        path: "STORAGE_TOKEN"
   secretObjects:
     - secretName: identity-prod-secrets
       type: Opaque
@@ -33,5 +31,3 @@ spec:
           key: STORAGE_ACCESS_KEY
         - objectName: "STORAGE_SECRET_KEY"
           key: STORAGE_SECRET_KEY
-        - objectName: "STORAGE_TOKEN"
-          key: STORAGE_TOKEN

--- a/k8s/staging/deployment-patch.yaml
+++ b/k8s/staging/deployment-patch.yaml
@@ -40,11 +40,6 @@ spec:
                 secretKeyRef:
                   name: identity-staging-secrets
                   key: STORAGE_SECRET_KEY
-            - name: STORAGE_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: identity-staging-secrets
-                  key: STORAGE_TOKEN
       volumes:
         - name: secrets-store
           csi:

--- a/k8s/staging/secret-provider-class.yaml
+++ b/k8s/staging/secret-provider-class.yaml
@@ -16,8 +16,6 @@ spec:
         path: "STORAGE_ACCESS_KEY"
       - resourceName: "projects/ethans-services/secrets/identity_staging_storage_secret_key/versions/latest"
         path: "STORAGE_SECRET_KEY"
-      - resourceName: "projects/ethans-services/secrets/identity_staging_storage_token/versions/latest"
-        path: "STORAGE_TOKEN"
   secretObjects:
     - secretName: identity-staging-secrets
       type: Opaque
@@ -32,5 +30,3 @@ spec:
           key: STORAGE_ACCESS_KEY
         - objectName: "STORAGE_SECRET_KEY"
           key: STORAGE_SECRET_KEY
-        - objectName: "STORAGE_TOKEN"
-          key: STORAGE_TOKEN

--- a/pkg/httpserver/admin.go
+++ b/pkg/httpserver/admin.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/eswan18/identity/pkg/auth"
 	"github.com/eswan18/identity/pkg/db"
@@ -145,7 +146,7 @@ func (s *Server) HandleAdminCreateUser(w http.ResponseWriter, r *http.Request) {
 		Email:         user.Email,
 		IsActive:      user.IsActive,
 		EmailVerified: user.EmailVerified,
-		CreatedAt:     user.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		CreatedAt:     user.CreatedAt.UTC().Format(time.RFC3339),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -214,8 +215,8 @@ func (s *Server) HandleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 			IsActive:      user.IsActive,
 			EmailVerified: user.EmailVerified,
 			MFAEnabled:    user.MfaEnabled,
-			CreatedAt:     user.CreatedAt.Format("2006-01-02T15:04:05Z"),
-			UpdatedAt:     user.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+			CreatedAt:     user.CreatedAt.UTC().Format(time.RFC3339),
+			UpdatedAt:     user.UpdatedAt.UTC().Format(time.RFC3339),
 		}
 	}
 


### PR DESCRIPTION
Three small, independent housekeeping cleanups:

1. **Admin timestamps: force UTC** — `pkg/httpserver/admin.go` formatted `CreatedAt`/`UpdatedAt` with the literal layout `"2006-01-02T15:04:05Z"`, which stamps a `Z` (UTC) suffix onto a `time.Time` without actually converting it to UTC. If the DB driver returns a non-UTC time, the response claims UTC but shows local wall-clock. Switched every occurrence to `.UTC().Format(time.RFC3339)`.

2. **Remove unused `STORAGE_TOKEN` / `ADMIN_DATABASE_URL` config** — neither is read by any Go code (verified via `grep -rn 'STORAGE_TOKEN\|ADMIN_DATABASE_URL' pkg/ cmd/`, no hits). Removed the `STORAGE_TOKEN` env var / secret entries from the k8s manifests and the `ADMIN_DATABASE_URL` line from `.env.dev.example`.
   - **Touches the k8s prod and staging manifests** (`k8s/prod/deployment-patch.yaml`, `k8s/prod/secret-provider-class.yaml`, `k8s/staging/deployment-patch.yaml`, `k8s/staging/secret-provider-class.yaml`, `k8s/README.md`): removes an unused secret mount. No runtime impact since nothing reads `STORAGE_TOKEN`.

3. **CLI: return errors instead of `log.Fatalf`** — in `cmd/identity-cli/cmd/`, `log.Fatalf`/`log.Fatal` inside cobra `RunE` functions call `os.Exit(1)` directly, bypassing cobra's error handling and skipping `PersistentPostRunE` cleanup (closing the DB connection). Converted all ~16 call sites across `client_create.go`, `client_delete.go`, `client_get.go`, `client_list.go`, and `client_update.go` to `return fmt.Errorf(..., %w, err)` (or `errors.New` for the one non-formatted message). Also removed the `datastore == nil` guards that followed `getDatastore()`, since `PersistentPreRunE` already returns an error before `RunE` runs if the datastore connection fails, making those checks dead code. Removed the now-unused `log` imports.

## Testing
- `go build ./...`
- `go vet ./...`
- `go vet -tags integration ./...`
- `go build ./cmd/identity-cli/...`
- `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE