### PR TITLE
Refuse to start if DB schema is behind the binary's migrations

### DIFF
--- a/cmd/auth-service/main.go
+++ b/cmd/auth-service/main.go
@@ -10,10 +10,12 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
+	"github.com/eswan18/identity/db/migrations"
 	"github.com/eswan18/identity/pkg/config"
 	"github.com/eswan18/identity/pkg/email"
 	"github.com/eswan18/identity/pkg/httpserver"
@@ -28,6 +30,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create datastore: %v", err)
 	}
+
+	// Refuse to start if the database schema isn't at the migration version
+	// this binary was built for. This is a check, not an auto-migration: a
+	// forgotten `make migrate-up` fails fast with a clear message instead of
+	// silently serving against an unexpected schema.
+	if err := migrations.Verify(context.Background(), datastore.DB); err != nil {
+		log.Fatalf("Database schema check failed: %v", err)
+	}
+	log.Println("Database schema is up to date")
 
 	// Create email sender based on configuration
 	var emailSender email.Sender

--- a/db/migrations/embed.go
+++ b/db/migrations/embed.go
@@ -1,0 +1,87 @@
+// Package migrations embeds the SQL migration files into the binary and
+// provides a fail-closed startup check (Verify) that the database schema
+// matches the migrations this binary was built with.
+//
+// It deliberately does NOT apply migrations. The goal is to refuse to start —
+// with a clear, actionable error — when code is deployed without running
+// `make migrate-up`, rather than silently serving against a schema the code
+// doesn't expect (which is how a forgotten migration once broke client-secret
+// auth). Applying migrations remains a deliberate, separate step.
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"strconv"
+	"strings"
+)
+
+// upFiles embeds the "up" migrations so the binary carries the schema version
+// it was built for. Only *.up.sql is needed to determine the latest version.
+//
+//go:embed *.up.sql
+var upFiles embed.FS
+
+// LatestVersion returns the highest migration version embedded in the binary,
+// i.e. the numeric prefix of the newest *.up.sql file (e.g. 11 for
+// 000011_add_mfa_enrollment_pending.up.sql).
+func LatestVersion() (int, error) {
+	entries, err := fs.ReadDir(upFiles, ".")
+	if err != nil {
+		return 0, fmt.Errorf("reading embedded migrations: %w", err)
+	}
+	latest := -1
+	for _, e := range entries {
+		name := e.Name()
+		i := strings.IndexByte(name, '_')
+		if i <= 0 {
+			continue
+		}
+		n, err := strconv.Atoi(name[:i])
+		if err != nil {
+			continue
+		}
+		if n > latest {
+			latest = n
+		}
+	}
+	if latest < 0 {
+		return 0, errors.New("no embedded migration files found")
+	}
+	return latest, nil
+}
+
+// Verify checks that the database schema is at exactly the migration version
+// this binary was built with, returning a descriptive error otherwise. It
+// reads golang-migrate's schema_migrations table (version, dirty) and compares
+// it against LatestVersion. It never applies migrations.
+//
+// Any mismatch — an unreadable/empty schema_migrations table (never migrated),
+// a dirty state (a migration failed partway), or a version that differs from
+// what the binary expects — is returned as an error so the caller can refuse
+// to start.
+func Verify(ctx context.Context, db *sql.DB) error {
+	latest, err := LatestVersion()
+	if err != nil {
+		return err
+	}
+
+	var version int
+	var dirty bool
+	err = db.QueryRowContext(ctx, "SELECT version, dirty FROM schema_migrations").Scan(&version, &dirty)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return fmt.Errorf("schema_migrations is empty: no migrations have been applied; run `make migrate-up` (this build expects version %d)", latest)
+	case err != nil:
+		return fmt.Errorf("could not read schema_migrations (migrations may never have been run): %w; run `make migrate-up`", err)
+	case dirty:
+		return fmt.Errorf("database schema is dirty at migration %d: a previous migration failed partway and must be resolved manually", version)
+	case version != latest:
+		return fmt.Errorf("database schema is at migration %d but this build expects %d; run `make migrate-up`", version, latest)
+	}
+	return nil
+}

