### PR TITLE
Add templ CI drift check, document templ, rename LoginPageData

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -28,6 +28,17 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
+      # The generated *_templ.go files are committed (go build / the steps below
+      # never run `templ generate`). Regenerate here and fail if anything drifts,
+      # so a .templ edit that wasn't regenerated — or stale committed output —
+      # can't slip through green CI. Pinned to the templ version in go.mod so the
+      # generator output matches what produced the committed files.
+      - name: Verify templ generation is up to date
+        run: |
+          go install github.com/a-h/templ/cmd/templ@v0.3.1020
+          templ generate
+          git diff --exit-code || { echo "::error::templ output is stale — run 'make templ' (or 'templ generate') and commit the result."; exit 1; }
+
       - name: Run go vet
         run: go vet ./...
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,17 @@ go install github.com/swaggo/swag/cmd/swag@latest
 go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 # golang-migrate/migrate for migrations
 go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@latest
+# a-h/templ for the server-rendered HTML pages (pkg/views/*.templ)
+go install github.com/a-h/templ/cmd/templ@latest
 ```
+
+### Templates (templ)
+
+The browser-facing pages are [templ](https://templ.guide) components in `pkg/views/*.templ`.
+templ compiles each `.templ` into a committed `*_templ.go` file (so `go build`/CI
+don't need the `templ` binary). **After editing any `.templ` file, run `make templ`
+(or `templ generate`) and commit the regenerated `*_templ.go`** — CI fails if the
+committed output is stale. `make build`/`make run` regenerate automatically.
 
 ### Tailwind CSS
 

--- a/pkg/httpserver/login.go
+++ b/pkg/httpserver/login.go
@@ -10,15 +10,15 @@ import (
 	"github.com/eswan18/identity/pkg/views"
 )
 
-// LoginPageData carries the OAuth authorization parameters through the login
+// oauthFlowParams carries the OAuth authorization parameters through the login
 // (and, via mfa.go, MFA) flow. Unlike pkg/views' *View types, it is not only
 // a rendering type: it doubles as the internal carrier passed between
 // handlers (e.g. HandleLoginPost -> createMFAPendingSession,
 // oauthParamsFromPending / resumeMFAFlow / buildAuthorizeURL in mfa.go), so
 // it stays in httpserver rather than moving to pkg/views. Render call sites
-// build a views.LoginView from it via loginViewFromPageData instead of
+// build a views.LoginView from it via loginViewFromParams instead of
 // rendering it directly.
-type LoginPageData struct {
+type oauthFlowParams struct {
 	Error               string
 	ClientID            string
 	RedirectURI         string
@@ -30,10 +30,10 @@ type LoginPageData struct {
 	CSRFToken           string
 }
 
-// loginViewFromPageData builds the views.LoginView used to render the login
-// page from the LoginPageData carrier plus the error message and CSRF token,
+// loginViewFromParams builds the views.LoginView used to render the login
+// page from the oauthFlowParams carrier plus the error message and CSRF token,
 // which vary by call site.
-func loginViewFromPageData(p LoginPageData, errMsg, csrfToken string) views.LoginView {
+func loginViewFromParams(p oauthFlowParams, errMsg, csrfToken string) views.LoginView {
 	return views.LoginView{
 		Error:               errMsg,
 		ClientID:            p.ClientID,
@@ -73,7 +73,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 
 	// If code_challenge_method is provided, it must be S256 -- meaning a sha256 hash of the code verifier.
 	if codeChallengeMethod != "" && codeChallengeMethod != "S256" {
-		oauthParams := LoginPageData{
+		oauthParams := oauthFlowParams{
 			ClientID:            clientID,
 			RedirectURI:         redirectURI,
 			State:               state,
@@ -128,7 +128,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 		errorMsg = "Your account is deactivated. You cannot log in to applications."
 	}
 
-	oauthParams := LoginPageData{
+	oauthParams := oauthFlowParams{
 		ClientID:            clientID,
 		RedirectURI:         redirectURI,
 		State:               state,
@@ -137,7 +137,7 @@ func (s *Server) HandleLoginGet(w http.ResponseWriter, r *http.Request) {
 		CodeChallengeMethod: codeChallengeMethod,
 		Nonce:               nonce,
 	}
-	if err := views.Login(loginViewFromPageData(oauthParams, errorMsg, s.ensureCSRFToken(w, r))).Render(r.Context(), w); err != nil {
+	if err := views.Login(loginViewFromParams(oauthParams, errorMsg, s.ensureCSRFToken(w, r))).Render(r.Context(), w); err != nil {
 		log.Printf("[ERROR] HandleLoginGet: Failed to render login page: %v", err)
 	}
 }
@@ -173,7 +173,7 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 	nonce := r.FormValue("nonce")
 
 	// Extract OAuth parameters into a struct for reuse.
-	oauthParams := LoginPageData{
+	oauthParams := oauthFlowParams{
 		ClientID:            clientID,
 		RedirectURI:         redirectURI,
 		State:               state,
@@ -251,12 +251,12 @@ func (s *Server) HandleLoginPost(w http.ResponseWriter, r *http.Request) {
 
 // renderLoginError renders the login page with an error message, preserving OAuth parameters.
 // It handles template execution errors gracefully by falling back to the error template.
-func (s *Server) renderLoginError(w http.ResponseWriter, r *http.Request, statusCode int, errorMsg string, oauthParams LoginPageData) {
+func (s *Server) renderLoginError(w http.ResponseWriter, r *http.Request, statusCode int, errorMsg string, oauthParams oauthFlowParams) {
 	// Ensure the CSRF token/cookie before writing the status line, so the re-rendered
 	// login form carries a token the eventual POST can echo back.
 	csrfToken := s.ensureCSRFToken(w, r)
 	w.WriteHeader(statusCode)
-	err := views.Login(loginViewFromPageData(oauthParams, errorMsg, csrfToken)).Render(r.Context(), w)
+	err := views.Login(loginViewFromParams(oauthParams, errorMsg, csrfToken)).Render(r.Context(), w)
 	if err != nil {
 		// Fallback to error template if login template fails
 		err = views.Error(views.ErrorView{
@@ -292,7 +292,7 @@ func (s *Server) setSessionCookie(w http.ResponseWriter, session Session) {
 // once the user is authenticated. It mirrors the parameters originally supplied by the
 // client; the authorize endpoint re-validates client_id, redirect_uri and scope on
 // arrival, so these values are not trusted blindly.
-func buildAuthorizeURL(p LoginPageData) string {
+func buildAuthorizeURL(p oauthFlowParams) string {
 	q := url.Values{
 		"client_id":             {p.ClientID},
 		"redirect_uri":          {p.RedirectURI},
@@ -310,7 +310,7 @@ func buildAuthorizeURL(p LoginPageData) string {
 // initiated the flow (client_id present) the user is routed back through
 // /oauth/authorize to handle consent and authorization-code issuance; otherwise this
 // was a direct login and the user is taken to account settings.
-func (s *Server) redirectAfterAuth(w http.ResponseWriter, r *http.Request, p LoginPageData) {
+func (s *Server) redirectAfterAuth(w http.ResponseWriter, r *http.Request, p oauthFlowParams) {
 	if p.ClientID == "" {
 		http.Redirect(w, r, "/oauth/account-settings", http.StatusFound)
 		return

--- a/pkg/httpserver/mfa.go
+++ b/pkg/httpserver/mfa.go
@@ -16,9 +16,9 @@ import (
 const mfaPendingExpiresIn = 5 * time.Minute
 
 // oauthParamsFromPending lifts the OAuth authorization parameters stored on a pending
-// MFA row into the common LoginPageData carrier.
-func oauthParamsFromPending(p db.AuthMfaPending) LoginPageData {
-	return LoginPageData{
+// MFA row into the common oauthFlowParams carrier.
+func oauthParamsFromPending(p db.AuthMfaPending) oauthFlowParams {
+	return oauthFlowParams{
 		ClientID:            p.ClientID.String,
 		RedirectURI:         p.RedirectUri.String,
 		State:               p.State.String,
@@ -38,7 +38,7 @@ func oauthParamsFromPending(p db.AuthMfaPending) LoginPageData {
 // code entry, or a duplicate/replayed submit already consumed it. Without this, a lost
 // pending row strips the OAuth context and the user is bounced to a context-free login
 // (and, after re-authenticating, dumped on the account page instead of the app).
-func mfaPageData(pendingID string, p LoginPageData, errMsg, csrfToken string) views.MFAView {
+func mfaPageData(pendingID string, p oauthFlowParams, errMsg, csrfToken string) views.MFAView {
 	return views.MFAView{
 		Error:               errMsg,
 		PendingID:           pendingID,
@@ -85,7 +85,7 @@ func (s *Server) HandleMFAPost(w http.ResponseWriter, r *http.Request) {
 	// longer be found; whenever the row is present it remains the authoritative source.
 	// Either way, /oauth/authorize re-validates client_id, redirect_uri and scope, so a
 	// tampered field cannot escalate — it just produces a validation error.
-	formParams := LoginPageData{
+	formParams := oauthFlowParams{
 		ClientID:            r.FormValue("client_id"),
 		RedirectURI:         r.FormValue("redirect_uri"),
 		State:               r.FormValue("state"),
@@ -172,7 +172,7 @@ func (s *Server) HandleMFAPost(w http.ResponseWriter, r *http.Request) {
 //
 // For a direct (non-OAuth) login there is no app context to preserve, so the user goes
 // to account settings if already authenticated, or the login page if not.
-func (s *Server) resumeMFAFlow(w http.ResponseWriter, r *http.Request, p LoginPageData) {
+func (s *Server) resumeMFAFlow(w http.ResponseWriter, r *http.Request, p oauthFlowParams) {
 	if p.ClientID != "" {
 		http.Redirect(w, r, buildAuthorizeURL(p), http.StatusFound)
 		return
@@ -185,7 +185,7 @@ func (s *Server) resumeMFAFlow(w http.ResponseWriter, r *http.Request, p LoginPa
 }
 
 // createMFAPendingSession creates a pending MFA session after password validation.
-func (s *Server) createMFAPendingSession(r *http.Request, userID uuid.UUID, oauthParams LoginPageData) (string, error) {
+func (s *Server) createMFAPendingSession(r *http.Request, userID uuid.UUID, oauthParams oauthFlowParams) (string, error) {
 	pendingID, err := generateRandomString(32)
 	if err != nil {
 		return "", err
@@ -213,7 +213,7 @@ func (s *Server) createMFAPendingSession(r *http.Request, userID uuid.UUID, oaut
 
 // renderMFAError renders the MFA page with an error message, preserving the OAuth
 // context so a retry keeps the originating authorization request intact.
-func (s *Server) renderMFAError(w http.ResponseWriter, r *http.Request, statusCode int, errorMsg string, pendingID string, p LoginPageData) {
+func (s *Server) renderMFAError(w http.ResponseWriter, r *http.Request, statusCode int, errorMsg string, pendingID string, p oauthFlowParams) {
 	csrfToken := s.ensureCSRFToken(w, r)
 	w.WriteHeader(statusCode)
 	if err := views.MFA(mfaPageData(pendingID, p, errorMsg, csrfToken)).Render(r.Context(), w); err != nil {

--- a/pkg/views/login.templ
+++ b/pkg/views/login.templ
@@ -15,7 +15,7 @@ const (
 )
 
 // LoginView holds everything the login page renders. It replaces
-// httpserver.LoginPageData for rendering purposes; the fields are checked at
+// httpserver.oauthFlowParams for rendering purposes; the fields are checked at
 // compile time against their use in the component below. Scope is joined
 // with a single space when rendered into the hidden "scope" input, matching
 // templates/login.html's `{{range $i, $s := .Scope}}{{if $i}} {{end}}{{$s}}{{end}}`.

--- a/pkg/views/login_templ.go
+++ b/pkg/views/login_templ.go
@@ -23,7 +23,7 @@ const (
 )
 
 // LoginView holds everything the login page renders. It replaces
-// httpserver.LoginPageData for rendering purposes; the fields are checked at
+// httpserver.oauthFlowParams for rendering purposes; the fields are checked at
 // compile time against their use in the component below. Scope is joined
 // with a single space when rendered into the hidden "scope" input, matching
 // templates/login.html's `{{range $i, $s := .Scope}}{{if $i}} {{end}}{{$s}}{{end}}`.


### PR DESCRIPTION
Three follow-ups after the templ migration:

1. **CI drift check** (the important one) — a new `Verify templ generation is up to date` step runs `templ generate` (pinned to the go.mod templ version) and fails on any `git diff`. Since the generated `*_templ.go` files are committed and `go build`/CI never regenerate them, a `.templ` edit that wasn't regenerated — or stale committed output — would otherwise pass green CI while the rendered page silently didn't match the source. This closes that gap (same skipped-codegen failure mode as the migration incident, now caught by CI).
2. **README** — added `templ` to the prerequisite CLI tools and a short "Templates (templ)" note: regenerate with `make templ` after editing a `.templ`; CI enforces it.
3. **Rename `LoginPageData` → `oauthFlowParams`** (and `loginViewFromPageData` → `loginViewFromParams`). Post-migration this type is no longer "page data" — it's the OAuth-parameter carrier threaded through the login/MFA handlers; the render type is `views.LoginView`. Pure rename, no behavior change.

`go build`, `go vet` (both tags), and `go test` pass; `templ generate` is a no-op against the committed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE