### PR TITLE
Add a `migrate` subcommand to auth-service

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -50,8 +50,8 @@ jobs:
 
       # Integration tests are gated behind the `integration` build tag. They use
       # testcontainers to spin up Postgres/MinIO, which relies on the Docker
-      # daemon available on GitHub-hosted ubuntu runners. Scoped to the package
-      # that holds them and to the suite entrypoints so the untagged unit tests
-      # (already run above) aren't rebuilt and re-run a second time.
+      # daemon available on GitHub-hosted ubuntu runners. Scoped to the packages
+      # that hold them and to the suite/test entrypoints so the untagged unit
+      # tests (already run above) aren't rebuilt and re-run a second time.
       - name: Run integration tests
-        run: go test -v -tags integration -timeout 600s -run 'TestOAuthFlowSuite|TestAvatarFlowSuite' ./pkg/httpserver/
+        run: go test -v -tags integration -timeout 600s -run 'TestOAuthFlowSuite|TestAvatarFlowSuite|TestUpAgainstPostgres' ./pkg/httpserver/ ./db/migrations/

--- a/README.md
+++ b/README.md
@@ -150,6 +150,48 @@ Regenerate sqlc queries and types.
 make sqlc
 ```
 
+## Migrations
+
+Migrations live in `db/migrations` as `{version}_{name}.{up,down}.sql` and are applied
+with [golang-migrate](https://github.com/golang-migrate/migrate).
+
+**The server never migrates on startup.** `db/migrations/embed.go` embeds the up
+migrations so the binary knows the schema version it was built for, and startup calls
+`migrations.Verify`, which refuses to start — naming the version mismatch — if the
+database is not at exactly that version. A forgotten `make migrate-up` fails fast
+instead of silently serving against a schema the code doesn't expect. Applying
+migrations is always a deliberate, separate step:
+
+- **By hand**, with the `migrate` CLI via the Makefile — the usual local and
+  staging/prod path:
+  ```shell
+  DATABASE_URL="postgresql://..." make migrate-up
+  ```
+- **From the binary**, with the `migrate` subcommand:
+  ```shell
+  DATABASE_URL="postgresql://..." ./identity migrate   # `auth-service migrate` in the image
+  ```
+  It applies every pending up migration and exits 0; a database already at the latest
+  version is a success, not an error. The migrations are embedded, so this needs no
+  `.sql` files on disk and no `migrate` CLI — just the binary and a database. It reads
+  `DATABASE_URL` and nothing else, so the serving config (`JWT_PRIVATE_KEY` and friends)
+  is irrelevant to it.
+
+Running the binary with **no arguments serves**, exactly as it always has. The prod and
+staging Deployments (`k8s/`) run it bare and never invoke `migrate`, so a missed
+migration still fails closed there.
+
+The subcommand exists for **preview environments**. A preview gets its own Neon database
+branch cut from staging's schema, so a branch that adds a migration would otherwise start
+against a schema that's behind and `Verify` would (correctly) refuse to start. bifrost's
+service registry runs a preview's migrations by injecting a `migrate` initContainer that
+runs the same image with the same env — so `DATABASE_URL` already points at that
+preview's own branch — to completion before the app container starts:
+
+```yaml
+migrate: ["/app/auth-service", "migrate"]
+```
+
 ## OAuth Client Management
 
 ### Adding a New Client

--- a/cmd/auth-service/main.go
+++ b/cmd/auth-service/main.go
@@ -12,6 +12,7 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 
@@ -24,7 +25,64 @@ import (
 )
 
 func main() {
+	// Subcommand dispatch. `auth-service` with no arguments serves, exactly as
+	// it always has: that is what the prod and staging Deployments run, and
+	// they pass no arguments, so this switch is never entered for them. The one
+	// subcommand has to be asked for explicitly and never runs as part of
+	// starting the server.
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "migrate":
+			if len(os.Args) > 2 {
+				log.Fatalf("Unexpected arguments after `migrate`: %v", os.Args[2:])
+			}
+			runMigrate()
+			return
+		default:
+			log.Fatalf("Unknown command %q (supported: migrate); run with no arguments to start the server", os.Args[1])
+		}
+	}
 
+	serve()
+}
+
+// runMigrate is the entrypoint for `auth-service migrate`. It applies all
+// pending migrations to DATABASE_URL and returns, so the process exits 0.
+//
+// This exists for preview environments: each preview gets its own database
+// branch cut from staging's schema, and bifrost runs this binary as a migrate
+// initContainer — same image, same env, so DATABASE_URL already points at the
+// preview's own branch — to completion before the app container starts.
+// Applying migrations is still a deliberate, separate step: startup does not
+// call this, and prod/staging never invoke it.
+//
+// It reads DATABASE_URL straight from the environment rather than through
+// config.NewFromEnv: applying migrations needs nothing but a database, and an
+// unrelated missing or malformed serving variable (JWT_PRIVATE_KEY, say) should
+// not be able to block a migration.
+func runMigrate() {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		log.Fatal("Migration failed: DATABASE_URL is not set")
+	}
+
+	latest, err := migrations.LatestVersion()
+	if err != nil {
+		log.Fatalf("Migration failed: %v", err)
+	}
+
+	log.Printf("Applying migrations up to version %d", latest)
+	if err := migrations.Up(databaseURL); err != nil {
+		log.Fatalf("Migration failed: %v", err)
+	}
+	// Reached whether migrations were applied or the database was already at
+	// the latest version; both are a success.
+	log.Printf("Database schema is at migration version %d", latest)
+}
+
+// serve is the default path: the whole of what `auth-service` did, and does,
+// when invoked with no arguments.
+func serve() {
 	cfg := config.NewFromEnv()
 	datastore, err := store.New(cfg.DatabaseURL)
 	if err != nil {

--- a/cmd/auth-service/main_test.go
+++ b/cmd/auth-service/main_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests build the real binary and run it, because the thing under test is
+// argv handling in main() — which of the two paths a given command line takes.
+// Both paths are pointed at an unreachable database so neither can do anything;
+// what each assertion looks for is the log line that only one path can produce:
+//
+//	serve path   -> "Failed to create datastore" (config, then store.New)
+//	migrate path -> "Applying migrations up to version"
+//
+// The k8s Deployments run the binary bare, so the bare case is the one that
+// must not drift.
+
+const testJWTPrivateKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEICQMNHONu2Sud2tu6jgOZs3LIj5yOZr89NBMLYiyqBK/oAoGCCqGSM49
+AwEHoUQDQgAERCHWHrX20emk31HypGNgptwBjdZOyBybV/9BLTbJPj8UsZ/46ri5
+/eFKkRfNApxFU/5lk1RGQJqt8t0GvkkJdw==
+-----END EC PRIVATE KEY-----`
+
+const (
+	serveMarker   = "Failed to create datastore"
+	migrateMarker = "Applying migrations up to version"
+)
+
+// buildAuthService compiles this package into a temporary binary.
+func buildAuthService(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "auth-service")
+	out, err := exec.Command("go", "build", "-o", bin, ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// unreachableDatabaseURL returns a Postgres URL pointing at a local port that
+// was just closed, so connecting fails immediately rather than hanging.
+func unreachableDatabaseURL(t *testing.T) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserving a closed port: %v", err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatalf("closing reserved port: %v", err)
+	}
+	return "postgres://identity:identity@" + addr + "/identity?sslmode=disable&connect_timeout=2"
+}
+
+// runAuthService runs the built binary with a fully explicit environment (so
+// nothing leaks in from the developer's shell) and an empty working directory
+// (so no .env file is picked up), and returns its combined output.
+func runAuthService(t *testing.T, bin string, args ...string) (string, error) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = t.TempDir()
+	cmd.Env = []string{
+		"HTTP_ADDRESS=:8080",
+		"DATABASE_URL=" + unreachableDatabaseURL(t),
+		"JWT_PRIVATE_KEY=" + testJWTPrivateKey,
+		"JWT_ISSUER=http://localhost:8080",
+		"PATH=" + os.Getenv("PATH"),
+	}
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// TestBareInvocationTakesServePath is the regression guard for the default
+// behavior: adding subcommand handling must not change what happens when the
+// binary is run with no arguments, which is how prod and staging run it.
+func TestBareInvocationTakesServePath(t *testing.T) {
+	out, err := runAuthService(t, buildAuthService(t))
+	if err == nil {
+		t.Fatalf("expected a nonzero exit against an unreachable database, got success\n%s", out)
+	}
+	if !strings.Contains(out, serveMarker) {
+		t.Errorf("bare invocation did not take the serve path; want output containing %q, got:\n%s", serveMarker, out)
+	}
+	if strings.Contains(out, migrateMarker) {
+		t.Errorf("bare invocation must never apply migrations, but output contains %q:\n%s", migrateMarker, out)
+	}
+}
+
+// TestMigrateSubcommandTakesMigratePath confirms `migrate` runs the migration
+// runner and nothing else — in particular it never starts the server.
+func TestMigrateSubcommandTakesMigratePath(t *testing.T) {
+	out, err := runAuthService(t, buildAuthService(t), "migrate")
+	if err == nil {
+		t.Fatalf("expected a nonzero exit against an unreachable database, got success\n%s", out)
+	}
+	if !strings.Contains(out, migrateMarker) {
+		t.Errorf("`migrate` did not take the migrate path; want output containing %q, got:\n%s", migrateMarker, out)
+	}
+	if !strings.Contains(out, "Migration failed") {
+		t.Errorf("`migrate` should report a clear failure against an unreachable database, got:\n%s", out)
+	}
+	if strings.Contains(out, serveMarker) {
+		t.Errorf("`migrate` must not fall through to the serve path, but output contains %q:\n%s", serveMarker, out)
+	}
+}
+
+// TestUnknownArgumentsFail keeps a typo or a stale argument from silently
+// starting the server (or silently doing nothing) instead of being reported.
+func TestUnknownArgumentsFail(t *testing.T) {
+	bin := buildAuthService(t)
+
+	for name, tc := range map[string]struct {
+		args []string
+		want string
+	}{
+		"unknown subcommand":       {args: []string{"serve"}, want: "Unknown command"},
+		"extra args after migrate": {args: []string{"migrate", "--all"}, want: "Unexpected arguments"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out, err := runAuthService(t, bin, tc.args...)
+			if err == nil {
+				t.Fatalf("expected a nonzero exit for %v, got success\n%s", tc.args, out)
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("want output containing %q, got:\n%s", tc.want, out)
+			}
+			if strings.Contains(out, serveMarker) || strings.Contains(out, migrateMarker) {
+				t.Errorf("%v should be rejected, not run, got:\n%s", tc.args, out)
+			}
+		})
+	}
+}

