### PR TITLE
Accept wildcard redirect URIs for preview environments

### DIFF
--- a/pkg/httpserver/credentials.go
+++ b/pkg/httpserver/credentials.go
@@ -119,7 +119,7 @@ func (s *Server) validateOAuthClientRedirect(ctx context.Context, clientID, redi
 		log.Printf("validateOAuthClientRedirect: error getting client by client ID: %s\n", err)
 		return db.OauthClient{}, ErrInvalidClient
 	}
-	if !slices.Contains(client.RedirectUris, redirectURI) {
+	if !redirectURIAllowed(client.RedirectUris, redirectURI) {
 		log.Printf("validateOAuthClientRedirect: redirect URI %s not in allowlist for client: %s\n", redirectURI, clientID)
 		return db.OauthClient{}, ErrInvalidRedirectURI
 	}

--- a/pkg/httpserver/redirect_match.go
+++ b/pkg/httpserver/redirect_match.go
@@ -14,9 +14,9 @@ import (
 // refuse candidates carrying a query string or fragment. The wildcard
 // pattern's path must equal the candidate's path exactly, so register the
 // pattern with the full callback path (a pattern with no path only matches a
-// candidate with no trailing slash). This exists so ephemeral stack
-// environments (https://<app>-<tag>.stacks.footstrike.run) can complete
-// OAuth without per-stack registration.
+// candidate with no trailing slash). This exists so ephemeral preview
+// environments (https://<app>-<tag>.preview.footstrike.run) can complete
+// OAuth without per-preview registration.
 func redirectURIAllowed(registered []string, candidate string) bool {
 	if slices.Contains(registered, candidate) {
 		return true

--- a/pkg/httpserver/redirect_match.go
+++ b/pkg/httpserver/redirect_match.go
@@ -11,9 +11,12 @@ import (
 // exactly, or if the entry's host begins with "*." and the candidate differs
 // only by replacing the "*" with exactly one non-empty DNS label. Wildcard
 // entries match https candidates only, require identical path and port, and
-// refuse candidates carrying a query string or fragment. This exists so
-// ephemeral stack environments (https://<app>-<tag>.stacks.footstrike.run)
-// can complete OAuth without per-stack registration.
+// refuse candidates carrying a query string or fragment. The wildcard
+// pattern's path must equal the candidate's path exactly, so register the
+// pattern with the full callback path (a pattern with no path only matches a
+// candidate with no trailing slash). This exists so ephemeral stack
+// environments (https://<app>-<tag>.stacks.footstrike.run) can complete
+// OAuth without per-stack registration.
 func redirectURIAllowed(registered []string, candidate string) bool {
 	if slices.Contains(registered, candidate) {
 		return true
@@ -32,14 +35,45 @@ func wildcardRedirectMatch(entry string, cand *url.URL) bool {
 	if err != nil || pat.Scheme != "https" || !strings.HasPrefix(pat.Host, "*.") {
 		return false
 	}
-	if cand.Scheme != "https" || cand.Path != pat.Path || cand.Port() != pat.Port() {
+	if cand.Scheme != "https" || cand.User != nil {
+		return false
+	}
+	if cand.EscapedPath() != pat.EscapedPath() || cand.Port() != pat.Port() {
 		return false
 	}
 	if cand.RawQuery != "" || cand.Fragment != "" {
 		return false
 	}
-	dotSuffix := "." + strings.ToLower(strings.TrimPrefix(pat.Hostname(), "*."))
-	candHost := strings.ToLower(cand.Hostname())
-	label, ok := strings.CutSuffix(candHost, dotSuffix)
+	patSuffix, ok := asciiLowerHost(strings.TrimPrefix(pat.Hostname(), "*."))
+	if !ok {
+		return false
+	}
+	candHost, ok := asciiLowerHost(cand.Hostname())
+	if !ok {
+		return false
+	}
+	label, ok := strings.CutSuffix(candHost, "."+patSuffix)
 	return ok && label != "" && !strings.ContainsAny(label, ".*")
+}
+
+// asciiLowerHost ASCII-lowercases host (A-Z to a-z only, no Unicode case
+// folding) and reports ok=false if the result contains any byte outside
+// [a-z0-9.-]. This rejects hosts that rely on Unicode folding or confusable
+// characters to defeat the single-label check above — for example U+212A
+// KELVIN SIGN, which strings.ToLower folds to "k", or U+FF0E FULLWIDTH FULL
+// STOP, which browsers' UTS-46 host mapping treats as "." but which would
+// otherwise pass the ASCII-only dot/label scan unnoticed.
+func asciiLowerHost(host string) (folded string, ok bool) {
+	b := make([]byte, len(host))
+	for i := 0; i < len(host); i++ {
+		c := host[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if !(c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '.' || c == '-') {
+			return "", false
+		}
+		b[i] = c
+	}
+	return string(b), true
 }

--- a/pkg/httpserver/redirect_match.go
+++ b/pkg/httpserver/redirect_match.go
@@ -1,0 +1,45 @@
+package httpserver
+
+import (
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// redirectURIAllowed reports whether candidate is allowed by a client's
+// registered redirect URIs. An entry allows the candidate if it matches
+// exactly, or if the entry's host begins with "*." and the candidate differs
+// only by replacing the "*" with exactly one non-empty DNS label. Wildcard
+// entries match https candidates only, require identical path and port, and
+// refuse candidates carrying a query string or fragment. This exists so
+// ephemeral stack environments (https://<app>-<tag>.stacks.footstrike.run)
+// can complete OAuth without per-stack registration.
+func redirectURIAllowed(registered []string, candidate string) bool {
+	if slices.Contains(registered, candidate) {
+		return true
+	}
+	cand, err := url.Parse(candidate)
+	if err != nil {
+		return false
+	}
+	return slices.ContainsFunc(registered, func(entry string) bool {
+		return wildcardRedirectMatch(entry, cand)
+	})
+}
+
+func wildcardRedirectMatch(entry string, cand *url.URL) bool {
+	pat, err := url.Parse(entry)
+	if err != nil || pat.Scheme != "https" || !strings.HasPrefix(pat.Host, "*.") {
+		return false
+	}
+	if cand.Scheme != "https" || cand.Path != pat.Path || cand.Port() != pat.Port() {
+		return false
+	}
+	if cand.RawQuery != "" || cand.Fragment != "" {
+		return false
+	}
+	dotSuffix := "." + strings.ToLower(strings.TrimPrefix(pat.Hostname(), "*."))
+	candHost := strings.ToLower(cand.Hostname())
+	label, ok := strings.CutSuffix(candHost, dotSuffix)
+	return ok && label != "" && !strings.ContainsAny(label, ".*")
+}

--- a/pkg/httpserver/redirect_match_test.go
+++ b/pkg/httpserver/redirect_match_test.go
@@ -30,6 +30,12 @@ func TestRedirectURIAllowed(t *testing.T) {
 		{"mid-label wildcard entry matches nothing", []string{"https://api-*.stacks.footstrike.run/auth/callback"}, "https://api-x.stacks.footstrike.run/auth/callback", false},
 		{"literal wildcard candidate passes only via the exact branch", []string{wild}, "https://*.stacks.footstrike.run/auth/callback", true},
 		{"empty registered list rejects", nil, exact, false},
+		{"wildcard rejects fullwidth-dot host", []string{wild}, "https://a\uFF0Eb.stacks.footstrike.run/auth/callback", false},
+		{"wildcard rejects Kelvin-sign host", []string{wild}, "https://evil.stacks.footstri\u212Ae.run/auth/callback", false},
+		{"wildcard rejects userinfo candidate", []string{wild}, "https://evil.com@x.stacks.footstrike.run/auth/callback", false},
+		{"wildcard rejects percent-encoded path", []string{wild}, "https://x.stacks.footstrike.run/auth%2Fcallback", false},
+		{"wildcard rejects trailing-dot FQDN", []string{wild}, "https://x.stacks.footstrike.run./auth/callback", false},
+		{"wildcard rejects explicit port vs portless pattern", []string{wild}, "https://x.stacks.footstrike.run:443/auth/callback", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/httpserver/redirect_match_test.go
+++ b/pkg/httpserver/redirect_match_test.go
@@ -1,0 +1,41 @@
+package httpserver
+
+import "testing"
+
+func TestRedirectURIAllowed(t *testing.T) {
+	wild := "https://*.stacks.footstrike.run/auth/callback"
+	exact := "https://staging.footstrike.run/auth/callback"
+
+	tests := []struct {
+		name       string
+		registered []string
+		candidate  string
+		want       bool
+	}{
+		{"exact match still works", []string{exact}, exact, true},
+		{"unregistered candidate rejected", []string{exact}, "https://evil.example.com/auth/callback", false},
+		{"wildcard matches single label", []string{wild}, "https://hae-cadence.stacks.footstrike.run/auth/callback", true},
+		{"wildcard alongside exact entries", []string{exact, wild}, "https://api-x.stacks.footstrike.run/auth/callback", true},
+		{"wildcard rejects multi-label", []string{wild}, "https://a.b.stacks.footstrike.run/auth/callback", false},
+		{"wildcard rejects bare suffix", []string{wild}, "https://stacks.footstrike.run/auth/callback", false},
+		{"wildcard rejects empty label", []string{wild}, "https://.stacks.footstrike.run/auth/callback", false},
+		{"wildcard rejects cousin domain", []string{wild}, "https://xstacks.footstrike.run/auth/callback", false},
+		{"wildcard rejects wrong path", []string{wild}, "https://x.stacks.footstrike.run/other", false},
+		{"wildcard rejects http candidate", []string{wild}, "http://x.stacks.footstrike.run/auth/callback", false},
+		{"http wildcard entry matches nothing", []string{"http://*.stacks.footstrike.run/auth/callback"}, "http://x.stacks.footstrike.run/auth/callback", false},
+		{"wildcard rejects query string", []string{wild}, "https://x.stacks.footstrike.run/auth/callback?a=b", false},
+		{"wildcard rejects fragment", []string{wild}, "https://x.stacks.footstrike.run/auth/callback#f", false},
+		{"wildcard rejects explicit port mismatch", []string{wild}, "https://x.stacks.footstrike.run:8443/auth/callback", false},
+		{"host match is case-insensitive", []string{wild}, "https://X.Stacks.Footstrike.Run/auth/callback", true},
+		{"mid-label wildcard entry matches nothing", []string{"https://api-*.stacks.footstrike.run/auth/callback"}, "https://api-x.stacks.footstrike.run/auth/callback", false},
+		{"literal wildcard candidate passes only via the exact branch", []string{wild}, "https://*.stacks.footstrike.run/auth/callback", true},
+		{"empty registered list rejects", nil, exact, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redirectURIAllowed(tt.registered, tt.candidate); got != tt.want {
+				t.Errorf("redirectURIAllowed(%v, %q) = %v, want %v", tt.registered, tt.candidate, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/httpserver/redirect_match_test.go
+++ b/pkg/httpserver/redirect_match_test.go
@@ -3,7 +3,7 @@ package httpserver
 import "testing"
 
 func TestRedirectURIAllowed(t *testing.T) {
-	wild := "https://*.stacks.footstrike.run/auth/callback"
+	wild := "https://*.preview.footstrike.run/auth/callback"
 	exact := "https://staging.footstrike.run/auth/callback"
 
 	tests := []struct {
@@ -14,28 +14,28 @@ func TestRedirectURIAllowed(t *testing.T) {
 	}{
 		{"exact match still works", []string{exact}, exact, true},
 		{"unregistered candidate rejected", []string{exact}, "https://evil.example.com/auth/callback", false},
-		{"wildcard matches single label", []string{wild}, "https://hae-cadence.stacks.footstrike.run/auth/callback", true},
-		{"wildcard alongside exact entries", []string{exact, wild}, "https://api-x.stacks.footstrike.run/auth/callback", true},
-		{"wildcard rejects multi-label", []string{wild}, "https://a.b.stacks.footstrike.run/auth/callback", false},
-		{"wildcard rejects bare suffix", []string{wild}, "https://stacks.footstrike.run/auth/callback", false},
-		{"wildcard rejects empty label", []string{wild}, "https://.stacks.footstrike.run/auth/callback", false},
-		{"wildcard rejects cousin domain", []string{wild}, "https://xstacks.footstrike.run/auth/callback", false},
-		{"wildcard rejects wrong path", []string{wild}, "https://x.stacks.footstrike.run/other", false},
-		{"wildcard rejects http candidate", []string{wild}, "http://x.stacks.footstrike.run/auth/callback", false},
-		{"http wildcard entry matches nothing", []string{"http://*.stacks.footstrike.run/auth/callback"}, "http://x.stacks.footstrike.run/auth/callback", false},
-		{"wildcard rejects query string", []string{wild}, "https://x.stacks.footstrike.run/auth/callback?a=b", false},
-		{"wildcard rejects fragment", []string{wild}, "https://x.stacks.footstrike.run/auth/callback#f", false},
-		{"wildcard rejects explicit port mismatch", []string{wild}, "https://x.stacks.footstrike.run:8443/auth/callback", false},
-		{"host match is case-insensitive", []string{wild}, "https://X.Stacks.Footstrike.Run/auth/callback", true},
-		{"mid-label wildcard entry matches nothing", []string{"https://api-*.stacks.footstrike.run/auth/callback"}, "https://api-x.stacks.footstrike.run/auth/callback", false},
-		{"literal wildcard candidate passes only via the exact branch", []string{wild}, "https://*.stacks.footstrike.run/auth/callback", true},
+		{"wildcard matches single label", []string{wild}, "https://hae-cadence.preview.footstrike.run/auth/callback", true},
+		{"wildcard alongside exact entries", []string{exact, wild}, "https://api-x.preview.footstrike.run/auth/callback", true},
+		{"wildcard rejects multi-label", []string{wild}, "https://a.b.preview.footstrike.run/auth/callback", false},
+		{"wildcard rejects bare suffix", []string{wild}, "https://preview.footstrike.run/auth/callback", false},
+		{"wildcard rejects empty label", []string{wild}, "https://.preview.footstrike.run/auth/callback", false},
+		{"wildcard rejects cousin domain", []string{wild}, "https://xpreview.footstrike.run/auth/callback", false},
+		{"wildcard rejects wrong path", []string{wild}, "https://x.preview.footstrike.run/other", false},
+		{"wildcard rejects http candidate", []string{wild}, "http://x.preview.footstrike.run/auth/callback", false},
+		{"http wildcard entry matches nothing", []string{"http://*.preview.footstrike.run/auth/callback"}, "http://x.preview.footstrike.run/auth/callback", false},
+		{"wildcard rejects query string", []string{wild}, "https://x.preview.footstrike.run/auth/callback?a=b", false},
+		{"wildcard rejects fragment", []string{wild}, "https://x.preview.footstrike.run/auth/callback#f", false},
+		{"wildcard rejects explicit port mismatch", []string{wild}, "https://x.preview.footstrike.run:8443/auth/callback", false},
+		{"host match is case-insensitive", []string{wild}, "https://X.Preview.Footstrike.Run/auth/callback", true},
+		{"mid-label wildcard entry matches nothing", []string{"https://api-*.preview.footstrike.run/auth/callback"}, "https://api-x.preview.footstrike.run/auth/callback", false},
+		{"literal wildcard candidate passes only via the exact branch", []string{wild}, "https://*.preview.footstrike.run/auth/callback", true},
 		{"empty registered list rejects", nil, exact, false},
-		{"wildcard rejects fullwidth-dot host", []string{wild}, "https://a\uFF0Eb.stacks.footstrike.run/auth/callback", false},
-		{"wildcard rejects Kelvin-sign host", []string{wild}, "https://evil.stacks.footstri\u212Ae.run/auth/callback", false},
-		{"wildcard rejects userinfo candidate", []string{wild}, "https://evil.com@x.stacks.footstrike.run/auth/callback", false},
-		{"wildcard rejects percent-encoded path", []string{wild}, "https://x.stacks.footstrike.run/auth%2Fcallback", false},
-		{"wildcard rejects trailing-dot FQDN", []string{wild}, "https://x.stacks.footstrike.run./auth/callback", false},
-		{"wildcard rejects explicit port vs portless pattern", []string{wild}, "https://x.stacks.footstrike.run:443/auth/callback", false},
+		{"wildcard rejects fullwidth-dot host", []string{wild}, "https://a\uFF0Eb.preview.footstrike.run/auth/callback", false},
+		{"wildcard rejects Kelvin-sign host", []string{wild}, "https://evil.preview.footstri\u212Ae.run/auth/callback", false},
+		{"wildcard rejects userinfo candidate", []string{wild}, "https://evil.com@x.preview.footstrike.run/auth/callback", false},
+		{"wildcard rejects percent-encoded path", []string{wild}, "https://x.preview.footstrike.run/auth%2Fcallback", false},
+		{"wildcard rejects trailing-dot FQDN", []string{wild}, "https://x.preview.footstrike.run./auth/callback", false},
+		{"wildcard rejects explicit port vs portless pattern", []string{wild}, "https://x.preview.footstrike.run:443/auth/callback", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What

Registered redirect URIs whose host begins with `*.` (e.g. `https://*.preview.footstrike.run/auth/callback`) now authorize callbacks to any **single-label** https subdomain of that suffix. All other registered entries keep byte-for-byte exact matching, checked first — existing clients are unaffected, and no schema change is needed: a client is "preview-eligible" simply by having a wildcard entry registered (admin-only, via identity-cli).

## Why

First step of the preview-environments design (`bifrost/docs/superpowers/specs/2026-07-26-preview-environments-design.md`): ephemeral per-branch deployments at `https://<app>-<tag>.preview.footstrike.run` need to complete OAuth without per-preview registration. Plan: `docs/superpowers/plans/2026-07-26-preview-wildcard-redirects.md`.

## Matching rules (wildcard entries only)

- https on both sides; exactly one non-empty DNS label replaces the `*`
- identical path (escaped-form comparison per RFC 6749 §3.1.2.2) and port; no query/fragment; no userinfo
- hosts validated as ASCII `[a-z0-9.-]` with ASCII-only case folding — rejects fullwidth-dot (U+FF0E) multi-label smuggling and Unicode-folding lookalikes (e.g. U+212A)
- a `*` anywhere else in an entry matches nothing

The token endpoint is untouched: it still requires the exact concrete URI stored with the authorization code.

## Testing

- 24-case table test for `redirectURIAllowed` covering every rule above plus pinned edge cases (trailing-dot FQDN, explicit `:443`, percent-encoded paths, cousin domains)
- Full suite + `go vet` green; adversarial security review of the branch (open-redirect shapes: sub-subdomain, userinfo, IDN/punycode, path traversal, scheme confusion, IP literals) came back clean

Deliberately deferred to the preview wiring plan: `post_logout_redirect_uri` remains exact-match; redirect-URI breadth validation in identity-cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)