### PR TITLE
Fix OAuth/OIDC spec nits: conditional exp/state, WWW-Authenticate on UserInfo 401

### DIFF
--- a/pkg/httpserver/authorize_consent_test.go
+++ b/pkg/httpserver/authorize_consent_test.go
@@ -105,6 +105,44 @@ func (s *OAuthFlowSuite) TestAuthorizeInvalidScopeRedirectsErrorToClient() {
 	s.Equal(scv.State, location.Query().Get("state"))
 }
 
+// TestAuthorizeErrorRedirectOmitsStateWhenNotSupplied is a regression test for
+// RFC 6749 §4.1.2.1: state is only returned to the client if it was present in
+// the authorization request. Previously the authorize error redirect always set
+// "state" (even to an empty string) via q.Set("state", state), which produced a
+// bogus "state=" in the redirect URL when the client never sent one.
+func (s *OAuthFlowSuite) TestAuthorizeErrorRedirectOmitsStateWhenNotSupplied() {
+	httpClient, client := s.mustLoginAndGetAuthorizeClient(db.CreateOAuthClientParams{
+		ClientID:       "authz-error-no-state-client",
+		Name:           "Authz Error No State Client",
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"openid"},
+		IsConfidential: false,
+		Audience:       "test-audience",
+	})
+	scv := s.mustCreateStateAndCodeVerifier()
+
+	// Request a scope the client doesn't support, without sending "state" at all.
+	query := url.Values{
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {"http://localhost:8080/callback"},
+		"response_type":         {"code"},
+		"scope":                 {"openid admin:users:read"},
+		"code_challenge":        {scv.CodeChallenge},
+		"code_challenge_method": {scv.CodeChallengeMethod},
+	}
+	resp, err := httpClient.Get("http://localhost:8080/oauth/authorize?" + query.Encode())
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Equal(http.StatusFound, resp.StatusCode)
+	location, err := url.Parse(resp.Header.Get("Location"))
+	s.Require().NoError(err)
+	s.Equal("/callback", location.Path)
+	s.Equal("invalid_scope", location.Query().Get("error"))
+	_, hasState := location.Query()["state"]
+	s.False(hasState, "state must be omitted from the redirect when the client did not supply it, got query %q", location.RawQuery)
+}
+
 func (s *OAuthFlowSuite) TestAuthorizeMissingPKCERedirectsErrorToClient() {
 	httpClient, client := s.mustLoginAndGetAuthorizeClient(db.CreateOAuthClientParams{
 		ClientID:       "authz-error-pkce-client",
@@ -290,6 +328,44 @@ func (s *OAuthFlowSuite) TestConsentApproveGeneratesCode() {
 	s.Equal("/callback", location.Path)
 	s.NotEmpty(location.Query().Get("code"), "should have authorization code")
 	s.Equal(scv.State, location.Query().Get("state"))
+}
+
+// TestConsentApproveOmitsStateWhenNotSupplied is a regression test for RFC 6749
+// §4.1.2: the successful authorization-code redirect must only include "state"
+// if the client's original request included it. Previously the consent-approve
+// redirect always set "state" (even to an empty string) via
+// q.Set("state", state), producing a bogus "state=" when the client never sent one.
+func (s *OAuthFlowSuite) TestConsentApproveOmitsStateWhenNotSupplied() {
+	httpClient, client := s.mustLoginAndGetAuthorizeClient(db.CreateOAuthClientParams{
+		ClientID:       "consent-approve-no-state-client",
+		Name:           "Consent Approve No State App",
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"openid", "profile", "email"},
+		IsConfidential: false,
+		Audience:       "test-audience",
+	})
+	scv := s.mustCreateStateAndCodeVerifier()
+
+	// POST consent approval without a "state" field at all.
+	resp, err := csrfPostFormLogin(s.T(), httpClient, "http://localhost:8080/oauth/consent", url.Values{
+		"decision":              {"allow"},
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {"http://localhost:8080/callback"},
+		"response_type":         {"code"},
+		"scope":                 {"openid profile email"},
+		"code_challenge":        {scv.CodeChallenge},
+		"code_challenge_method": {scv.CodeChallengeMethod},
+	})
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	s.Equal(http.StatusFound, resp.StatusCode)
+	location, err := url.Parse(resp.Header.Get("Location"))
+	s.Require().NoError(err)
+	s.Equal("/callback", location.Path)
+	s.NotEmpty(location.Query().Get("code"), "should have authorization code")
+	_, hasState := location.Query()["state"]
+	s.False(hasState, "state must be omitted from the redirect when the client did not supply it, got query %q", location.RawQuery)
 }
 
 func (s *OAuthFlowSuite) TestConsentDenyRedirectsWithError() {

--- a/pkg/httpserver/introspection_revocation_test.go
+++ b/pkg/httpserver/introspection_revocation_test.go
@@ -9,8 +9,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/eswan18/identity/pkg/db"
+	"github.com/google/uuid"
 )
 
 func (s *OAuthFlowSuite) TestTokenIntrospectionAccessToken() {
@@ -171,6 +173,67 @@ func (s *OAuthFlowSuite) TestTokenIntrospectionRefreshToken() {
 	s.Equal(user.ID.String(), introspectResponse["sub"])
 	s.Equal("openid profile email", introspectResponse["scope"])
 	s.Equal("refresh_token", introspectResponse["token_type"])
+}
+
+// TestTokenIntrospectionRefreshTokenNonExpiringOmitsExp is a regression test for
+// RFC 7662: "exp" should only be present in an introspection response when the
+// token actually has an expiration. RefreshExpiresAt is a nullable DB column —
+// NULL represents a non-expiring refresh token — so introspecting one must not
+// synthesize a bogus "exp" from the zero-value time. The normal token-issuance
+// flow (via /oauth/token) always populates RefreshExpiresAt, so this test
+// inserts a token row directly to exercise the non-expiring case.
+func (s *OAuthFlowSuite) TestTokenIntrospectionRefreshTokenNonExpiringOmitsExp() {
+	clientSecret := s.mustGenerateRandomString(32)
+	introspectClient := s.mustRegisterOAuthClient(db.CreateOAuthClientParams{
+		ClientID:       s.mustGenerateRandomString(8),
+		ClientSecret:   sql.NullString{String: clientSecret, Valid: true},
+		Name:           s.mustGenerateRandomString(8),
+		RedirectUris:   []string{"http://localhost:8080/callback"},
+		AllowedScopes:  []string{"openid"},
+		IsConfidential: true,
+		Audience:       "http://localhost:8000",
+	})
+
+	user := s.mustRegisterUser(
+		s.mustGenerateRandomString(8),
+		s.mustGenerateRandomString(8),
+		fmt.Sprintf("%s@example.com", s.mustGenerateRandomString(8)),
+	)
+
+	refreshToken := s.mustGenerateRandomString(32)
+	_, err := s.datastore.Q.InsertToken(s.T().Context(), db.InsertTokenParams{
+		AccessToken:      sql.NullString{String: s.mustGenerateRandomString(32), Valid: true},
+		RefreshToken:     sql.NullString{String: refreshToken, Valid: true},
+		UserID:           uuid.NullUUID{UUID: user.ID, Valid: true},
+		ClientID:         introspectClient.ID,
+		Scope:            []string{"openid"},
+		TokenType:        sql.NullString{String: "Bearer", Valid: true},
+		ExpiresAt:        time.Now().Add(time.Hour),
+		RefreshExpiresAt: sql.NullTime{Valid: false}, // non-expiring refresh token
+	})
+	s.Require().NoError(err)
+
+	introspectValues := url.Values{
+		"token":           {refreshToken},
+		"token_type_hint": {"refresh_token"},
+		"client_id":       {introspectClient.ClientID},
+		"client_secret":   {clientSecret},
+	}
+	resp, err := s.httpClient.PostForm("http://localhost:8080/oauth/introspect", introspectValues)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	s.Equal(http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+
+	var introspectResponse map[string]interface{}
+	err = json.Unmarshal(body, &introspectResponse)
+	s.Require().NoError(err)
+
+	s.True(introspectResponse["active"].(bool), "non-expiring refresh token should be active")
+	_, hasExp := introspectResponse["exp"]
+	s.False(hasExp, "exp must be omitted for a non-expiring refresh token, got %v", introspectResponse["exp"])
 }
 
 func (s *OAuthFlowSuite) TestTokenIntrospectionInvalidToken() {

--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -2,7 +2,6 @@ package httpserver
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -54,12 +53,18 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 			if _, err := s.validateOAuthClientRedirect(r.Context(), clientID, redirectURI); err == nil {
 				// OAuth error: redirect back to client with error parameters
 				errorDesc := "Only S256 code challenge method is supported"
-				redirectURL := fmt.Sprintf("%s?error=invalid_request&error_description=%s&state=%s",
-					redirectURI,
-					url.QueryEscape(errorDesc),
-					url.QueryEscape(state))
-				http.Redirect(w, r, redirectURL, http.StatusFound)
-				return
+				if redirectURL, err := url.Parse(redirectURI); err == nil {
+					q := redirectURL.Query()
+					q.Set("error", "invalid_request")
+					q.Set("error_description", errorDesc)
+					// Per RFC 6749 §4.1.2.1, state is only echoed back if the client sent it.
+					if state != "" {
+						q.Set("state", state)
+					}
+					redirectURL.RawQuery = q.Encode()
+					http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+					return
+				}
 			}
 		}
 		// No redirect_uri, or client_id/redirect_uri failed validation: show error page

--- a/pkg/httpserver/oauth.go
+++ b/pkg/httpserver/oauth.go
@@ -82,7 +82,10 @@ func (s *Server) HandleOauthAuthorize(w http.ResponseWriter, r *http.Request) {
 		q := redirectURL.Query()
 		q.Set("error", errorCode)
 		q.Set("error_description", description)
-		q.Set("state", state)
+		// Per RFC 6749 §4.1.2.1, state is only echoed back if the client sent it.
+		if state != "" {
+			q.Set("state", state)
+		}
 		redirectURL.RawQuery = q.Encode()
 		http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 	}
@@ -141,7 +144,11 @@ func (s *Server) HandleOauthAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 	q := redirectURL.Query()
 	q.Set("code", authorizationCode)
-	q.Set("state", state)
+	// Per RFC 6749 §4.1.2, state is only returned to the client if it was present
+	// in the authorization request.
+	if state != "" {
+		q.Set("state", state)
+	}
 	redirectURL.RawQuery = q.Encode()
 	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 }
@@ -450,6 +457,19 @@ func (s *Server) writeInvalidClientError(w http.ResponseWriter) {
 	writeJSONError(w, http.StatusUnauthorized, "invalid_client", "Invalid client credentials")
 }
 
+// writeUserInfoUnauthorized writes a 401 JSON error for the UserInfo endpoint,
+// including a WWW-Authenticate header per RFC 6750 §3. Unlike the token,
+// introspection, and revocation endpoints (which authenticate the *client* via
+// HTTP Basic and so challenge with `Basic realm="oauth"` — see
+// writeInvalidClientError), UserInfo is a Bearer-token-protected resource: a
+// missing, invalid, or revoked bearer token must be challenged with the Bearer
+// scheme instead. The errorCode/description are echoed into both the header
+// and the JSON body so the two agree.
+func writeUserInfoUnauthorized(w http.ResponseWriter, errorCode, description string) {
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf(`Bearer error=%q, error_description=%q`, errorCode, description))
+	writeJSONError(w, http.StatusUnauthorized, errorCode, description)
+}
+
 // handleUserInfo godoc
 // @Summary      OIDC UserInfo endpoint
 // @Description  Returns user identity claims for the authenticated user. Claims are gated by scope per OIDC Core Section 5.4: "sub" is always returned; "email" and "email_verified" require the "email" scope; "username", "given_name", "family_name", and "picture" require the "profile" scope. Supports both GET and POST per OIDC Core Section 5.3; on POST, the access token may alternatively be sent as a form-encoded "access_token" parameter (RFC 6750 Section 2.2) instead of the Authorization header.
@@ -488,12 +508,7 @@ func (s *Server) HandleOauthUserInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if accessToken == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		json.NewEncoder(w).Encode(map[string]string{
-			"error":             "invalid_token",
-			"error_description": "Missing or invalid Authorization header",
-		})
+		writeUserInfoUnauthorized(w, "invalid_token", "Missing or invalid Authorization header")
 		return
 	}
 
@@ -505,12 +520,7 @@ func (s *Server) HandleOauthUserInfo(w http.ResponseWriter, r *http.Request) {
 		// Log the detailed error server-side, but return generic error to client
 		// to avoid leaking information about token structure or validation logic
 		log.Printf("JWT validation failed: %v", err)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		json.NewEncoder(w).Encode(map[string]string{
-			"error":             "invalid_token",
-			"error_description": "Invalid or expired access token",
-		})
+		writeUserInfoUnauthorized(w, "invalid_token", "Invalid or expired access token")
 		return
 	}
 
@@ -536,12 +546,7 @@ func (s *Server) HandleOauthUserInfo(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			// No matching, non-revoked, non-expired row - the token is invalid.
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			json.NewEncoder(w).Encode(map[string]string{
-				"error":             "invalid_token",
-				"error_description": "Token has been revoked",
-			})
+			writeUserInfoUnauthorized(w, "invalid_token", "Token has been revoked")
 			return
 		}
 	}