--- a/db/migrations/apply.go
+++ b/db/migrations/apply.go
@@ -1,0 +1,59 @@
+package migrations
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/golang-migrate/migrate/v4"
+	// Registers the "postgres"/"postgresql" schemes with golang-migrate so
+	// NewWithSourceInstance can open a DATABASE_URL of either form.
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+)
+
+// Up applies every pending up migration to the database at databaseURL.
+//
+// Nothing calls this implicitly. It runs only when someone explicitly asks for
+// it via `auth-service migrate` (see cmd/auth-service/main.go) — a human, or
+// the migrate initContainer of a preview environment that needs this branch's
+// migrations applied to its own database branch. Startup is unchanged: it still
+// calls Verify, still applies nothing, and still refuses to serve against a
+// schema this build doesn't expect. The prod and staging Deployments run the
+// binary bare and never reach this function, so a forgotten `make migrate-up`
+// still fails closed there exactly as it did before. See the package comment.
+//
+// Migrations are read out of the embedded FS through golang-migrate's iofs
+// source, so the binary carries its own migrations and needs no files on disk.
+// Embedding only *.up.sql is sufficient: iofs indexes a version as soon as it
+// sees a file for either direction, and the up path only ever calls ReadUp.
+//
+// A database already at the latest version is a success, not a failure.
+// golang-migrate reports that case as ErrNoChange, and the preview
+// initContainer runs on *every* pod start — treating "nothing to do" as an
+// error would break every restart of an already-migrated preview.
+func Up(databaseURL string) error {
+	src, err := iofs.New(upFiles, ".")
+	if err != nil {
+		return fmt.Errorf("reading embedded migrations: %w", err)
+	}
+
+	m, err := migrate.NewWithSourceInstance("iofs", src, databaseURL)
+	if err != nil {
+		return fmt.Errorf("opening database for migration: %w", err)
+	}
+	defer func() {
+		// Teardown problems are logged, not returned: by this point the
+		// migration has already succeeded or failed on its own terms, and
+		// failing the process over a connection close would fail the preview
+		// initContainer for nothing.
+		if srcErr, dbErr := m.Close(); srcErr != nil || dbErr != nil {
+			log.Printf("warning: closing migration source/database (source=%v, database=%v)", srcErr, dbErr)
+		}
+	}()
+
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("applying migrations: %w", err)
+	}
+	return nil
+}