--- a/db/migrations/embed_test.go
+++ b/db/migrations/embed_test.go
@@ -1,0 +1,16 @@
+package migrations
+
+import "testing"
+
+func TestLatestVersion(t *testing.T) {
+	v, err := LatestVersion()
+	if err != nil {
+		t.Fatalf("LatestVersion() error: %v", err)
+	}
+	// Bump the floor when you add migrations. The important guard is that this
+	// never silently returns 0 (which would make Verify accept an empty DB as
+	// "up to date").
+	if v < 11 {
+		t.Errorf("LatestVersion() = %d, want >= 11 (embed matched too few files?)", v)
+	}
+}

--- a/pkg/httpserver/migration_check_integration_test.go
+++ b/pkg/httpserver/migration_check_integration_test.go
@@ -1,0 +1,39 @@
+//go:build integration
+
+package httpserver
+
+import (
+	"context"
+
+	"github.com/eswan18/identity/db/migrations"
+)
+
+// TestSchemaVerificationPassesOnMigratedDB confirms the startup schema check
+// (migrations.Verify) does NOT false-positive against a correctly-migrated
+// database — the suite runs all migrations in setup, so Verify must pass.
+func (s *OAuthFlowSuite) TestSchemaVerificationPassesOnMigratedDB() {
+	s.Require().NoError(migrations.Verify(context.Background(), s.datastore.DB))
+}
+
+// TestSchemaVerificationDetectsPendingMigration confirms the check actually
+// fires: it temporarily rewinds schema_migrations to one version behind the
+// binary's latest, asserts Verify returns an error, then restores the real
+// version. Only this test reads schema_migrations, so the temporary mutation
+// is safe for the rest of the suite as long as it's restored here.
+func (s *OAuthFlowSuite) TestSchemaVerificationDetectsPendingMigration() {
+	ctx := context.Background()
+
+	var orig int
+	s.Require().NoError(s.datastore.DB.QueryRowContext(ctx, "SELECT version FROM schema_migrations").Scan(&orig))
+	s.Require().Greater(orig, 0)
+
+	_, err := s.datastore.DB.ExecContext(ctx, "UPDATE schema_migrations SET version = $1", orig-1)
+	s.Require().NoError(err)
+	defer func() {
+		_, restoreErr := s.datastore.DB.ExecContext(ctx, "UPDATE schema_migrations SET version = $1", orig)
+		s.Require().NoError(restoreErr)
+	}()
+
+	s.Require().Error(migrations.Verify(ctx, s.datastore.DB),
+		"Verify should reject a database that is behind the binary's migration version")
+}


### PR DESCRIPTION
Fail-closed startup check so a forgotten `make migrate-up` crash-loops with a clear message instead of silently serving against an unexpected schema — the failure mode behind the Bifrost token-exchange incident. **It does not auto-apply migrations** (per the concern about surprise DB mutations); it only verifies and refuses to start.

Mirrors fitness-api's `check_migrations()` (Alembic, called from the FastAPI lifespan), adapted to golang-migrate.

## What it does
- New `db/migrations` package embeds the `*.up.sql` files (`//go:embed`), so the binary carries the schema version it was built for. `LatestVersion()` returns the highest embedded migration number.
- `Verify(ctx, db)` reads golang-migrate's `schema_migrations` (version, dirty) and returns a descriptive error if: the table is empty/unreadable (never migrated), `dirty` (a migration failed partway), or `version != latest`.
- `cmd/auth-service/main.go` calls `Verify` right after connecting to the DB and `log.Fatal`s on error — with a `run make migrate-up` hint.

## Tests
- Hermetic `TestLatestVersion` (embed matched the files; never silently 0).
- Integration (under `TestOAuthFlowSuite`, real Postgres): `Verify` passes on the fully-migrated test DB, and fires when `schema_migrations` is temporarily rewound one version behind (restored after).

Build/vet (both tags) and all non-integration tests pass. Nothing new ships at runtime — the migration files are embedded in the binary at build (the Dockerfile already `COPY . .`s them into the build stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXogBsA6skTsyca9ado3ZE