@@ -717,16 +722,25 @@ func (s *Server) introspectRefreshToken(ctx context.Context, token string) map[s
 		username = user.Username
 	}
 
-	return map[string]interface{}{
+	response := map[string]interface{}{
 		"active":     true,
 		"scope":      strings.Join(dbToken.Scope, " "),
 		"client_id":  dbToken.ClientID.String(),
 		"username":   username,
 		"token_type": "refresh_token",
-		"exp":        dbToken.RefreshExpiresAt.Time.Unix(),
 		"iat":        dbToken.CreatedAt.Unix(),
 		"sub":        dbToken.UserID.UUID.String(),
 	}
+
+	// Per RFC 7662, "exp" should only be present when the token actually expires.
+	// RefreshExpiresAt is a nullable column (NULL means the refresh token does not
+	// expire), so unconditionally taking .Time.Unix() would emit the zero-value
+	// time's epoch (a bogus negative/zero "exp") for non-expiring refresh tokens.
+	if dbToken.RefreshExpiresAt.Valid {
+		response["exp"] = dbToken.RefreshExpiresAt.Time.Unix()
+	}
+
+	return response
 }
 
 // handleRevoke godoc
@@ -1050,7 +1064,10 @@ func (s *Server) HandleConsentPost(w http.ResponseWriter, r *http.Request) {
 		q := redirectURL.Query()
 		q.Set("error", errorCode)
 		q.Set("error_description", description)
-		q.Set("state", state)
+		// Per RFC 6749 §4.1.2.1, state is only echoed back if the client sent it.
+		if state != "" {
+			q.Set("state", state)
+		}
 		redirectURL.RawQuery = q.Encode()
 		http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 	}