--- a/db/migrations/apply_integration_test.go
+++ b/db/migrations/apply_integration_test.go
@@ -1,0 +1,69 @@
+//go:build integration
+
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go/modules/postgres"
+)
+
+// TestUpAgainstPostgres exercises the `auth-service migrate` runner against a
+// real Postgres, standing in for a preview environment's freshly-branched
+// database. The subtests share one container and run in order: the first
+// migrates an unmigrated database, the second re-runs against the now
+// up-to-date database the way the initContainer does on every pod restart.
+func TestUpAgainstPostgres(t *testing.T) {
+	ctx := context.Background()
+
+	pgContainer, err := postgres.Run(
+		ctx,
+		"postgres:17",
+		postgres.WithDatabase("identity"),
+		postgres.WithUsername("postgres"),
+		postgres.WithPassword("postgres"),
+		postgres.BasicWaitStrategies(),
+		postgres.WithSQLDriver("pgx"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = pgContainer.Terminate(context.Background()) })
+
+	databaseURL, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+	require.NoError(t, err)
+
+	conn, err := sql.Open("pgx", databaseURL)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	latest, err := LatestVersion()
+	require.NoError(t, err)
+
+	// Precondition: an unmigrated database is exactly what the startup check
+	// refuses to serve against, which is why the subcommand has to exist.
+	require.Error(t, Verify(ctx, conn), "startup check should reject an unmigrated database")
+
+	t.Run("applies pending migrations", func(t *testing.T) {
+		require.NoError(t, Up(databaseURL))
+
+		var version int
+		var dirty bool
+		require.NoError(t, conn.QueryRowContext(ctx, "SELECT version, dirty FROM schema_migrations").Scan(&version, &dirty))
+		require.Equal(t, latest, version, "database should be at the version this build embeds")
+		require.False(t, dirty)
+
+		// The real postcondition: the schema the service refused to start
+		// against a moment ago now passes the same check.
+		require.NoError(t, Verify(ctx, conn), "startup check should pass after migrating")
+	})
+
+	t.Run("already at latest is a success", func(t *testing.T) {
+		require.NoError(t, Up(databaseURL),
+			"re-running against an up-to-date database must succeed: golang-migrate reports ErrNoChange, "+
+				"and the preview initContainer runs on every pod start")
+		require.NoError(t, Verify(ctx, conn))
+	})
+}

