### PR TITLE
CI: stop pushing the mutable latest image tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,6 @@ steps:
           --cache-from type=registry,ref=us-central1-docker.pkg.dev/ethans-services/containers/identity:buildcache \
           --cache-to type=registry,ref=us-central1-docker.pkg.dev/ethans-services/containers/identity:buildcache,mode=max \
           -t us-central1-docker.pkg.dev/ethans-services/containers/identity:$SHORT_SHA \
-          -t us-central1-docker.pkg.dev/ethans-services/containers/identity:latest \
           --push \
           .
 


### PR DESCRIPTION
## Why

Nothing consumes the mutable tag: the staging image-updater is restricted to SHA tags via `allowTags` in the ImageUpdater CR, and `ib`/bifrost promotions only ever write SHA pins. Its one remaining effect was a hazard — an ArgoCD Application recreated without its kustomize image override (as in the July 2026 footstrike rename) falls back to the base manifest's mutable tag and then silently tracks new builds whenever a pod reschedules.

With CI pushing only immutable `{sha}` tags, that fallback fails loudly (ImagePullBackOff, visible as drift in bifrost and fixable with one promote) instead of quietly running unpromoted code. Once this lands across all service repos, the frozen mutable tags get deleted from Artifact Registry.

The `buildcache` tag is unaffected — it is the BuildKit layer cache, never deployed, and excluded by every `allowTags` regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)