@@ -1096,7 +1113,11 @@ func (s *Server) HandleConsentPost(w http.ResponseWriter, r *http.Request) {
 	}
 	q := redirectURL.Query()
 	q.Set("code", authorizationCode)
-	q.Set("state", state)
+	// Per RFC 6749 §4.1.2, state is only returned to the client if it was present
+	// in the authorization request.
+	if state != "" {
+		q.Set("state", state)
+	}
 	redirectURL.RawQuery = q.Encode()
 	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 }

--- a/pkg/httpserver/userinfo_test.go
+++ b/pkg/httpserver/userinfo_test.go
@@ -34,7 +34,45 @@ func TestHandleOauthUserInfo_NoTokenReturns401(t *testing.T) {
 			if body["error"] != "invalid_token" {
 				t.Errorf("expected error invalid_token, got %q", body["error"])
 			}
+			// RFC 6750 §3: a Bearer-protected resource returning 401 SHOULD include
+			// a WWW-Authenticate header, using the Bearer scheme (not the Basic
+			// scheme used by the token/introspect/revoke client-auth endpoints),
+			// and it should agree with the JSON body's error/error_description.
+			wantAuth := `Bearer error="invalid_token", error_description="Missing or invalid Authorization header"`
+			if got := rec.Header().Get("WWW-Authenticate"); got != wantAuth {
+				t.Errorf("WWW-Authenticate = %q, want %q", got, wantAuth)
+			}
 		})