--- a/db/migrations/embed.go
+++ b/db/migrations/embed.go
@@ -2,11 +2,19 @@
 // provides a fail-closed startup check (Verify) that the database schema
 // matches the migrations this binary was built with.
 //
-// It deliberately does NOT apply migrations. The goal is to refuse to start —
-// with a clear, actionable error — when code is deployed without running
-// `make migrate-up`, rather than silently serving against a schema the code
-// doesn't expect (which is how a forgotten migration once broke client-secret
-// auth). Applying migrations remains a deliberate, separate step.
+// Startup deliberately does NOT apply migrations. The goal is to refuse to
+// start — with a clear, actionable error — when code is deployed without
+// running `make migrate-up`, rather than silently serving against a schema the
+// code doesn't expect (which is how a forgotten migration once broke
+// client-secret auth). Applying migrations remains a deliberate, separate step.
+//
+// That property is intact. The package does expose Up (see apply.go), but
+// nothing calls it implicitly: it runs only when someone explicitly invokes
+// `auth-service migrate`, which the prod and staging Deployments never do (they
+// run the binary bare, and bare invocation still goes straight to Verify and
+// serve). Up exists so a preview environment, whose database branch is cut from
+// staging's schema, can apply its own branch's migrations from an
+// initContainer before the app container starts.
 package migrations
 
 import (
@@ -30,7 +38,15 @@ var upFiles embed.FS
 // i.e. the numeric prefix of the newest *.up.sql file (e.g. 11 for
 // 000011_add_mfa_enrollment_pending.up.sql).
 func LatestVersion() (int, error) {
-	entries, err := fs.ReadDir(upFiles, ".")
+	return latestVersionIn(upFiles)
+}
+
+// latestVersionIn is LatestVersion's scan, taking the filesystem as a parameter
+// so a test can confirm the result depends only on the version prefixes and not
+// on which files the embed happens to match — widening the embed to include the
+// *.down.sql files would not change the answer.
+func latestVersionIn(fsys fs.FS) (int, error) {
+	entries, err := fs.ReadDir(fsys, ".")
 	if err != nil {
 		return 0, fmt.Errorf("reading embedded migrations: %w", err)
 	}

--- a/db/migrations/embed_test.go
+++ b/db/migrations/embed_test.go
@@ -1,6 +1,14 @@
 package migrations
 
-import "testing"
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+)
 
 func TestLatestVersion(t *testing.T) {
 	v, err := LatestVersion()
@@ -12,5 +20,102 @@ func TestLatestVersion(t *testing.T) {
 	// "up to date").
 	if v < 11 {
 		t.Errorf("LatestVersion() = %d, want >= 11 (embed matched too few files?)", v)
+	}
+}
+
+// TestLatestVersionIgnoresDownMigrations pins that the startup check's notion
+// of "latest" is decided by version prefixes alone. The embed matches only
+// *.up.sql today; if it is ever widened (e.g. to *.sql, which would pull in the
+// eleven *.down.sql files sitting in the same directory), LatestVersion — and
+// therefore Verify, which compares against it — must return exactly the same
+// number.
+func TestLatestVersionIgnoresDownMigrations(t *testing.T) {
+	upOnly := fstest.MapFS{
+		"000001_init.up.sql":         {},
+		"000002_add_audience.up.sql": {},
+	}
+	withDowns := fstest.MapFS{
+		"000001_init.up.sql":           {},
+		"000001_init.down.sql":         {},
+		"000002_add_audience.up.sql":   {},
+		"000002_add_audience.down.sql": {},
+	}
+
+	upOnlyVersion, err := latestVersionIn(upOnly)
+	if err != nil {
+		t.Fatalf("latestVersionIn(up-only) error: %v", err)
+	}
+	withDownsVersion, err := latestVersionIn(withDowns)
+	if err != nil {
+		t.Fatalf("latestVersionIn(with downs) error: %v", err)
+	}
+	if upOnlyVersion != 2 {
+		t.Errorf("latestVersionIn(up-only) = %d, want 2", upOnlyVersion)
+	}
+	if withDownsVersion != upOnlyVersion {
+		t.Errorf("latestVersionIn(with downs) = %d, want %d (down files must not change the answer)",
+			withDownsVersion, upOnlyVersion)
+	}
+}
+
+// TestEmbeddedSourceEnumeratesEveryVersion checks what golang-migrate's iofs
+// source actually sees in the embedded FS, which is what Up walks to decide
+// which migrations to apply. It enumerates 1..LatestVersion contiguously and
+// can read the body of each — with only *.up.sql embedded, which is what
+// answers the "do we also need to embed the down files?" question: iofs indexes
+// a version from a file in either direction, and the up path only ever calls
+// ReadUp, so up-only is enough.
+func TestEmbeddedSourceEnumeratesEveryVersion(t *testing.T) {
+	latest, err := LatestVersion()
+	if err != nil {
+		t.Fatalf("LatestVersion() error: %v", err)
+	}
+
+	src, err := iofs.New(upFiles, ".")
+	if err != nil {
+		t.Fatalf("iofs.New over embedded migrations: %v", err)
+	}
+	defer src.Close()
+
+	version, err := src.First()
+	if err != nil {
+		t.Fatalf("First(): %v", err)
+	}
+
+	var seen []uint
+	for {
+		seen = append(seen, version)
+
+		body, identifier, err := src.ReadUp(version)
+		if err != nil {
+			t.Fatalf("ReadUp(%d): %v", version, err)
+		}
+		content, err := io.ReadAll(body)
+		body.Close()
+		if err != nil {
+			t.Fatalf("reading up migration %d (%s): %v", version, identifier, err)
+		}
+		if len(content) == 0 {
+			t.Errorf("up migration %d (%s) is empty", version, identifier)
+		}
+
+		next, err := src.Next(version)
+		if errors.Is(err, fs.ErrNotExist) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Next(%d): %v", version, err)
+		}
+		version = next
+	}
+
+	if len(seen) != latest {
+		t.Fatalf("iofs enumerated %d versions (%v), want %d to match LatestVersion",
+			len(seen), seen, latest)
+	}
+	for i, v := range seen {
+		if v != uint(i+1) {
+			t.Fatalf("iofs enumerated versions %v, want a contiguous 1..%d", seen, latest)
+		}
 	}
 }


### PR DESCRIPTION
Preview environments give each preview its own Neon database branch, cut from staging's schema, and bifrost can apply that branch's migrations via a `migrate` initContainer running the same image before the app starts. footstrike-api already uses this.

identity can't. Its runtime image contains exactly one binary, which has no subcommands and deliberately declines to migrate — so a preview of a branch that adds an identity migration branches the database at staging's schema, nothing migrates it, and `migrations.Verify` (fail-closed, and it rejects *any* version mismatch, not just older ones) `log.Fatalf`s. A guaranteed `CrashLoopBackOff`, every time, for exactly the case the initContainer exists to serve.

## The startup safety property is unchanged

`embed.go` is explicit that it deliberately does not apply migrations — a forgotten migration once broke client-secret auth, so the service refuses to start rather than serving against an unexpected schema.

**That still holds.** This is not auto-migration. `auth-service` with no arguments serves exactly as before, which is what the prod and staging Deployments run — they pass no arguments, so the dispatch is never entered and startup still only calls `Verify`. The subcommand has to be asked for explicitly, and only a preview's initContainer does. No k8s manifest changes; no Dockerfile change, since it's the same binary.

## Details

- **The registry entry will be `["/app/auth-service", "migrate"]`** — absolute, because the Dockerfile copies the binary to `/app/auth-service` and `/app` is not on `PATH`, so footstrike-api's bare-name form would not work here.
- **`ErrNoChange` is success.** The initContainer runs on every pod start, so treating already-at-latest as failure would break every restart.
- **The embed is unchanged** (`*.up.sql` only). Rather than assume, this was verified: iofs indexes a version on seeing a file in either direction and the up path only calls `ReadUp`, and an integration test migrates a real Postgres 0→11 from the up-only embed. The mutation is instructive — adding `*.down.sql` to the embed fails the new enumeration test while the pre-existing `TestLatestVersion` still passes, which is precisely the gap it covers.
- CI's integration step is widened by one line so the new test actually runs, rather than silently never executing.

## Merge ordering

**Merge and build this before** bifrost's registry gains `migrate:` for identity. Adding the registry key first would make every identity preview invoke a subcommand its image doesn't have — worse than today. Previews built from branches cut before this merges won't have it either and will need a rebase.

## Verification

Full suite green. Every assertion revert-checked; I independently re-ran the one that matters most — mutating the bare path to run migrate instead of serve fails `TestBareInvocationTakesServePath`. `gofmt -l` lists 6 files, all pre-existing at the base commit and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)