### PR TITLE
Validate wildcard redirect URIs in identity-cli

### DIFF
--- a/cmd/identity-cli/cmd/client_create.go
+++ b/cmd/identity-cli/cmd/client_create.go
@@ -50,6 +50,11 @@ func runClientCreate(cmd *cobra.Command, args []string) error {
 	redirectURIList := internal.ParseList(createRedirectURIs)
 	scopeList := internal.ParseList(createAllowedScopes)
 
+	// Validate redirect URIs
+	if err := internal.ValidateRedirectURIs(redirectURIList); err != nil {
+		return err
+	}
+
 	// Get shared datastore
 	datastore := getDatastore()
 

--- a/cmd/identity-cli/cmd/client_update.go
+++ b/cmd/identity-cli/cmd/client_update.go
@@ -121,6 +121,13 @@ func runClientUpdate(cmd *cobra.Command, args []string) error {
 		return errors.New("cannot make a public client confidential - secret generation not yet supported in update")
 	}
 
+	// Validate redirect URIs if they were modified
+	if redirectURIsSet || addRedirectURIsSet {
+		if err := internal.ValidateRedirectURIs(params.RedirectUris); err != nil {
+			return err
+		}
+	}
+
 	updatedClient, err := datastore.Q.UpdateOAuthClient(ctx, params)
 	if err != nil {
 		return fmt.Errorf("failed to update OAuth client: %w", err)

--- a/cmd/identity-cli/internal/validate.go
+++ b/cmd/identity-cli/internal/validate.go
@@ -1,0 +1,48 @@
+package internal
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// ValidateRedirectURIs rejects malformed wildcard redirect entries before
+// they reach the database. Only entries containing "*" are validated —
+// non-wildcard URIs (including localhost/http dev entries) pass through
+// untouched, matching the server's runtime behavior where exact-match
+// entries are compared byte-for-byte. The rules mirror
+// pkg/httpserver/redirect_match.go: https only, "*." as the entire leftmost
+// label, a real path, no query/fragment — plus a breadth guard: the suffix
+// after "*." must contain at least two dots (e.g. preview.footstrike.run),
+// so an operator can't accidentally register https://*.run/....
+func ValidateRedirectURIs(uris []string) error {
+	for _, raw := range uris {
+		if !strings.Contains(raw, "*") {
+			continue
+		}
+		if strings.Count(raw, "*") != 1 {
+			return fmt.Errorf("redirect URI %q: multiple wildcards", raw)
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			return fmt.Errorf("redirect URI %q: %w", raw, err)
+		}
+		if u.Scheme != "https" {
+			return fmt.Errorf("redirect URI %q: wildcard entries must be https", raw)
+		}
+		suffix, ok := strings.CutPrefix(u.Host, "*.")
+		if !ok || strings.Contains(suffix, "*") {
+			return fmt.Errorf("redirect URI %q: wildcard must be the entire leftmost host label (\"*.suffix\")", raw)
+		}
+		if strings.Count(suffix, ".") < 2 {
+			return fmt.Errorf("redirect URI %q: wildcard suffix %q too broad — needs at least two dots", raw, suffix)
+		}
+		if u.Path == "" || u.Path == "/" {
+			return fmt.Errorf("redirect URI %q: wildcard entries must include the full callback path", raw)
+		}
+		if u.RawQuery != "" || u.Fragment != "" {
+			return fmt.Errorf("redirect URI %q: wildcard entries must not carry a query or fragment", raw)
+		}
+	}
+	return nil
+}

--- a/cmd/identity-cli/internal/validate_test.go
+++ b/cmd/identity-cli/internal/validate_test.go
@@ -1,0 +1,30 @@
+package internal
+
+import "testing"
+
+func TestValidateRedirectURIs(t *testing.T) {
+	cases := []struct {
+		name    string
+		uris    []string
+		wantErr bool
+	}{
+		{"non-wildcard URIs pass untouched", []string{"http://localhost:5173/oauth/callback", "https://footstrike.run/oauth/callback", "not-even-a-url"}, false},
+		{"valid preview wildcard", []string{"https://*.preview.footstrike.run/oauth/callback"}, false},
+		{"wildcard suffix too broad (one dot)", []string{"https://*.run/oauth/callback"}, true},
+		{"wildcard must be whole leftmost label", []string{"https://api-*.preview.footstrike.run/oauth/callback"}, true},
+		{"two wildcards rejected", []string{"https://*.*.footstrike.run/oauth/callback"}, true},
+		{"http wildcard rejected", []string{"http://*.preview.footstrike.run/oauth/callback"}, true},
+		{"wildcard without path rejected", []string{"https://*.preview.footstrike.run"}, true},
+		{"wildcard with query rejected", []string{"https://*.preview.footstrike.run/cb?x=1"}, true},
+		{"wildcard with fragment rejected", []string{"https://*.preview.footstrike.run/cb#f"}, true},
+		{"mixed list validates only wildcards", []string{"https://staging.footstrike.run/oauth/callback", "https://*.preview.footstrike.run/oauth/callback"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateRedirectURIs(tc.uris)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("ValidateRedirectURIs(%v) error = %v, wantErr %v", tc.uris, err, tc.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Structural guard for wildcard redirect entries (https, whole-label *, ≥2-dot suffix, full path, no query/fragment) before they reach the DB. Non-wildcard URIs untouched. Deferred item from the preview-environments plan 1 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)