+	}
+}
+
+// TestHandleOauthUserInfo_InvalidTokenReturns401WithBearerChallenge verifies that
+// a syntactically-invalid/unparseable bearer token (which fails JWT validation
+// before any database lookup, so this is hermetically testable without a real
+// Postgres connection) also gets the RFC 6750 §3 WWW-Authenticate header, with
+// the Bearer scheme and an error/error_description matching the JSON body.
+func TestHandleOauthUserInfo_InvalidTokenReturns401WithBearerChallenge(t *testing.T) {
+	s := newHermeticTestServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/oauth/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer not-a-valid-jwt")
+	rec := httptest.NewRecorder()
+
+	s.HandleOauthUserInfo(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("failed to unmarshal response body: %v", err)
+	}
+	if body["error"] != "invalid_token" {
+		t.Errorf("expected error invalid_token, got %q", body["error"])
+	}
+	wantAuth := `Bearer error="invalid_token", error_description="Invalid or expired access token"`
+	if got := rec.Header().Get("WWW-Authenticate"); got != wantAuth {
+		t.Errorf("WWW-Authenticate = %q, want %q", got, wantAuth)
 	}
 }
 


### PR DESCRIPTION
## Summary

Three small OAuth2/OIDC spec-compliance fixes, all in `pkg/httpserver/oauth.go` (plus a small touch to `login.go` for #3):

1. **Bogus `exp` for non-expiring refresh tokens (RFC 7662)** — `introspectRefreshToken` unconditionally set `"exp": dbToken.RefreshExpiresAt.Time.Unix()`, but `RefreshExpiresAt` is a `sql.NullTime`. When NULL (a non-expiring refresh token), `.Time` is the zero value, producing a nonsensical negative/zero `exp`. Fixed to only include `exp` when `RefreshExpiresAt.Valid` is true. Checked `introspectAccessToken`: its `exp`/`iat` come from JWT claims and the non-nullable `expires_at` column, so no change was needed there.

2. **UserInfo 401s missing `WWW-Authenticate` (RFC 6750 §3)** — `HandleOauthUserInfo`'s three 401 paths (missing token, invalid/expired JWT, revoked token) didn't set a `WWW-Authenticate` header. Added `Bearer error="...", error_description="..."` challenges matching each response body. This is intentionally the Bearer scheme, not the `Basic realm="oauth"` scheme used by `/oauth/token`, `/oauth/introspect`, and `/oauth/revoke` — those authenticate the *client*, whereas UserInfo is a Bearer-token-protected resource. The 500 `server_error` path is untouched.

3. **Empty `state=` emitted when the client sent none (RFC 6749 §4.1.2 / §4.1.2.1)** — `state` should only be echoed back if the client's authorization request included it. Guarded all four `q.Set("state", state)` call sites in `oauth.go` (authorize error redirect, authorize success redirect, consent error redirect, consent success redirect) plus `login.go`'s S256-mismatch error redirect (rewritten from a raw `fmt.Sprintf` to `url.Values`, matching the pattern used elsewhere, so `state` — and the `fmt` import — could be dropped cleanly when empty).

## Testing

- `go build ./...` — passes
- `go vet ./...` — passes
- `go vet -tags integration ./...` — passes (compiles)
- `go test ./...` (non-integration) — passes

Reviewed `oauth_flow_test.go`, `oidc_test.go`, `introspection_revocation_test.go`, and `authorize_consent_test.go`: the `StateAndCodeVerifier` test fixture always generates a random non-empty `state`, and no existing assertion checks for an absent/empty `exp` or the presence/absence of `WWW-Authenticate`, so no existing assertions needed updating.

Added tests:
- `pkg/httpserver/userinfo_test.go` (hermetic, no DB): asserts the `WWW-Authenticate: Bearer error="...", error_description="..."` header on the missing-token and invalid-JWT 401 paths.
- `pkg/httpserver/introspection_revocation_test.go` (integration): inserts a refresh-token row directly with `RefreshExpiresAt.Valid = false` (the normal issuance flow always sets this, so this exercises the previously-latent non-expiring case) and asserts `exp` is absent from the introspection response.
- `pkg/httpserver/authorize_consent_test.go` (integration): asserts the authorize-error and consent-approve redirects omit `state` entirely when the client didn't supply it.

Diff is scoped to these three nits only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE