### PR TITLE
Add cloudbuild-preview.yaml

### DIFF
--- a/cloudbuild-preview.yaml
+++ b/cloudbuild-preview.yaml
@@ -1,0 +1,20 @@
+steps:
+  # Same buildx pattern as cloudbuild.yaml, but read-only on the shared
+  # registry cache: --cache-from without --cache-to, so preview branches get
+  # warm layers without polluting the cache mainline builds rely on. The
+  # preview-{sha} tag fails the ImageUpdater allowTags regexp
+  # (^[a-f0-9]{7,}$), so preview builds never auto-deploy to staging.
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        docker buildx create --use --driver docker-container
+        docker buildx build \
+          --cache-from type=registry,ref=us-central1-docker.pkg.dev/ethans-services/containers/identity:buildcache \
+          -t us-central1-docker.pkg.dev/ethans-services/containers/identity:preview-$SHORT_SHA \
+          --push \
+          .
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
Manual-trigger preview builds: buildx with read-only registry cache, preview-{sha} tags that image-updater ignores. Part of the preview-environments effort (spec in bifrost repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)